### PR TITLE
Deprecate gpt4all

### DIFF
--- a/docs/weaviate/model-providers/gpt4all/embeddings.md
+++ b/docs/weaviate/model-providers/gpt4all/embeddings.md
@@ -16,6 +16,12 @@ import TSConnect from '!!raw-loader!../_includes/provider.connect.local.ts';
 import PyCode from '!!raw-loader!../_includes/provider.vectorizer.py';
 import TSCode from '!!raw-loader!../_includes/provider.vectorizer.ts';
 
+:::caution Deprecated integration
+This integration is deprecated and will be removed in a future release. We recommend using alternative model providers for new projects.
+
+For local AI model integrations, consider using [Ollama](../ollama/index.md) or the [local HuggingFace](../transformers/) model integrations.
+:::
+
 Weaviate's integration with GPT4All's models allows you to access their models' capabilities directly from Weaviate.
 
 [Configure a Weaviate vector index](#configure-the-vectorizer) to use an GPT4All embedding model, and Weaviate will generate embeddings for various operations using the specified model via the GPT4All inference container. This feature is called the *vectorizer*.

--- a/docs/weaviate/model-providers/gpt4all/index.md
+++ b/docs/weaviate/model-providers/gpt4all/index.md
@@ -7,6 +7,12 @@ image: og/docs/integrations/provider_integrations_gpt4all.jpg
 
 <!-- Note: for images, use https://docs.google.com/presentation/d/15opIcJuaIjEEcs_1Zm8B6pccox2p7_MHSjCnRv4dPfU/edit?usp=sharing -->
 
+:::caution Deprecated integration
+This integration is deprecated and will be removed in a future release. We recommend using alternative model providers for new projects.
+
+For local AI model integrations, consider using [Ollama](../ollama/index.md) or the [local HuggingFace](../transformers/) model integrations.
+:::
+
 The GPT4All library allows you to easily run a wide range of models on your own device. Weaviate seamlessly integrates with the GPT4All library, allowing users to leverage compatible models directly from the Weaviate Database.
 
 These integrations empower developers to build sophisticated AI-driven applications with ease.

--- a/docs/weaviate/model-providers/index.md
+++ b/docs/weaviate/model-providers/index.md
@@ -51,7 +51,7 @@ Read more about [enabling all API-based modules](../configuration/modules.md#ena
 
 | Model provider | Embeddings | Generative AI | Others |
 | --- | --- | --- | --- |
-| [GPT4All](./gpt4all/index.md) | [Text](./gpt4all/embeddings.md) | - | - |
+| [GPT4All (Deprecated)](./gpt4all/index.md) | [Text (Deprecated)](./gpt4all/embeddings.md) | - | - |
 | [Hugging Face](./transformers/index.md) | [Text](./transformers/embeddings.md), [Multimodal (CLIP)](./transformers/embeddings-multimodal.md) | - | [Reranker](./transformers/reranker.md) |
 | [KubeAI](./kubeai/index.md) | [Text](./kubeai/embeddings.md) | - | - |
 | [Model2vec](./model2vec/index.md) | [Text](./model2vec/embeddings.md) | - | - |


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

Thanks again!
-->

### What's being changed:

Mark `gpt4all` as deprecated

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation content** updates (non-breaking change to fix/update documentation )
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How has this been tested?

<!-- Please select all options that apply -->

- [x] **Local build** - the site works as expected when running `yarn start`
