### PR TITLE
Document hosting setup for Weaviate with reverse proxy

### DIFF
--- a/docs/deploy/installation-guides/docker-installation.md
+++ b/docs/deploy/installation-guides/docker-installation.md
@@ -135,6 +135,15 @@ To start your Weaviate instance, run this command from your shell:
 docker compose up -d
 ```
 
+## Hosting
+
+Making Weaviate accessible over both http and grpc requires exposing both ports 8080 and 50051. To make them accessible to over a domain, configure your reverse proxy to forward
+traffic to both ports. To do so it's best to prefix the traffic with `grpc-` for grpc traffic to the http endpoint, this will be compatible most Weaviate clients.
+
+For example, when your domain is `weaviate.example.com`, you can configure your reverse proxy to forward:
+- `weaviate.example.com` to `localhost:8080` (http://)
+- `grpc-weaviate.example.com` to `localhost:50051` (grpc often h2c://)
+
 ## Configurator
 
 The Configurator can generate a `docker-compose.yml` file for you. Use the Configurator to select specific Weaviate modules, including vectorizers that run locally (i.e. `text2vec-transformers`, or `multi2vec-clip`)


### PR DESCRIPTION
Added hosting instructions for Weaviate with reverse proxy configuration.

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

Thanks again!
-->

### What's being changed:

Adds information on hosting to url: grpc-weaviate.mydomain.com and weaviate.mydomain.com
<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Type of change:

<!--Please delete options that are not relevant.-->

- [x] **Documentation content** updates (non-breaking change to fix/update documentation )
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How has this been tested?

<!-- Please select all options that apply -->

- [ ] **Local build** - the site works as expected when running `yarn start`
