### PR TITLE
fix: correct typo from "or RAM" to "of RAM"

### DIFF
--- a/docs/weaviate/quickstart/local.md
+++ b/docs/weaviate/quickstart/local.md
@@ -82,7 +82,7 @@ ollama pull nomic-embed-text
 ollama pull llama3.2
 ```
 
-We will be running Weaviate and language models locally. We recommend that you use a modern computer with at least 8GB or RAM, preferably 16GB or more.
+We will be running Weaviate and language models locally. We recommend that you use a modern computer with at least 8GB of RAM, preferably 16GB or more.
 
 <hr/>
 


### PR DESCRIPTION
### What's being changed:

"or RAM" changed to "of RAM" in docs.

### Type of change:

- [x ] **Documentation content** updates (non-breaking change to fix/update documentation )

### How has this been tested?

<!-- Please select all options that apply -->

- [x] By reading the site content.