### PR TITLE
Remove community Slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,6 +4,6 @@ contact_links:
     url: https://forum.weaviate.io
     about: "Community-powered knowledge repository: search, ask questions, give feedback"
 
-  - name: Community Slack
-    url: https://weaviate.io/slack
-    about: Chat with the community about any issues, questions, or feedback
+  - name: Community Support
+    url: mailto:support@weaviate.io
+    about: Contact us directly for private support inquiries

--- a/.github/ISSUE_TEMPLATE/create_issue.yml
+++ b/.github/ISSUE_TEMPLATE/create_issue.yml
@@ -5,7 +5,7 @@ body:
     attributes:
       value: |
 
-        * For questions, check the [Community Forum](https:/forum.weaviate.io), or ask in [Slack](https://weaviate.io/slack).
+        * For questions, check the [Community Forum](https://forum.weaviate.io).
         * Before you file an issue read the [Contributing guide](https://docs.weaviate.io/contributor-guide).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/weaviate/docs/issues).
 

--- a/.github/ISSUE_TEMPLATE/report_bug.yml
+++ b/.github/ISSUE_TEMPLATE/report_bug.yml
@@ -5,7 +5,7 @@ body:
     attributes:
       value: |
 
-        * For questions, check the [Community Forum](https:/forum.weaviate.io), or ask in [Slack](https://weaviate.io/slack).
+        * For questions, check the [Community Forum](https://forum.weaviate.io).
         * Before you file an issue read the [Contributing guide](https://github.com/weaviate/docs/blob/main/CONTRIBUTING.md).
         * Check to make sure someone hasn't already opened a similar [issue](https://github.com/weaviate/docs/issues).
 

--- a/docs/contributor-guide/index.mdx
+++ b/docs/contributor-guide/index.mdx
@@ -71,13 +71,11 @@ export const contributionAreasData = [
 
 ## Join the Weaviate Community
 
-A lot of community chat happens on the [Weaviate Community Slack](https://weaviate.io/slack), with longer-form discussions taking place on the [forum](https://forum.weaviate.io)
+Community discussions take place on the [forum](https://forum.weaviate.io)
 
 Many members of our community help us by giving feedback, asking questions, or proposing ideas. To get involved in our community, please make sure to familiarize yourself with the project's [Code of Conduct](https://weaviate.io/service/code-of-conduct).
 
-Please set your forum or Slack workspace display name to your name. This will make it easier to connect with other community members. Then reach out to members of the community, introduce yourself, and share your ideas/questions. Tell us about your areas of interest and what technologies you are using to build your projects. The more we know about you, the better we will be able to match project requirements to your interests and abilities.
-
-If at any time you face any difficulties, don't hesitate to reach out in the `#general` channel on our Slack for quick help, or in the [General category of the forum](https://forum.weaviate.io/c/general/4) for more complex issues. Our team and the community will help you solve your problem.
+Tell us about your areas of interest and what technologies you are using to build your projects. The more we know about you, the better we will be able to match project requirements to your interests and abilities.
 
 ## License
 

--- a/docs/contributor-guide/weaviate-core/cicd.md
+++ b/docs/contributor-guide/weaviate-core/cicd.md
@@ -81,7 +81,7 @@ disadvantages: Mainly deviating code-bases and painful merge conflicts.
 
 *This section only applies to Weaviate employees. Outside contributors cannot make
 releases. If you have made a contribution and think it should be released,
-please let us know on the public Weaviate Slack.*
+please let us know on the [Weaviate Community Forum](https://forum.weaviate.io/).*
 
 There is a convenience script located at `tools/prepare_release.sh`, to use it
 adhere to the following steps:

--- a/docs/contributor-guide/weaviate-modules/how-to-build-a-new-module.md
+++ b/docs/contributor-guide/weaviate-modules/how-to-build-a-new-module.md
@@ -46,7 +46,7 @@ The inference model is a service that provides at least four API endpoints:
 3. `GET /meta` responds meta information about the inference model.
 4. `POST /<foo>` (at least 1) is the endpoint that the Weaviate Module uses for inference. For a vectorizer this might for example be `POST /vectors`, which takes a JSON body with the data to vectorize. A vector will be returned (in JSON format). The Question Answering model, on the other hand, has an endpoint `POST /answers`, which takes a JSON body with the text to tokenize and returns a list of tokens found in the text (also formatted as JSON).
 
-You can always ask us on [the forum](https://forum.weaviate.io/), [Slack](https://weaviate.io/slack) or [GitHub](https://github.com/weaviate/weaviate/issues) to get help with the design.
+You can always ask us on [the forum](https://forum.weaviate.io/) or [GitHub](https://github.com/weaviate/weaviate/issues) to get help with the design.
 
 ## How to build a custom module - guidelines
 

--- a/docs/weaviate/client-libraries/community.md
+++ b/docs/weaviate/client-libraries/community.md
@@ -27,7 +27,7 @@ Members of the Weaviate community provide client libraries for some additional l
 
 To contribute to these libraries, contact the maintainers directly.
 
-If you have a Weaviate client library you would like to add here, let us know in the [forum](https://forum.weaviate.io/) or on [Slack](https://weaviate.io/slack).
+If you have a Weaviate client library you would like to add here, let us know on the [forum](https://forum.weaviate.io/).
 
 ## Questions and feedback
 

--- a/docs/weaviate/more-resources/faq.md
+++ b/docs/weaviate/more-resources/faq.md
@@ -636,6 +636,17 @@ If you need resources from the previous version of Weaviate Academy, check out t
 
 </details>
 
+#### Q: What happened to the Weaviate Community Slack?
+
+<details>
+  <summary>Answer</summary>
+
+> The Weaviate Community Slack has been decommissioned. We've moved community discussions to the [Weaviate Community Forum](https://forum.weaviate.io/), which offers better long-term discoverability — conversations are indexed and searchable, so valuable answers don't get lost over time.
+>
+> Join us at [forum.weaviate.io](https://forum.weaviate.io/) to ask questions, share ideas, and connect with the community. For private support inquiries, you can reach us at [support@weaviate.io](mailto:support@weaviate.io).
+
+</details>
+
 ## Questions and feedback
 
 import DocsFeedback from '/_includes/docs-feedback.mdx';

--- a/docs/weaviate/more-resources/index.md
+++ b/docs/weaviate/more-resources/index.md
@@ -25,7 +25,6 @@ For additional information, try these sources.
 
 - [Weaviate Community Forum](https://forum.weaviate.io/)
 - [Knowledge base of old issues](https://github.com/weaviate/weaviate/issues?utf8=%E2%9C%93&q=label%3Abug)
-- [Weaviate slack channel](https://weaviate.io/slack)
 
 
 ## Questions and feedback

--- a/src/theme/DocItem/Footer/Footer.js
+++ b/src/theme/DocItem/Footer/Footer.js
@@ -49,14 +49,6 @@ function Footer() {
                 <i className="fab fa-github" aria-hidden="true"></i>
               </Link>
               <Link
-                to="https://weaviate.io/slack"
-                title="Slack"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <i className="fab fa-slack" aria-hidden="true"></i>
-              </Link>
-              <Link
                 to="https://x.com/weaviate_io"
                 title="X"
                 target="_blank"
@@ -140,15 +132,6 @@ function Footer() {
                     rel="noopener noreferrer"
                   >
                     Forum
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="https://weaviate.io/slack"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Slack
                   </Link>
                 </li>
               </ul>

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,0 @@
-# Redirect from weaviate.io/slack to the slack invite link
-# See https://www.notion.so/weaviate/Community-Slack-invite-link-updates-12d70562ccd68034abb9fdfd77cbdc02?pvs=4 for instructions
-/slack https://join.slack.com/t/weaviate/shared_invite/zt-38ilpqzf7-XH2q~gOKX_w~OcHphoHw~Q


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

Thanks again!
-->

### What's being changed:

Remove mentions of the community Slack workspace as it's being decommissioned. 
