### PR TITLE
Add Docs on Search Mode Diversity Ranking

### DIFF
--- a/docs/agents/_includes/query_agent.mts
+++ b/docs/agents/_includes/query_agent.mts
@@ -382,6 +382,17 @@ for (const obj of basicSearchResponse.searchResults.objects) {
 }
 // END BasicSearchQuery
 
+// START DiversityRanking
+const diversitySearchResponse = await qa.search("summer shoes", {
+    limit: 10,
+    diversityWeight: 0.5
+})
+
+// Access the search results
+for (const obj of diversitySearchResponse.searchResults.objects) {
+    console.log(`Product: ${obj.properties['name']} - ${obj.properties['price']}`)
+}
+// END DiversityRanking
 
 // START BasicAskQuery
 // Perform a query

--- a/docs/agents/_includes/query_agent.py
+++ b/docs/agents/_includes/query_agent.py
@@ -453,6 +453,18 @@ for page_num, page_response in enumerate(
     print()
 # END SearchPagination
 
+# START DiversityRanking
+search_response = qa.search(
+    "summer shoes",
+    limit=10,
+    diversity_weight=0.5,
+)
+
+# Access the search results
+for obj in search_response.search_results.objects:
+    print(f"Product: {obj.properties['name']} - ${obj.properties['price']}")
+# END DiversityRanking
+
 # START FollowUpQuery
 # Perform a follow-up query and include the answer from the previous query
 from weaviate.agents.classes import ChatMessage

--- a/docs/agents/query/usage.md
+++ b/docs/agents/query/usage.md
@@ -327,9 +327,9 @@ Page 3:
 
 </details>
 
-#### `Search` with Diversity Ranking
+#### `Search` with diversity ranking
 
-`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR).
+`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR). This is enabled by passing a `diversity_weight` parameter in the range of 0 to 1. To use diversity ranking with target vectors, set the single target vector that you want to use in the Query Agent's constructor.
 
 <Tabs className="code" groupId="languages">
     <TabItem value="py_agents" label="Python">

--- a/docs/agents/query/usage.md
+++ b/docs/agents/query/usage.md
@@ -327,6 +327,32 @@ Page 3:
 
 </details>
 
+#### `Search` with Diversity Ranking
+
+`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR).
+
+<Tabs className="code" groupId="languages">
+    <TabItem value="py_agents" label="Python">
+        <FilteredTextBlock
+            text={PyCode}
+            startMarker="# START DiversityRanking"
+            endMarker="# END DiversityRanking"
+            language="py"
+        />
+    </TabItem>
+    <TabItem value="ts_agents" label="JavaScript/TypeScript">
+    <FilteredTextBlock
+            text={TSCode}
+            startMarker="// START SearchPagination"
+            endMarker="// END SearchPagination"
+            language="ts"
+        />
+    </TabItem>
+
+</Tabs>
+
+
+
 ### `Ask`
 
 `Ask` the Query Agent a question using natural language. The Query Agent will process the question, perform the necessary searches in Weaviate, and return the answer.

--- a/docs/agents/query/usage.md
+++ b/docs/agents/query/usage.md
@@ -343,8 +343,8 @@ Page 3:
     <TabItem value="ts_agents" label="JavaScript/TypeScript">
     <FilteredTextBlock
             text={TSCode}
-            startMarker="// START SearchPagination"
-            endMarker="// END SearchPagination"
+            startMarker="// START DiversityRanking"
+            endMarker="// END DiversityRanking"
             language="ts"
         />
     </TabItem>

--- a/docs/agents/query/usage.md
+++ b/docs/agents/query/usage.md
@@ -329,7 +329,7 @@ Page 3:
 
 #### `Search` with diversity ranking
 
-`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR). This is enabled by passing a `diversity_weight` parameter in the range of 0 to 1. To use diversity ranking with target vectors, set the single target vector that you want to use in the Query Agent's constructor.
+`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR). This is enabled by passing a `diversity_weight` parameter in the range of 0.0 to 1.0. To use diversity ranking with target vectors, set the single target vector that you want to use in the Query Agent's constructor. Diversity ranking is not yet supported with collections using multi-vector embeddings. Diversity ranking will work with multiple collections, unless they are using **different** embedding models.
 
 <Tabs className="code" groupId="languages">
     <TabItem value="py_agents" label="Python">


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

Thanks again!
-->

### What's being changed:

This adds docs for Diversity Ranking in Weaviate's Query Agent Search Mode.

For quick reference:

### Blurb

`Search` supports adding diversity weighting to search result rankings using Maximal Marginal Relevance (MMR). This is enabled by passing a `diversity_weight` parameter in the range of 0.0 to 1.0. To use diversity ranking with target vectors, set the single target vector that you want to use in the Query Agent's constructor. Diversity ranking is not yet supported with collections using multi-vector embeddings. Diversity ranking will work with multiple collections, unless they are using **different** embedding models.

### The Python and TypeScript examples have been added as well

### Type of change:

<!--Please delete options that are not relevant.-->

- [X] **Feature** or **enhancements** (non-breaking change to add functionality)

### How has this been tested?

<!-- Please select all options that apply -->

- [X] **Local build** - the site works as expected when running `yarn start`
