### PR TITLE
[v1.37] Diversity selection (MMR)

### DIFF
--- a/_includes/code/howto/search.similarity.mmr.py
+++ b/_includes/code/howto/search.similarity.mmr.py
@@ -1,0 +1,103 @@
+# START MMRNearText
+import weaviate
+from weaviate.classes.query import Diversity
+
+client = weaviate.connect_to_local()
+
+collection = client.collections.get("JeopardyQuestion")
+
+# Retrieve 20 candidates, then rerank to select 5 diverse results
+response = collection.query.near_text(
+    query="animals in movies",
+    limit=20,
+    selection=Diversity.MMR(
+        limit=5,
+        balance=0.5,
+    ),
+)
+
+for o in response.objects:
+    print(o.properties["question"])
+# END MMRNearText
+
+# Test
+assert response.objects[0].collection == "JeopardyQuestion"
+assert len(response.objects) == 5
+assert "question" in response.objects[0].properties.keys()
+
+# Verify MMR produces different ordering than standard search
+standard_response = collection.query.near_text(
+    query="animals in movies",
+    limit=5,
+)
+standard_questions = [o.properties["question"] for o in standard_response.objects]
+mmr_questions = [o.properties["question"] for o in response.objects]
+# First result should be the same (most relevant), but sets should differ
+assert standard_questions[0] == mmr_questions[0], "First result should be the most relevant in both"
+assert set(standard_questions) != set(mmr_questions), "MMR should select different items than standard search"
+
+# START MMRNearVector
+from weaviate.classes.query import Diversity
+
+collection = client.collections.get("JeopardyQuestion")
+
+# Get a vector to use as query
+sample = collection.query.fetch_objects(limit=1, include_vector=True)
+query_vector = sample.objects[0].vector["default"]
+
+response = collection.query.near_vector(
+    near_vector=query_vector,
+    limit=20,
+    selection=Diversity.MMR(
+        limit=5,
+        balance=0.5,
+    ),
+)
+
+for o in response.objects:
+    print(o.properties["question"])
+# END MMRNearVector
+
+# Test
+assert len(response.objects) == 5
+assert "question" in response.objects[0].properties.keys()
+
+# START MMRBalanceExamples
+from weaviate.classes.query import Diversity
+
+collection = client.collections.get("JeopardyQuestion")
+
+# Pure diversity — maximize difference between results
+response_diverse = collection.query.near_text(
+    query="animals in movies",
+    limit=20,
+    selection=Diversity.MMR(limit=5, balance=0.0),
+)
+
+# Balanced — equal weight on relevance and diversity
+response_balanced = collection.query.near_text(
+    query="animals in movies",
+    limit=20,
+    selection=Diversity.MMR(limit=5, balance=0.5),
+)
+
+# Pure relevance — equivalent to standard vector search
+response_relevant = collection.query.near_text(
+    query="animals in movies",
+    limit=20,
+    selection=Diversity.MMR(limit=5, balance=1.0),
+)
+# END MMRBalanceExamples
+
+# Test
+assert len(response_diverse.objects) == 5
+assert len(response_balanced.objects) == 5
+assert len(response_relevant.objects) == 5
+
+# Different balance values should produce different result orderings
+diverse_questions = [o.properties["question"] for o in response_diverse.objects]
+balanced_questions = [o.properties["question"] for o in response_balanced.objects]
+relevant_questions = [o.properties["question"] for o in response_relevant.objects]
+assert diverse_questions != relevant_questions, "Pure diversity and pure relevance should differ"
+
+client.close()

--- a/_includes/feature-notes/v137-preview.mdx
+++ b/_includes/feature-notes/v137-preview.mdx
@@ -1,0 +1,5 @@
+:::caution Preview — added in `v1.37`
+
+This is a preview feature. The API may change in future releases.
+
+:::

--- a/docs/weaviate/concepts/search/vector-search.md
+++ b/docs/weaviate/concepts/search/vector-search.md
@@ -248,6 +248,34 @@ Weaviate uses cosine distance as the default distance metric for vector searches
 In a "distance", the lower the value, the closer the vectors are to each other. In a "similarity", or "certainty" score, the higher the value, the closer the vectors are to each other. Some metrics, such as cosine distance, can also be expressed as a similarity score. Others, such as Euclidean distance, are only expressable as a distance.
 :::
 
+## Diversity selection (MMR)
+
+import V137Preview from '/_includes/feature-notes/v137-preview.mdx';
+
+<V137Preview/>
+
+Standard vector search returns the closest matches to a query, which often means a cluster of near-duplicate results. For example, searching for "Italian food" in a product catalog might return five images of pizza instead of a diverse spread of Italian dishes.
+
+**Maximum Marginal Relevance (MMR)** solves this by reranking results to balance two objectives:
+
+- **Relevance**: how well does the item match the query?
+- **Diversity**: how different is the item from the results already selected?
+
+The algorithm works iteratively. It selects the most relevant item first, then for each subsequent pick it scores candidates by weighing their query similarity against their maximum similarity to any already-selected result. The `balance` parameter (λ) controls the trade-off:
+- **λ = 0.0**: Pure diversity — maximizes difference from already-selected items
+- **λ = 0.5**: Balanced — each result must be both relevant and distinct
+- **λ = 1.0**: Pure relevance — equivalent to standard vector search
+
+MMR is applied at query time as a reranking step on top of standard search. No reindexing is needed. The typical pattern is to retrieve a larger candidate set via regular vector search, then rerank a subset using MMR.
+
+:::note Result ordering
+
+Results are ordered by MMR score, not query similarity. The first result is always the most relevant, but subsequent results may have lower query similarity because they were chosen for the diversity they add.
+
+:::
+
+See the [how-to guide](../../search/similarity.md#diversity-selection-mmr) for configuration details and code examples.
+
 ## Notes and best practices
 
 All compatible vectors are similar to some degree search.

--- a/docs/weaviate/search/similarity.md
+++ b/docs/weaviate/search/similarity.md
@@ -15,11 +15,11 @@ import TSCode from '!!raw-loader!/\_includes/code/howto/search.similarity.ts';
 import GoCode from '!!raw-loader!/\_includes/code/howto/go/docs/mainpkg/search-similarity_test.go';
 import JavaCode from '!!raw-loader!/\_includes/code/howto/java/src/test/java/io/weaviate/docs/search/VectorSearchTest.java';
 import JavaV6Code from "!!raw-loader!/\_includes/code/java-v6/src/test/java/SearchSimilarityTest.java";
-import CSharpCode from "!!raw-loader!/_includes/code/csharp/SearchSimilarityTest.cs";
+import CSharpCode from "!!raw-loader!/\_includes/code/csharp/SearchSimilarityTest.cs";
 
 Vector search returns the objects with most similar vectors to that of the query.
 
-import QueryAgentTip from '/_includes/query-agent-tip.mdx';
+import QueryAgentTip from '/\_includes/query-agent-tip.mdx';
 
 <QueryAgentTip/>
 
@@ -745,6 +745,59 @@ The output is like this:
 />
 
 </details>
+
+## Diversity selection (MMR)
+
+import MMRPyCode from '!!raw-loader!/\_includes/code/howto/search.similarity.mmr.py';
+import V137Preview from '/\_includes/feature-notes/v137-preview.mdx';
+
+<V137Preview/>
+
+Standard vector search returns the closest matches to the query, which often means a cluster of near-duplicate results. **Maximum Marginal Relevance (MMR)** reranks results to balance relevance with diversity — each selected result must add something new to the result set.
+
+Add the `selection` parameter to any vector search query:
+
+<FilteredTextBlock
+  text={MMRPyCode}
+  startMarker="# START MMRNearText"
+  endMarker="# END MMRNearText"
+  language="python"
+/>
+
+#### How it works
+
+1. Weaviate runs a regular vector search to retrieve a candidate set (controlled by the query's `limit`)
+2. The most relevant candidate is selected first
+3. For each remaining candidate, MMR computes a score that balances query similarity against maximum similarity to already-selected results, weighted by `balance`
+4. The candidate with the highest MMR score is selected next
+5. Steps 3–4 repeat until the `Diversity.MMR(limit)` is reached
+
+#### Parameters
+
+| Parameter | Type  | Description                                                                                                                                             |
+| :-------- | :---- | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `limit`   | int   | Number of results to return after MMR reranking. Must be less than or equal to the query's top-level `limit` (the candidate set size).                  |
+| `balance` | float | Controls the relevance-diversity trade-off (0.0–1.0). `0.0` = pure diversity, `0.5` = balanced, `1.0` = pure relevance (equivalent to standard search). |
+
+<FilteredTextBlock
+  text={MMRPyCode}
+  startMarker="# START MMRBalanceExamples"
+  endMarker="# END MMRBalanceExamples"
+  language="python"
+/>
+
+:::tip
+A larger candidate set (higher top-level `limit`) gives MMR more results to choose from, improving diversity at the cost of slightly more computation. A good starting point is setting the candidate `limit` to 2–4x the MMR `limit`.
+:::
+
+:::info Important notes
+
+- **Result ordering**: Results are ordered by MMR score, not query similarity. The first result is the most relevant, but subsequent results may have lower query similarity because they were chosen for diversity.
+- **No reindexing needed**: MMR is applied at query time. You can use it on any existing collection without schema changes.
+- **Supported queries**: `near_text`, `near_vector`, `near_object`, `near_image`, and `near_media`.
+- **Not supported**: hybrid search and multi-vector collections.
+
+:::
 
 ## Related pages
 


### PR DESCRIPTION
## Summary

Document MMR (Maximum Marginal Relevance) diversity selection for vector search queries. MMR reranks results to balance relevance and diversity, reducing near-duplicate clusters.

- How-to: new `## Diversity selection (MMR)` section in `search/similarity.md` with Python examples and parameter reference
- Concepts: new section in `concepts/search/vector-search.md` explaining the algorithm and trade-offs
- Shared `v137-preview.mdx` feature note
- Python code examples with test assertions verified against Weaviate 1.37.0-rc.0