### PR TITLE
[v1.38] Drop vector index

### DIFF
--- a/_includes/code/howto/manage-data.collections.py
+++ b/_includes/code/howto/manage-data.collections.py
@@ -1105,4 +1105,15 @@ print(article_shards)
 # END UpdateCollectionShards
 
 
+# START DropVectorIndex
+collection = client.collections.get("Article")
+
+# Drop the vector index for a named vector
+# This is a destructive operation — the index is removed from disk
+result = collection.config.delete_vector_index(vector_name="title")
+
+print(result)  # True if successful
+# END DropVectorIndex
+
+
 client.close()

--- a/_includes/feature-notes/drop-vector-index.mdx
+++ b/_includes/feature-notes/drop-vector-index.mdx
@@ -1,0 +1,6 @@
+:::caution Preview — added in `v1.37`
+
+This is a preview feature. The API may change in future releases.
+
+:::
+

--- a/docs/weaviate/config-refs/indexing/vector-index.mdx
+++ b/docs/weaviate/config-refs/indexing/vector-index.mdx
@@ -368,8 +368,6 @@ import V137Preview from '/_includes/feature-notes/drop-vector-index.mdx';
 
 You can drop (delete) a vector index from a collection. This is a destructive, irreversible operation — the index data is removed from disk and cannot be rebuilt on the same collection. The vector data itself is preserved, but vector searches on the dropped index will no longer work.
 
-**REST endpoint:** `DELETE /v1/schema/{className}/vectors/{vectorName}/index`
-
 See [How-to: Drop a vector index](../../manage-collections/vector-config.mdx#drop-a-vector-index) for code examples.
 
 ## Further resources

--- a/docs/weaviate/config-refs/indexing/vector-index.mdx
+++ b/docs/weaviate/config-refs/indexing/vector-index.mdx
@@ -360,6 +360,18 @@ import MultiVectorSupport from "/_includes/multi-vector-support.mdx";
 
 <MultiVectorSupport />
 
+## Drop a vector index
+
+import V137Preview from '/_includes/feature-notes/drop-vector-index.mdx';
+
+<V137Preview/>
+
+You can drop (delete) a vector index from a collection. This is a destructive, irreversible operation — the index data is removed from disk and cannot be rebuilt on the same collection. The vector data itself is preserved, but vector searches on the dropped index will no longer work.
+
+**REST endpoint:** `DELETE /v1/schema/{className}/vectors/{vectorName}/index`
+
+See [How-to: Drop a vector index](../../manage-collections/vector-config.mdx#drop-a-vector-index) for code examples.
+
 ## Further resources
 
 - [Concepts: Vector index](../../concepts/indexing/vector-index.md)

--- a/docs/weaviate/manage-collections/vector-config.mdx
+++ b/docs/weaviate/manage-collections/vector-config.mdx
@@ -438,6 +438,27 @@ Read more about index types & compression in:
 
 </details>
 
+## Drop a vector index
+
+import V137Preview from '/_includes/feature-notes/drop-vector-index.mdx';
+
+<V137Preview/>
+
+Drop (delete) a vector index from a collection. This is a destructive, irreversible operation — the index data is removed from disk and cannot be rebuilt on the same collection. The vector data itself is preserved, but vector searches on the dropped index will no longer work.
+
+Specify the named vector whose index to drop:
+
+<Tabs className="code" groupId="languages">
+  <TabItem value="py" label="Python">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# START DropVectorIndex"
+      endMarker="# END DropVectorIndex"
+      language="py"
+    />
+  </TabItem>
+</Tabs>
+
 ## Property-level settings
 
 Configure individual properties in a collection. Each property can have it's own configuration. Here are some common settings:


### PR DESCRIPTION
## Summary

Document the new `delete_vector_index` API for dropping a named vector index from a collection. This is a destructive, irreversible operation — the index is removed from disk but vector data is preserved.

- How-to section in `manage-collections/vector-config.mdx` with Python code example
- Reference section in `config-refs/indexing/vector-index.mdx` with REST endpoint
- Verified against Weaviate 1.37.0-rc.0