### PR TITLE
Refresh Engram docs to match current API and SDK

### DIFF
--- a/docs/engram/_includes/check_run_status.sh
+++ b/docs/engram/_includes/check_run_status.sh
@@ -18,9 +18,10 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and uses VS Code."
+    "input": {
+      "string": {
+        "content": ["The user prefers dark mode and uses VS Code."]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"

--- a/docs/engram/_includes/cleanup_memories.py
+++ b/docs/engram/_includes/cleanup_memories.py
@@ -15,7 +15,7 @@ for _ in range(20):
         break
     for m in results:
         try:
-            client.memories.delete(m.id, topic=m.topic, user_id=user_id)
+            client.memories.delete(m.id, user_id=user_id, group=group)
             deleted += 1
         except Exception:
             pass

--- a/docs/engram/_includes/manage_memories.sh
+++ b/docs/engram/_includes/manage_memories.sh
@@ -23,9 +23,10 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and uses VS Code."
+    "input": {
+      "string": {
+        "content": ["The user prefers dark mode and uses VS Code."]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"

--- a/docs/engram/_includes/quickstart.sh
+++ b/docs/engram/_includes/quickstart.sh
@@ -10,9 +10,12 @@ curl -X POST https://api.engram.weaviate.io/v1/memories \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and uses VS Code as their primary editor."
+    "input": {
+      "string": {
+        "content": [
+          "The user prefers dark mode and uses VS Code as their primary editor."
+        ]
+      }
     },
     "user_id": "user-uuid"
   }'
@@ -44,9 +47,12 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and uses VS Code as their primary editor."
+    "input": {
+      "string": {
+        "content": [
+          "The user prefers dark mode and uses VS Code as their primary editor."
+        ]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"

--- a/docs/engram/_includes/search_memories.sh
+++ b/docs/engram/_includes/search_memories.sh
@@ -89,9 +89,10 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user works primarily in Python and prefers dark mode. They are building a RAG application with FastAPI."
+    "input": {
+      "string": {
+        "content": ["The user works primarily in Python and prefers dark mode. They are building a RAG application with FastAPI."]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"

--- a/docs/engram/_includes/store_memories.py
+++ b/docs/engram/_includes/store_memories.py
@@ -1,7 +1,7 @@
 import os
 import time
 import uuid
-from engram import EngramClient, PreExtractedContent
+from engram import EngramClient, PreExtractedInput, PreExtractedItem
 
 client = EngramClient(
     api_key=os.environ["ENGRAM_API_KEY"]
@@ -39,13 +39,12 @@ results = client.memories.search(query="Python RAG dark mode", user_id=test_user
 assert len(results) >= 1
 assert any("Python" in m.content or "dark mode" in m.content or "RAG" in m.content for m in results)
 
-"""TODO[g-despot] Needs topic
-
 # START StorePreExtracted
 run = client.memories.add(
-    PreExtractedContent(
-        content="User prefers dark mode",
-    ),
+    PreExtractedInput(items=[
+        PreExtractedItem(content="User prefers dark mode", topic="UserKnowledge"),
+        PreExtractedItem(content="User works in Python", topic="UserKnowledge"),
+    ]),
     user_id=test_user_id,
     group="default",
 )
@@ -61,7 +60,7 @@ assert status.status == "completed"
 results = client.memories.search(query="dark mode preference", user_id=test_user_id, group="default")
 assert len(results) >= 1
 assert any("dark mode" in m.content for m in results)
-"""
+
 # START StoreConversation
 run = client.memories.add(
     [

--- a/docs/engram/_includes/store_memories.sh
+++ b/docs/engram/_includes/store_memories.sh
@@ -11,9 +11,12 @@ curl -X POST https://api.engram.weaviate.io/v1/memories \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and works primarily in Python. They are building a RAG application."
+    "input": {
+      "string": {
+        "content": [
+          "The user prefers dark mode and works primarily in Python. They are building a RAG application."
+        ]
+      }
     },
     "user_id": "user-uuid",
     "group": "default"
@@ -25,10 +28,13 @@ curl -X POST https://api.engram.weaviate.io/v1/memories \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "pre_extracted",
-      "content": "User prefers dark mode",
-      "topic": "preferences"
+    "input": {
+      "pre_extracted": {
+        "items": [
+          { "content": "User prefers dark mode", "topic": "UserKnowledge" },
+          { "content": "User works in Python", "topic": "UserKnowledge" }
+        ]
+      }
     },
     "user_id": "user-uuid",
     "group": "default"
@@ -40,8 +46,7 @@ curl -X POST https://api.engram.weaviate.io/v1/memories \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "conversation",
+    "input": {
       "conversation": {
         "messages": [
           {
@@ -72,9 +77,12 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "string",
-      "content": "The user prefers dark mode and works primarily in Python. They are building a RAG application."
+    "input": {
+      "string": {
+        "content": [
+          "The user prefers dark mode and works primarily in Python. They are building a RAG application."
+        ]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"
@@ -112,10 +120,12 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "pre_extracted",
-      "content": "User prefers dark mode",
-      "topic": "preferences"
+    "input": {
+      "pre_extracted": {
+        "items": [
+          { "content": "User prefers dark mode", "topic": "UserKnowledge" }
+        ]
+      }
     },
     "user_id": "'"$USER_ID"'",
     "group": "default"
@@ -142,8 +152,7 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
   -H "Authorization: Bearer $ENGRAM_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "content": {
-      "type": "conversation",
+    "input": {
       "conversation": {
         "messages": [
           {"role": "user", "content": "I just moved to Berlin and I am looking for a good coffee shop."},
@@ -153,7 +162,6 @@ RUN_ID=$(curl -s -X POST "$BASE_URL/v1/memories" \
       }
     },
     "user_id": "'"$USER_ID"'",
-    "conversation_id": "'"$CONVERSATION_ID"'",
     "group": "default"
   }' | jq -r '.run_id')
 

--- a/docs/engram/_includes/tutorial_personalized_rag.py
+++ b/docs/engram/_includes/tutorial_personalized_rag.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 import asyncio
-from engram import EngramClient, AsyncEngramClient, RetrievalConfig, PreExtractedContent
+from engram import EngramClient, AsyncEngramClient, RetrievalConfig
 
 # START SetupClients
 engram = EngramClient(

--- a/docs/engram/concepts/groups.md
+++ b/docs/engram/concepts/groups.md
@@ -15,12 +15,9 @@ Each project can have multiple named groups, but most use cases only need the `d
 - Pipeline steps that define the processing flow
 - Topic name isolation — different groups can have topics with the same name without collision (e.g. two agents can each have a `user_preferences` topic in separate groups)
 
-## Default groups
+## The `default` group
 
-When you create a project, Engram sets up two default groups:
-
-- **`default_personalisation`** — [User-scoped](scopes.md). Requires a `user_id` when storing and searching. Use this for per-user preferences, facts, and context.
-- **`default_continual_learning`** — Project-wide. No `user_id` needed. Use this for things an agent learns about how to perform a task, regardless of which user it's working with.
+When you create a project, Engram provisions a group named `default`. All API requests use this group unless you specify another with the `group` parameter. Project templates may seed the default group with a starter set of topics — the [Personalization template](../quickstart.md), for example, seeds it with a `UserKnowledge` topic.
 
 ## When to create additional groups
 
@@ -30,8 +27,8 @@ Create additional groups when you have distinct use cases that need different to
 
 A **customer support agent** could use two groups:
 
-- **`default_personalisation`** (user-scoped) — Stores per-user facts like "prefers email over phone" or "has a Pro subscription". Requires a `user_id` on every store and search so each user's memories stay separate.
-- **`default_continual_learning`** (project-wide) — Stores knowledge the agent learns about how to do its job, like "always check the billing FAQ before escalating refund requests". No `user_id` needed — these memories are shared across all users.
+- **`personalization`** (user-scoped) — Stores per-user facts like "prefers email over phone" or "has a Pro subscription". Requires a `user_id` on every store and search so each user's memories stay separate.
+- **`continual_learning`** (project-wide) — Stores knowledge the agent learns about how to do its job, like "always check the billing FAQ before escalating refund requests". No `user_id` needed — these memories are shared across all users.
 
 When the agent handles a support ticket, it searches the personalization group with the user's ID to recall their history, and searches the continual learning group to recall best practices.
 

--- a/docs/engram/concepts/index.md
+++ b/docs/engram/concepts/index.md
@@ -11,7 +11,7 @@ Engram organizes and processes memories for your AI applications. Here's how the
 | [Memories](memories.md)                 | Discrete pieces of information stored in Engram, automatically embedded as vectors for semantic search.                                                                                    |
 | [Groups](groups.md)                     | A named configuration bundle. Each group contains topics (what to remember) and a pipeline (how to process). Most projects start with a single group.                                      |
 | [Topics](topics.md)                     | A category of memory within a group. Each topic defines what kind of information to extract, like `UserKnowledge` or `ConversationSummary`.                                                |
-| [Scopes](scopes.md)                     | Controls memory visibility. Every memory belongs to a project. Topics can additionally require a user ID (user-scoped) or conversation ID (conversation-scoped).                           |
+| [Scopes](scopes.md)                     | Controls memory visibility. Every memory belongs to a project. Topics can additionally require a `user_id` and custom `properties` (e.g. `conversation_id`) for isolation.                 |
 | [Input data types](input-data-types.md) | The three content formats Engram accepts: `string`, `pre-extracted`, and `conversation`.                                                                                                   |
 | [Pipelines](pipelines.md)               | The processing flow that turns raw input into stored memories. Steps include extracting facts, transforming with context, and committing to storage. _Will be configurable in the future._ |
 | [Search](search.md)                     | Search retrieval strategies for finding memories: vector, BM25, and hybrid.                                                                                                                |
@@ -22,7 +22,7 @@ Below is an overview of Engram's key concepts and how they relate to each other:
 
 ![Weaviate Engram Concepts](../_includes/concepts.png "Weaviate Engram Concepts")
 
-- You send [**input data**](input-data-types.md) (text, a conversation, or pre-extracted facts) along with [**scope**](scopes.md) parameters (`user_id`, `conversation_id`) that identify who the memories belong to.
+- You send [**input data**](input-data-types.md) (text, a conversation, or pre-extracted facts) along with [**scope**](scopes.md) parameters (`user_id` and any `properties` the target topic requires) that identify who the memories belong to.
 - The input is routed to a [**group**](groups.md), which bundles [**topics**](topics.md) with a [**pipeline**](pipelines.md) — one group per use case.
 - **Topics** tell the pipeline what kinds of information to extract (e.g. `UserKnowledge`, `ConversationSummary`) and which **scopes** are required.
 - The **pipeline** extracts facts from the input, deduplicates and merges them with existing data, and commits the results to storage.

--- a/docs/engram/concepts/input-data-types.md
+++ b/docs/engram/concepts/input-data-types.md
@@ -8,21 +8,62 @@ Engram accepts three types of input content when storing memories:
 
 | Type | Description | Use case |
 |------|-------------|----------|
-| `string` | Raw text | Free-form notes, agent observations |
-| `pre_extracted` | Already-structured content | When you've done your own extraction |
+| `string` | Raw text (one or more strings) | Free-form notes, agent observations |
+| `pre_extracted` | Already-structured items, each with a target topic | When you've done your own extraction |
 | `conversation` | Multi-turn messages with roles | Chat transcripts, agent conversations |
+
+All three are sent in the `input` field of `POST /v1/memories`. Exactly one of `string`, `pre_extracted`, or `conversation` must be set.
+
+```json
+{
+  "input": {
+    "string": { "content": ["..."] }
+    // or "pre_extracted": { "items": [{ "content": "...", "topic": "..." }] }
+    // or "conversation": { "messages": [{ "role": "user", "content": "..." }] }
+  }
+}
+```
 
 ## String
 
-Send raw text and let Engram's [pipeline](pipelines.md) extract structured memories from it. This is the simplest input type — suitable for free-form notes, agent observations, or any unstructured text.
+Send raw text and let Engram's [pipeline](pipelines.md) extract structured memories from it. `content` is an array, so you can send multiple unrelated strings in one call — each becomes its own pipeline input.
+
+```python
+client.memories.add("The user prefers dark mode and uses VS Code.", user_id="alice")
+```
 
 ## Pre-extracted
 
-Send already-structured content when you've done your own extraction or want to bypass Engram's extraction step. The content is passed through directly to the transform and commit stages.
+Send already-structured items when you've done your own extraction. Each item carries its target topic and bypasses the LLM extraction step — it still flows through the transform and commit stages.
+
+```python
+from engram import PreExtractedInput, PreExtractedItem
+
+client.memories.add(
+    PreExtractedInput(items=[
+        PreExtractedItem(content="User prefers dark mode", topic="UserKnowledge"),
+        PreExtractedItem(content="User works in Python",   topic="UserKnowledge"),
+    ]),
+    user_id="alice",
+)
+```
 
 ## Conversation
 
-Send multi-turn messages with roles (e.g. `user`, `assistant`) for chat transcripts and agent conversations. The pipeline uses conversation-aware extraction to pull memories from the dialogue context.
+Send multi-turn messages with roles for chat transcripts and agent conversations. The pipeline uses conversation-aware extraction to pull memories from the dialogue.
+
+Messages follow the OpenAI Chat Completions format: `role` is one of `user`, `assistant`, `system`, `tool`, or `developer`. Tool calls (`tool_calls`, `tool_call_id`, `name`) are supported. The server normalizes `tool` → `user` and `developer` → `system` internally.
+
+```python
+client.memories.add(
+    [
+        {"role": "user", "content": "I just moved to Berlin."},
+        {"role": "assistant", "content": "Welcome to Berlin!"},
+        {"role": "user", "content": "I prefer specialty coffee."},
+    ],
+    user_id="alice",
+)
+```
 
 ## Questions and feedback
 

--- a/docs/engram/concepts/memories.md
+++ b/docs/engram/concepts/memories.md
@@ -14,7 +14,7 @@ A memory is a discrete piece of information stored in Engram. Each memory has:
 | [`group`](groups.md) | The memory group that defines how it was processed |
 | `project_id` | The project this memory belongs to |
 | [`user_id`](scopes.md) | The user this memory is scoped to (if user-scoped) |
-| [`conversation_id`](scopes.md) | The conversation this memory is scoped to (if conversation-scoped) |
+| [`properties`](scopes.md) | Custom scope properties attached to the memory (e.g. `{"conversation_id": "abc"}` for conversation-scoped topics) |
 | `created_at` | When the memory was created (RFC 3339) |
 | `updated_at` | When the memory was last updated (RFC 3339) |
 | `score` | Relevance score (only present in search results) |

--- a/docs/engram/concepts/pipelines.md
+++ b/docs/engram/concepts/pipelines.md
@@ -17,8 +17,8 @@ Pipelines will be configurable in the future.
 Each pipeline is a DAG with multiple entrypoints — one per content type — that converge into shared downstream steps:
 
 1. **Extract** — The entrypoint into the pipeline. Each [content type](input-data-types.md) has its own extraction step (`ExtractFromString`, `ExtractFromConversation`, or `ExtractFromPreExtracted`), but they all feed into the same downstream transform and commit steps.
-2. **Transform** — Refines extracted memories using existing context. Steps like `TransformWithContext` and `TransformOperations` deduplicate, merge, and resolve conflicts with existing memories.
-3. **Buffer** — Pauses the pipeline and accumulates memories until a trigger fires (e.g. a time interval). Buffers can appear anywhere in the pipeline, not just at the start. Memories from different content types that route into the same buffer are aggregated together.
+2. **Transform** — Refines extracted memories using existing context. Steps like `TransformWithContext`, `TransformOperations`, `TransformConcatenate`, and `TransformAggregate` deduplicate, merge, consolidate, and resolve conflicts with existing memories. `TransformAggregate` and `TransformWithContext` also honor [bounded topics](topics.md), shrinking the topic back under its cap when it would overflow.
+3. **Buffer** — Pauses the pipeline and accumulates memories (or raw inputs) until a trigger fires — by count, time since the first item, or time since the last item. Buffers can appear anywhere in the pipeline, not just at the start. Memories from different content types that route into the same buffer are aggregated together.
 4. **Commit** — Finalizes the operations (create, update, delete) and persists them to storage.
 
 A pipeline can chain these steps in different ways. For example, a pipeline for aggregated daily summaries might look like:

--- a/docs/engram/concepts/scopes.md
+++ b/docs/engram/concepts/scopes.md
@@ -1,37 +1,87 @@
 ---
 title: Scopes
 sidebar_position: 4
-description: "Engram's multi-level scoping system: project, user, and conversation isolation for memories."
+description: "Engram's multi-level scoping system: project, user, and custom property isolation for memories."
 ---
 
 Engram uses a multi-level scoping system to isolate memories:
 
 - **Project** — Always required. Every memory belongs to a project, identified by the API key.
-- **User** — Required for user-scoped topics. Memories are strictly isolated between users.
-- **Conversation** — Required when storing to conversation-scoped topics. Optional when searching (see below).
+- **User** — Required for user-scoped [topics](topics.md). Memories are strictly isolated between users.
+- **Custom properties** — Arbitrary `key: value` pairs (e.g. `conversation_id`, `session_id`, `tenant_id`) that topics can require for additional isolation.
 
-Which scopes are required depends on the [topic](topics.md) configuration.
+Which scopes a request must provide depends on the topic configuration.
 
 ## User-scoped topics
 
 User-scoped topics store memories that belong to an individual user, such as preferences or personal details. Memories are strictly isolated between users — a query for one `user_id` never returns another user's memories. Both storing and searching require the `user_id`.
 
+```python
+client.memories.add(
+    "The user prefers dark mode.",
+    user_id="alice",
+)
+
+results = client.memories.search(
+    query="What does the user prefer?",
+    user_id="alice",
+)
+```
+
 ## Project-wide topics
 
-Topics that are not user-scoped are shared across the entire project. These are useful for procedural memory — things an agent learns about how to perform a task, regardless of which user it is working with. No `user_id` is needed for storing or searching.
+Topics that are not user-scoped are shared across the entire project. These are useful for procedural memory — things an agent learns about how to perform a task, regardless of which user it is working with. No `user_id` is needed.
 
-## Conversation-scoped topics
+## Custom property scopes
 
-Conversation-scoped topics associate memories with a specific conversation. When **storing**, you must provide the `conversation_id`. When **searching**, the `conversation_id` is optional:
+Topics can declare additional `properties` they are scoped by. For example, a `conversation_summary` topic might be scoped by `conversation_id`, or a `tenant_facts` topic might be scoped by `tenant_id`. The property key is arbitrary — it just has to match what the topic was configured with.
 
-- **With `conversation_id`** — Returns only memories from that conversation (e.g. to get a summary of a specific chat).
-- **Without `conversation_id`** — Returns memories across all conversations (e.g. to find everything a user has discussed).
+When storing or searching memories for a property-scoped topic, pass the values in the `properties` map:
 
-Conversation-scoped topics are typically also user-scoped (e.g. conversation summaries are private to a user).
+```python
+client.memories.add(
+    ConversationInput(messages=[...]),
+    user_id="alice",
+    properties={"conversation_id": "abc-123"},
+)
+
+# Search within a single conversation
+results = client.memories.search(
+    query="What did we discuss?",
+    user_id="alice",
+    properties={"conversation_id": "abc-123"},
+)
+```
+
+When **storing**, every property the target topic is scoped by must be present.
+
+When **searching**:
+
+- Including a property narrows results to memories matching that value.
+- Omitting a property searches across all values (e.g. omit `conversation_id` to find a user's memories across all conversations).
+
+## Per-topic property filters
+
+When searching across multiple topics with different scope requirements, the per-topic `properties` filter lets you set different values per topic, or clear an inherited global filter on a specific topic:
+
+```python
+from engram import Topic
+
+results = client.memories.search(
+    query="...",
+    user_id="alice",
+    properties={"conversation_id": "abc-123"},  # default for all topics
+    topics=[
+        "user_facts",                                          # not conversation-scoped, ignores the filter
+        Topic(name="conversation_summary"),                    # uses the global filter (abc-123)
+        Topic(name="messages", properties={"conversation_id": None}),  # clear filter — search all conversations
+    ],
+)
+```
 
 ## Multiple topics in one request
 
-A single request can interact with multiple topics. When it does, the required scope parameters are the union of each topic's requirements. For example, if one topic requires `user_id` and another requires `conversation_id`, the request must include both.
+A single request can interact with multiple topics. The required scope parameters are the union of each topic's requirements. For example, if one topic requires `user_id` and another requires `properties.conversation_id`, the request must include both.
 
 ## Questions and feedback
 

--- a/docs/engram/concepts/topics.md
+++ b/docs/engram/concepts/topics.md
@@ -12,6 +12,8 @@ Each topic has:
 |----------|-------------|
 | `name` | Unique identifier within the group (e.g. `user_facts`) |
 | `description` | Natural language description used in LLM prompts during extraction (e.g. "What food the user likes to eat") |
+| `scoping` | Which scopes the topic requires: `user_scoped` (requires `user_id`) and a list of custom `scope_properties` keys (e.g. `conversation_id`). See [scopes](scopes.md). |
+| `is_bounded` | Whether the topic has a size cap. Bounded topics trigger consolidation transforms in the pipeline to keep the topic compact. |
 
 The topic `description` is important — it's what the extraction [pipeline](pipelines.md) uses to decide how to categorize information. For example, a travel agent might have separate topics with descriptions like "The places the user would like to visit" and "What food the user likes to eat" so the pipeline can route extracted facts to the right topic.
 

--- a/docs/engram/guides/manage-memories.md
+++ b/docs/engram/guides/manage-memories.md
@@ -44,8 +44,7 @@ Retrieve a single memory by its ID.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `user_id` | string | User [scope](../concepts/scopes.md) (required if the topic is user-scoped) |
-| `conversation_id` | string | Conversation [scope](../concepts/scopes.md) (required if the topic is conversation-scoped) |
-| `group` | string | The memory [group](../concepts/groups.md) name |
+| `group` | string | The memory [group](../concepts/groups.md) name (defaults to `default`) |
 
 ### Response
 
@@ -57,6 +56,7 @@ Retrieve a single memory by its ID.
   "content": "The user prefers dark mode.",
   "topic": "UserKnowledge",
   "group": "default",
+  "properties": { "conversation_id": "abc-123" },
   "created_at": "2025-01-01T00:00:00Z",
   "updated_at": "2025-01-01T00:00:00Z"
 }

--- a/docs/engram/guides/search-memories.md
+++ b/docs/engram/guides/search-memories.md
@@ -177,12 +177,33 @@ If you omit `topics`, Engram searches across all topics in the group.
 Search results are [scoped](../concepts/scopes.md) to match the parameters you provide:
 
 - **`user_id`** — Required for user-scoped topics. Only returns memories for this user.
-- **`conversation_id`** — Optional for conversation-scoped topics. Include it to filter to a single conversation, or omit it to search across all conversations.
+- **`properties`** — Optional map of custom scope properties (e.g. `{"conversation_id": "abc-123"}`). Including a key narrows results; omitting a key searches across all values for that key.
 - **`group`** — Search within this group. Defaults to `default`.
 
 :::tip
-For user-scoped topics, always include the `user_id` you used when storing the memories. For conversation-scoped topics, you can omit `conversation_id` to search across all conversations at once.
+For user-scoped topics, always include the `user_id` you used when storing the memories. For property-scoped topics, you can omit a property key to search across all values — for example, omit `conversation_id` to find a user's memories across all conversations at once.
 :::
+
+### Per-topic property filters
+
+When searching multiple topics with different scope requirements, you can override the global `properties` filter on a per-topic basis. Pass an object instead of a string in the `topics` array:
+
+```python
+from engram import Topic
+
+results = client.memories.search(
+    query="...",
+    user_id="alice",
+    properties={"conversation_id": "abc-123"},  # global default
+    topics=[
+        "user_facts",                                            # not conversation-scoped, ignores the filter
+        Topic(name="conversation_summary"),                      # uses the global filter
+        Topic(name="messages", properties={"conversation_id": None}),  # clear filter — all conversations
+    ],
+)
+```
+
+A `null` value clears an inherited global filter for that topic only.
 
 ## Questions and feedback
 

--- a/docs/engram/guides/store-memories.md
+++ b/docs/engram/guides/store-memories.md
@@ -114,13 +114,13 @@ A successful response means the pipeline has started, not that the memories have
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `user_id` | string | [Scope](../concepts/scopes.md) the memory to a specific user |
-| `conversation_id` | string (UUID) | [Scope](../concepts/scopes.md) the memory to a specific conversation. Must be a valid UUID. |
+| `user_id` | string | [Scope](../concepts/scopes.md) the memory to a specific user. Required if the target topic is user-scoped. |
+| `properties` | object\<string, string\> | Custom [scope properties](../concepts/scopes.md) (e.g. `{"conversation_id": "abc-123"}`). Must include every key any target topic is scoped by. |
 | `group` | string | Memory [group](../concepts/groups.md) name (defaults to `default`) |
 | `root` | string | Pipeline root name (for advanced pipeline configurations) |
 
 :::info
-Which parameters are required depends on the topic's [scoping](../concepts/scopes.md) configuration, not the content type. If a topic is user-scoped, you must include `user_id`. If a topic is conversation-scoped, you must include `conversation_id` when storing (it is optional when searching). These scoping parameters apply equally to all three content types — for example, you can include `conversation_id` with string content, or omit it with conversation content, depending on the topic configuration.
+Which parameters are required depends on the topic's [scoping](../concepts/scopes.md) configuration, not the content type. If a topic is user-scoped, you must include `user_id`. If a topic is scoped by a custom property (e.g. `conversation_id`), pass it in `properties`. These scoping parameters apply equally to all three content types.
 :::
 
 ## Questions and feedback

--- a/docs/engram/index.md
+++ b/docs/engram/index.md
@@ -13,7 +13,7 @@ Use Engram to give your agents persistent memory that they can write to and sear
 
 - **Automatic memory extraction** — Send raw text, pre-extracted facts, or full conversations. Engram's [pipeline](concepts/pipelines.md) extracts and stores structured [memories](concepts/memories.md) automatically.
 - **Semantic search** — Find relevant memories using vector similarity, BM25 keyword search, or [hybrid retrieval](concepts/search.md).
-- **Scoped memory** — Organize memories by project, user, and conversation. [Topics](concepts/topics.md) let you categorize memories within a [group](concepts/groups.md) (e.g. `UserKnowledge`, `ConversationSummary`).
+- **Scoped memory** — Isolate memories by project, user, and any custom scope properties (e.g. `conversation_id`, `tenant_id`). [Topics](concepts/topics.md) let you categorize memories within a [group](concepts/groups.md).
 - **Async processing** — Memory storage runs asynchronously through a pipeline. Poll [run status](guides/check-run-status.md) to track when memories are committed.
 
 ## How it works

--- a/docs/engram/quickstart.md
+++ b/docs/engram/quickstart.md
@@ -42,9 +42,9 @@ Every memory in Engram belongs to a project. Create one in the [Weaviate Cloud c
 
 You can select a predefined template when creating a project. For this tutorial, use the **Personalization template**.
 
-The template provides you with a default [group](concepts/groups.md) called `personalization` and a default [topic](concepts/topics.md) called `UserKnowledge` (description: *"Anything relating to the user personally: their personal details (name, age, interpersonal relationships, etc.), their preferences, what they've done or plan to do, etc., i.e., any generic information about the user."*). This is enough to get started.
+The template seeds the project's `default` [group](concepts/groups.md) with a [topic](concepts/topics.md) called `UserKnowledge` (description: *"Anything relating to the user personally: their personal details (name, age, interpersonal relationships, etc.), their preferences, what they've done or plan to do, etc., i.e., any generic information about the user."*). This is enough to get started.
 
-The template also lets you optionally add a `ConversationSummary` topic, which maintains a single summary for each conversation ID containing the entire history of that conversation. Enabling this option makes `conversation_id` required when adding memories, which is why it's disabled by default.
+The template also lets you optionally add a `ConversationSummary` topic, which maintains a single summary per conversation. Enabling this option makes a `conversation_id` [property](concepts/scopes.md) required when adding memories that target it, which is why it's disabled by default.
 
 <details>
 


### PR DESCRIPTION
## Summary

Refreshes the Engram documentation to match the current state of the API (commit `512e8c8`) and Python SDK (`weaviate-engram` v0.6.0). The docs had drifted from the implementation in several places.

### What changed

**Request format (curl examples).** All `POST /v1/memories` curl payloads switched from the deprecated `content: { type, content, ... }` discriminated form to the modern `input: { string | pre_extracted | conversation: ... }` union — across `quickstart.sh`, `store_memories.sh`, `search_memories.sh`, `manage_memories.sh`, `check_run_status.sh`.

**Scoping model.** `conversation_id` is no longer a first-class parameter — it's a key in the generic `properties` map. Updated `concepts/scopes.md` (rewritten), `concepts/memories.md`, `concepts/index.md`, `guides/store-memories.md`, `guides/search-memories.md`, `guides/manage-memories.md` to reflect this. Added a per-topic property filter section using the SDK's `Topic(...)` selector.

**SDK examples.** Fixed broken `PreExtractedContent` import in `store_memories.py` and `tutorial_personalized_rag.py` — replaced with `PreExtractedInput(items=[PreExtractedItem(content, topic)])`. Un-commented the `StorePreExtracted` block (it was previously a `TODO`). Removed an invalid `topic=` argument from `cleanup_memories.py`'s `delete()` call.

**Concepts.**
- `concepts/topics.md`: added `scoping` and `is_bounded` properties.
- `concepts/pipelines.md`: documented `TransformAggregate`, `TransformConcatenate`, bounded-topic enforcement, and buffer trigger types.
- `concepts/input-data-types.md`: rewritten with the modern `input` shape and Python examples for each variant.
- `concepts/groups.md`: removed the stale `default_personalisation` / `default_continual_learning` names — projects now provision a single `default` group.

**Quickstart.** Softened the template-specific group/topic claims so they describe what the template seeds rather than asserting fixed names.

## Test plan

- [ ] CI builds the docs site without broken links
- [ ] Run `_includes/quickstart.sh` and `_includes/store_memories.sh` against staging to confirm the new `input` payloads work
- [ ] Run `_includes/store_memories.py` to confirm the un-commented `StorePreExtracted` example completes
- [ ] Spot-check the rendered pages for `concepts/scopes.md`, `guides/search-memories.md`, and `concepts/input-data-types.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)