### PR TITLE
Query Agent docs rework + naming, tests, and redirects

### DIFF
--- a/docs/agents/_includes/code/query_agent.mts
+++ b/docs/agents/_includes/code/query_agent.mts
@@ -147,9 +147,15 @@ for (const obj of basicSearchResponse.searchResults.objects) {
 // END BasicSearchQuery
 
 // START DiversityRanking
+// Diversity ranking needs a vectorizer it can resolve. Scope the call to a
+// single collection with a target vector so the agent knows what to use.
 const diversitySearchResponse = await qa.search("summer shoes", {
     limit: 10,
-    diversityWeight: 0.5
+    diversityWeight: 0.5,
+    collections: [{
+        name: "ECommerce",
+        targetVector: ["name_description_brand_vector"],
+    }],
 })
 
 // Access the search results
@@ -349,7 +355,7 @@ if (!basicResponse.finalAnswer || basicResponse.finalAnswer === '') {
 
 // START SuggestQueries
 const suggestResponse = await qa.suggestQueries({
-    collections: ["IRPAPERS"],
+    collections: ["FinancialContracts"],
     numQueries: 3,
     instructions: "High-level themes and open-ended exploration",
 });

--- a/docs/agents/_includes/code/query_agent.py
+++ b/docs/agents/_includes/code/query_agent.py
@@ -273,6 +273,12 @@ search_response = qa.search(
     "summer shoes",
     limit=10,
     diversity_weight=0.5,
+    collections=[
+        QueryAgentCollectionConfig(
+            name="ECommerce",
+            target_vector=["name_description_brand_vector"],
+        )
+    ],
 )
 
 # Access the search results
@@ -364,12 +370,18 @@ client.close()
 import asyncio
 import os
 import weaviate
+from weaviate.classes.init import Auth
 from weaviate.agents.query import AsyncQueryAgent
 
+# Provide any inference-provider keys your collections' vectorizers / generative
+# models need; an empty dict is fine if the cluster uses Weaviate Embeddings.
+headers = {
+    "X-OpenAI-API-Key": os.environ.get("OPENAI_API_KEY", ""),
+}
 
 async_client = weaviate.use_async_with_weaviate_cloud(
     cluster_url=os.environ.get("WEAVIATE_URL"),
-    auth_credentials=os.environ.get("WEAVIATE_API_KEY"),
+    auth_credentials=Auth.api_key(os.environ.get("WEAVIATE_API_KEY")),
     headers=headers,
 )
 
@@ -492,7 +504,7 @@ asyncio.run(run_streaming_query())
 
 # START SuggestQueries
 response = qa.suggest_queries(
-    collections=["IRPAPERS"],
+    collections=["FinancialContracts"],
     num_queries=3,
     instructions="High-level themes and open-ended exploration",
 )

--- a/docs/agents/_includes/code/search_mode.mts
+++ b/docs/agents/_includes/code/search_mode.mts
@@ -52,6 +52,10 @@ for (const obj of searchResponse.searchResults.objects) {
 const diversitySearchResponse = await qa.search("summer shoes", {
     limit: 10,
     diversityWeight: 0.5,
+    collections: [{
+        name: "ECommerce",
+        targetVector: ["name_description_brand_vector"],
+    }],
 });
 
 for (const obj of diversitySearchResponse.searchResults.objects) {

--- a/docs/agents/_includes/code/search_mode.mts
+++ b/docs/agents/_includes/code/search_mode.mts
@@ -91,4 +91,15 @@ pages.forEach((pageResponse, index) => {
 });
 // END SearchPagination
 
+// START FilteringExample
+const filteringResponse = await qa.search("Find me some vintage shoes under $70", {
+    filtering: "precision",
+    limit: 10,
+});
+
+for (const obj of filteringResponse.searchResults.objects) {
+    console.log(`Product: ${obj.properties['name']} - $${obj.properties['price']}`);
+}
+// END FilteringExample
+
 await client.close();

--- a/docs/agents/_includes/code/search_mode.py
+++ b/docs/agents/_includes/code/search_mode.py
@@ -96,6 +96,17 @@ for page_num, page_response in enumerate(
     print()
 # END SearchPagination
 
+# START FilteringExample
+search_response = qa.search(
+    "Find me some vintage shoes under $70",
+    filtering="precision",
+    limit=10,
+)
+
+for obj in search_response.search_results.objects:
+    print(f"Product: {obj.properties['name']} - ${obj.properties['price']}")
+# END FilteringExample
+
 # --- Async code examples in string as top-level await doesn't work, full code will be executed in 
 # asyncio.run below
 

--- a/docs/agents/_includes/code/suggest_queries.py
+++ b/docs/agents/_includes/code/suggest_queries.py
@@ -61,6 +61,7 @@ async def _async_run_for_testing():
     import weaviate
     from weaviate.classes.init import Auth
     from weaviate.agents.query import AsyncQueryAgent
+    from weaviate.agents.classes import QueryAgentCollectionConfig
 
     async_client = weaviate.use_async_with_weaviate_cloud(
         cluster_url=os.environ.get("WEAVIATE_URL"),

--- a/docs/agents/clients/index.md
+++ b/docs/agents/clients/index.md
@@ -1,6 +1,6 @@
 ---
 title: Agents clients
-description: "Use the Python or TypeScript client to interact with Weaviate Agents."
+description: "Use the Python or TypeScript client to interact with the Query Agent."
 image: og/docs/agents.jpg
 tags: ['agents', 'query-agent', 'clients']
 ---
@@ -14,13 +14,13 @@ export const agentsClientLibrariesData = [
   {
     title: "Python Client",
     description:
-      "Install and use the official Weaviate Agents Python client.",
+      "Install and use the official Query Agent Python client.",
     link: "/agents/clients/python/",
     icon: "fab fa-python",
   },
   {
     title: "JavaScript / TypeScript Client",
-    description: "Use the official Weaviate Agents TypesScript/JavaScript client.",
+    description: "Use the official Query Agent TypeScript/JavaScript client.",
     link: "/agents/clients/typescript/",
     icon: "fab fa-js",
   }

--- a/docs/agents/clients/python.md
+++ b/docs/agents/clients/python.md
@@ -1,6 +1,6 @@
 ---
 title: Python client
-description: "Use the Python client to interact with Weaviate Agents."
+description: "Use the Python client to interact with the Query Agent."
 image: og/docs/agents.jpg
 tags: ['agents', 'query-agent', 'clients']
 ---
@@ -20,14 +20,14 @@ export const pythonCardsData = [
   },
 ];
 
-The Python client allows you to easily interact with the Weaviate Agents API from your Python applications. 
+The Python client allows you to easily interact with the Query Agent API from your Python applications. 
 
 It relies on the [Weaviate Client package](../../weaviate/client-libraries/python/index.mdx), and handles authentication and connection to your Weaviate instance from there.
 
 
 :::note Python client (SDK)
 
-The latest Weaviate Agents Python client is version `v||site.agents_python_version||`.
+The latest Query Agent Python client is version `v||site.agents_python_version||`.
 
 <QuickLinks items={pythonCardsData} />
 
@@ -35,7 +35,7 @@ The latest Weaviate Agents Python client is version `v||site.agents_python_versi
 
 ## Installation
 
-The Weaviate Agents Python client is distributed as the [`weaviate-agents`](https://pypi.org/project/weaviate-agents/) package on PyPI, and depends on the [`weaviate-client`](https://pypi.org/project/weaviate-client/) package. You can install it in one of two equivalent ways.
+The Query Agent Python client is distributed as the [`weaviate-agents`](https://pypi.org/project/weaviate-agents/) package on PyPI, and depends on the [`weaviate-client`](https://pypi.org/project/weaviate-client/) package. You can install it in one of two equivalent ways.
 
 **Recommended: Install via the `weaviate-client` extra**
 

--- a/docs/agents/clients/typescript.md
+++ b/docs/agents/clients/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: JavaScript/TypeScript client
-description: "Use the TypeScript client to interact with Weaviate Agents."
+description: "Use the TypeScript client to interact with the Query Agent."
 image: og/docs/agents.jpg
 tags: ['agents', 'query-agent', 'clients']
 ---
@@ -20,13 +20,13 @@ export const pythonCardsData = [
   },
 ];
 
-The TypeScript client supports code that is written in TypeScript or JavaScript. It allows you to easily interact with the Weaviate Agents API from your JavaScript or TypeScript applications.
+The TypeScript client supports code that is written in TypeScript or JavaScript. It allows you to easily interact with the Query Agent API from your JavaScript or TypeScript applications.
 
 It relies on the [Weaviate Client package](../../weaviate/client-libraries/typescript/index.mdx), and handles authentication and connection to your Weaviate instance from there.
 
-:::note JavaScript/TypeScript Client client (SDK)
+:::note JavaScript/TypeScript client (SDK)
 
-The latest Weaviate Agents TypeScript client is version `v||site.agents_typescript_version||`.
+The latest Query Agent TypeScript client is version `v||site.agents_typescript_version||`.
 
 <QuickLinks items={pythonCardsData} />
 
@@ -34,7 +34,7 @@ The latest Weaviate Agents TypeScript client is version `v||site.agents_typescri
 
 ## Installation
 
-The Weaviate Agents TypeScript client is distributed as the [`weaviate-agents`](https://www.npmjs.com/package/weaviate-agents) package on npm, and depends on the [`weaviate-client`](https://www.npmjs.com/package/weaviate-client) package, which it declares as a peer dependency. You should install both packages together:
+The Query Agent TypeScript client is distributed as the [`weaviate-agents`](https://www.npmjs.com/package/weaviate-agents) package on npm, and depends on the [`weaviate-client`](https://www.npmjs.com/package/weaviate-client) package, which it declares as a peer dependency. You should install both packages together:
 
 ```shell
 npm install weaviate-client weaviate-agents

--- a/docs/agents/guides/search_mode.md
+++ b/docs/agents/guides/search_mode.md
@@ -177,6 +177,10 @@ The Search Mode response has the following properties:
 
 </Tabs>
 
+:::note Result scores
+The `search_results` / `searchResults` field reuses Weaviate's native `QueryReturn` / `WeaviateReturn` type, so results have the same shape as a standard Weaviate query. However, the `score` in each object's metadata is replaced with Search Mode's own ranking score rather than the original Weaviate search score.
+:::
+
 
 ### Pagination
 

--- a/docs/agents/guides/search_mode.md
+++ b/docs/agents/guides/search_mode.md
@@ -67,6 +67,7 @@ The `.search()` method accepts several arguments:
 | `query` | The user query you want the agent to search with. This can be a simple string (`"Find me some vintage shoes under $70"`) or a list of chat messages (for conversational context). [See the page on multi-turn conversations for more detail](../reference/multi_turn_conversations.md). |
 | `collections` | The name(s) of the collections to search. You can pass one or many collection names as a list of strings (e.g., `["ECommerce", "BookSales"]`), or provide collection configuration objects for more control. If specified in the `ask` method, it will overwrite those defined in the instantiation of `QueryAgent`. [See the page on collection configuration for more detail](../reference/advanced_collections.md). |
 | `limit` | The maximum number of results returned in this page of results. Use [`.next()`](#pagination) to fetch additional pages. |
+| `filtering` | Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. See [Customized filtering](#customized-filtering) below. |
 | `diversity_weight` | A value between `0.0` and `1.0` that biases the result ranking towards diversity using Maximal Marginal Relevance (MMR). See [Diversity ranking](#diversity-ranking) below. |
 
 </TabItem>
@@ -76,12 +77,41 @@ The `.search()` method accepts several arguments:
 | `query` | The user query you want the agent to search with. This can be a simple string (`"Find me some vintage shoes under $70"`) or a list of chat messages (for conversational context). [See the page on multi-turn conversations for more detail](../reference/multi_turn_conversations.md). |
 | `collections` | The name(s) of the collections to search. You can pass one or many collection names as a list of strings (e.g., `["ECommerce", "BookSales"]`), or provide collection configuration objects for more control. If specified in the `ask` method, it will overwrite those defined in the instantiation of `QueryAgent`. [See the page on collection configuration for more detail](../reference/advanced_collections.md). |
 | `limit` | The maximum number of results returned in this page of results. Use [`.next()`](#pagination) to fetch additional pages. |
+| `filtering` | Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. See [Customized filtering](#customized-filtering) above. |
 | `diversityWeight` | A value between `0.0` and `1.0` that biases the result ranking towards diversity using Maximal Marginal Relevance (MMR). See [Diversity ranking](#diversity-ranking) below. |
 
 </TabItem>
 </Tabs>
 
 For more advanced searches, you can also specify _additional filters_ within the collection configuration. [See the page on additional filters for more detail](../reference/additional_filters.md).
+
+### Customized filtering
+
+Search Mode uses query rewriting to transform your original query into one or multiple Weaviate queries, each with either a search query, metadata filters, or both. The `filtering` parameter controls how many Weaviate queries are generated.
+
+- **`"recall"`** (default): Generates multiple Weaviate queries spanning different filters and interpretations of the user query. You should use these when you prefer to get results, even if they don't match every criteria in your query.
+
+- **`"precision"`**: Generates a single Weaviate query targeting the most likely interpretation of the user query. You should use this when you want the results to follow your query intent closely, even if that means potentially receiving no results.
+
+<Tabs className="code" groupId="languages">
+    <TabItem value="py_agents" label="Python">
+        <FilteredTextBlock
+            text={PyCode}
+            startMarker="# START FilteringExample"
+            endMarker="# END FilteringExample"
+            language="py"
+        />
+    </TabItem>
+    <TabItem value="ts_agents" label="JavaScript/TypeScript">
+        <FilteredTextBlock
+            text={TSCode}
+            startMarker="// START FilteringExample"
+            endMarker="// END FilteringExample"
+            language="ts"
+        />
+    </TabItem>
+
+</Tabs>
 
 ### Diversity ranking
 

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -151,7 +151,7 @@ Already have a cluster but no data? Upload via CSV in the cloud console, or [via
 
 
 <!-- :::info Changelog and feedback
-The official changelog for Weaviate Agents can be [found here](https://weaviateagents.featurebase.app/changelog). If you have feedback, such as feature requests, bug reports or questions, please [submit them here](https://weaviateagents.featurebase.app/), where you will be able to see the status of your feedback and vote on others' feedback.
+The official changelog for the Query Agent can be [found here](https://weaviateagents.featurebase.app/changelog). If you have feedback, such as feature requests, bug reports or questions, please [submit them here](https://weaviateagents.featurebase.app/), where you will be able to see the status of your feedback and vote on others' feedback.
 ::: -->
 
 import DocsFeedback from '/_includes/docs-feedback.mdx';

--- a/docs/agents/installation.md
+++ b/docs/agents/installation.md
@@ -7,6 +7,8 @@ tags: ['agents', 'query-agent', 'getting-started']
 
 <CloudOnlyBadge />
 
+Install the Query Agent client package alongside the regular Weaviate client. Below are the prerequisites and the install commands for Python and JavaScript/TypeScript.
+
 ## Prerequisites
 
 :::info What does the Query Agent have access to?
@@ -27,7 +29,7 @@ At this time, the Query Agent clients are available only for Python and JavaScri
 
 ## Python client
 
-For Python, you can install the Weaviate client library with the optional `agents` extras to use Weaviate Agents. This will install the `weaviate-agents` package along with the `weaviate-client` package. For JavaScript/TypeScript, you can install the `weaviate-agents` package alongside the `weaviate-client` package.
+For Python, you can install the Weaviate client library with the optional `agents` extras to use the Query Agent. This will install the `weaviate-agents` package along with the `weaviate-client` package. For JavaScript/TypeScript, you can install the `weaviate-agents` package alongside the `weaviate-client` package.
 
 Install the client library using the following command:
 

--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -13,6 +13,8 @@ import TSCode from '!!raw-loader!/docs/agents/\_includes/code/quickstart.mts';
 
 <CloudOnlyBadge />
 
+This quickstart walks through connecting to a Weaviate Cloud cluster, pointing the Query Agent at one or more existing collections, and running your first natural-language queries in both Search Mode and Ask Mode.
+
 ## Prerequisites
 
 Ensure you have access to:

--- a/docs/agents/recipes/index.mdx
+++ b/docs/agents/recipes/index.mdx
@@ -1,10 +1,12 @@
 ---
-title: Recipes
+title: Tutorials and guides
 description: "Examples of using the Query Agent in different use cases."
 image: og/docs/agents.jpg
 tags: ['agents', 'query-agent', 'recipes']
 ---
 
 import RecipesCards from "@site/src/components/RecipesCards";
+
+Self-contained examples that show how to apply the Query Agent to specific problems — from getting started against a single collection to wiring it into a Streamlit chat UI or exposing it as a tool to another LLM.
 
 <RecipesCards path="/agents/recipes" />

--- a/docs/agents/reference/additional_filters.md
+++ b/docs/agents/reference/additional_filters.md
@@ -11,8 +11,6 @@ import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBl
 import PyCode from '!!raw-loader!/docs/agents/_includes/code/additional_filters.py';
 import TSCode from '!!raw-loader!/docs/agents/_includes/code/additional_filters.mts';
 
-<!-- Details on using the `additional_filters` argument, as well as typical usecases or examples where this might be useful. -->
-
 Additional filters can be used to subset the data in a single collection manually in addition to whatever filters the Query Agent decides to use in a particular search.
 
 These persistent filters are defined at the specification of the collection, and combined with agent-generated filters using logical `AND` operations at search time.

--- a/docs/agents/reference/advanced_collections.md
+++ b/docs/agents/reference/advanced_collections.md
@@ -11,14 +11,6 @@ import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBl
 import PyCode from '!!raw-loader!/docs/agents/_includes/code/advanced_collections.py';
 import TSCode from '!!raw-loader!/docs/agents/_includes/code/advanced_collections.mts';
 
-<!-- Contains:
-* Explanation on how the QA can choose which collections are queried
-* Detail on how you can pass either string or `QueryAgentCollectionConfig` to the `collections` argument to `.ask()` or `.search()`
-* Full breakdown of `QueryAgentCollectionConfig` and all its arguments:
-    * `target_vector`
-    * `view_properties`
-    * `additional_filters` and link to additional filters reference page -->
-
 The Query Agent, in Ask Mode or Search Mode, has the option to search one or more of any collections that are provided to it. 
 
 These collections can either be specified by a string (the name of the collection) or via a more advanced configuration.

--- a/docs/agents/reference/instantiation.md
+++ b/docs/agents/reference/instantiation.md
@@ -12,6 +12,8 @@ import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBl
 import PyCode from '!!raw-loader!/docs/agents/_includes/code/instantiation.py';
 import TSCode from '!!raw-loader!/docs/agents/_includes/code/instantiation.mts';
 
+Instantiate the Query Agent against an authenticated Weaviate Cloud client. Configuration can be set at construction time (collections, system prompt, default timeout) and most options can also be overridden per call to `ask()` or `search()`.
+
 ## Basic instantiation
 
 The Query Agent requires only a target [Weaviate Cloud instance](/cloud/manage-clusters/connect.mdx) to be initialised. First, set up a Weaviate client:

--- a/docs/agents/reference/multi_turn_conversations.md
+++ b/docs/agents/reference/multi_turn_conversations.md
@@ -11,8 +11,6 @@ import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBl
 import PyCode from '!!raw-loader!/docs/agents/_includes/code/conversations.py';
 import TSCode from '!!raw-loader!/docs/agents/_includes/code/conversations.mts';
 
-<!-- Detail on passing user/assistant message history instead of user query, typical usecases. Maybe an example function that iteratively updates message history every time `qa.ask()` is called. -->
-
 The Query Agent transforms a natural language query into actionable searches. You can either pass a single string for the query, or provide more context by including a full conversation with previous message turns.
 
 

--- a/docs/agents/reference/troubleshooting.md
+++ b/docs/agents/reference/troubleshooting.md
@@ -5,6 +5,8 @@ image: og/docs/agents.jpg
 tags: ['agents', 'query-agent', 'troubleshooting']
 ---
 
+Things to check when the Query Agent isn't behaving as expected, plus the soft usage limits and typical execution timings to keep in mind.
+
 ## Usage limits
 
 import UsageLimits from "/\_includes/agents/query-agent-usage-limits.mdx";

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -14,7 +14,7 @@ Frequently asked questions (FAQs) about [Weaviate Cloud (WCD)](/go/console?utm_c
 <details>
 <summary> Answer </summary>
 
-Using Weaviate Cloud gives you access to a 14-day free sandbox for testing. You also get access to advanced features like [Weaviate Embeddings](docs/cloud/embeddings/index.md) and [Weaviate Agents](docs/agents/index.md), which are not available in all deployment methods.
+Using Weaviate Cloud gives you access to a 14-day free sandbox for testing. You also get access to advanced features like [Weaviate Embeddings](docs/cloud/embeddings/index.md) and the [Query Agent](docs/agents/index.md), which are not available in all deployment methods.
 
 </details>
 

--- a/docs/cloud/tools/query-agent.mdx
+++ b/docs/cloud/tools/query-agent.mdx
@@ -71,7 +71,7 @@ In addition to selecting one or more collections to query, you can also:
 
 ## Generate code snippets
 
-After executing a query, you can also generate a code snippet that performs the same task through one of the available Weaviate Agents client libraries, either Python or TypeScript.
+After executing a query, you can also generate a code snippet that performs the same task through one of the available Query Agent client libraries, either Python or TypeScript.
 
 <div
   style={{
@@ -135,7 +135,7 @@ The WCD Query Agent does not support multi-tenancy. In order to utilize multi-te
 
 ## Further resources
 
-- [Weaviate Agents: Query Agent](/docs/agents/index.md)
+- [Query Agent](/docs/agents/index.md)
 
 ## Support
 

--- a/docs/contributor-guide/weaviate-docs/development.mdx
+++ b/docs/contributor-guide/weaviate-docs/development.mdx
@@ -59,7 +59,7 @@ Always fix any build errors before submitting changes, as broken builds will pre
 
 <!-- Within /agents section -->
 
-[Weaviate Agents](../index.md)
+[Query Agent](../index.md)
 ```
 
 ### Absolute link paths
@@ -69,7 +69,7 @@ Always fix any build errors before submitting changes, as broken builds will pre
 ```markdown
 <!-- Linking from /weaviate to /agents -->
 
-[Weaviate Agents](/agents/index.md)
+[Query Agent](/agents/index.md)
 
 <!-- Linking from /agents to /weaviate -->
 
@@ -83,7 +83,7 @@ Always fix any build errors before submitting changes, as broken builds will pre
 ```markdown
 <!-- Linking from _includes/ to /agents -->
 
-[Weaviate Agents](/agents/qeuery)
+[Query Agent](/agents/quickstart)
 ```
 
 This convention ensures links work correctly regardless of where the component is imported.

--- a/docs/contributor-guide/weaviate-docs/style-guide.mdx
+++ b/docs/contributor-guide/weaviate-docs/style-guide.mdx
@@ -48,7 +48,7 @@ The documentation is organized into key sections. When contributing, understand 
 
 - **Deployment docs - `/docs/deploy`:** Documentation for deploying and operating Weaviate instances. Covers installation methods including Docker and Kubernetes, configuration options for authentication and performance, production deployment patterns, scaling and high availability setups, cloud provider-specific guides, troubleshooting information, and version migration procedures.
 
-- **Weaviate Agents - `/docs/agents`:** Documentation for Weaviate's agent framework. Includes setup instructions, usage examples, and implementation patterns for building AI agents that can interact with Weaviate databases.
+- **Query Agent - `/docs/agents`:** Documentation for the Query Agent — Weaviate's pre-built agentic search service. Includes setup instructions, mode usage (Ask, Search, Suggest Queries), configuration references, client library guides, and recipes for common patterns.
 
 - **Weaviate Cloud - `/docs/cloud`:** Documentation for Weaviate's managed cloud service. Contains account setup procedures, Weaviate embeddings service documentation, billing and subscription management, service limitations, and cloud-specific configuration options.
 

--- a/docs/weaviate/best-practices/code-generation.md
+++ b/docs/weaviate/best-practices/code-generation.md
@@ -98,11 +98,11 @@ Some AI-powered code generation tools such as Cursor allow you to index further 
 
 Review the documentation of your specific IDE to see if it has this feature, and how to use it.
 
-### Consider using Weaviate Agents
+### Consider using the Query Agent
 
-[Weaviate Agents](/agents) are pre-built agentic services designed for searching your data, with AI deciding the search terms, filters, sorts, and other search parameters. The [Query Agent](/agents/guides/index.md) is purpose-built for this usecase.
+The [Query Agent](/agents) is a pre-built agentic search service that decides the search terms, filters, sorts, and other search parameters for you — the [modes overview](/agents/guides/index.md) covers what it can do.
 
-Weaviate agents are available for Weaviate Cloud users to enable interacting with the Weaviate Cloud instance using natural language. For some use cases, this may be a better approach than using AI-powered code generation tools.
+The Query Agent is available to Weaviate Cloud users for interacting with their Weaviate Cloud instance in natural language. For some use cases, this may be a better approach than using AI-powered code generation tools.
 
 ## Help us improve this page
 

--- a/docs/weaviate/client-libraries/python/index.mdx
+++ b/docs/weaviate/client-libraries/python/index.mdx
@@ -78,9 +78,9 @@ ports:
 
 </details>
 
-#### Weaviate Agents
+#### Query Agent
 
-You can install the Weaviate client library with the optional agents extras to use [Weaviate Agents](../../../agents/index.md). Install the client library using the following command:
+You can install the Weaviate client library with the optional `agents` extras to use the [Query Agent](../../../agents/index.md). Install the client library using the following command:
 
 ```bash
 pip install -U "weaviate-client[agents]"

--- a/docs/weaviate/config-refs/collections.mdx
+++ b/docs/weaviate/config-refs/collections.mdx
@@ -162,7 +162,7 @@ import InitialCaps from "/_includes/schemas/initial-capitalization.md";
 
 #### `description`
 
-A description of the collection. This is for your reference and can also provide additional information to [Weaviate Agents](/docs/agents/index.md).
+A description of the collection. This is for your reference and can also provide additional information to the [Query Agent](/docs/agents/index.md).
 
 ---
 

--- a/docs/weaviate/index.mdx
+++ b/docs/weaviate/index.mdx
@@ -125,7 +125,7 @@ As shown in the high-level overview above, the ecosystem consists of:
 
 - **[Weaviate Database](#what-is-weaviate)**: An open source vector database that stores both objects and vectors.
 - **[Weaviate Cloud](/cloud)**: A fully managed cloud deployment of the Weaviate vector database.
-- **[Weaviate Agents](/agents)**: Pre-built agentic services for Weaviate Cloud users.
+- **[Query Agent](/agents)**: A pre-built agentic search service for Weaviate Cloud users.
 - **[Weaviate Embeddings](/cloud/embeddings)**: A managed embedding inference service for Weaviate Cloud users.
 - **[External model providers](/weaviate/model-providers)**: Third-party models that integrate with Weaviate.
 

--- a/docs/weaviate/quickstart/local.md
+++ b/docs/weaviate/quickstart/local.md
@@ -194,7 +194,7 @@ import QueryNearVectorImportVectors from "/_includes/code/quickstart/quickstart.
 
 </details>
 
-:::tip Weaviate Agents
+:::tip Query Agent
 
 Try the [Query Agent](/agents/index.md) with a Weaviate Cloud instance. You simply provide a prompt/question in natural language, and the Query Agent takes care of all the needed steps to provide an answer.
 

--- a/docs/weaviate/search/query-agent.md
+++ b/docs/weaviate/search/query-agent.md
@@ -17,8 +17,8 @@ The Weaviate Query Agent enables users to perform Weaviate searches or ask quest
 
 An agentic LLM will dynamically determine query terms and search strategies based on the natural language query.
 
-:::info First time using Weaviate Agents?
-Weaviate Agents are only available for Weaviate Cloud instances. See the [full setup guide](../../agents/installation.md) for setup and instantiation details.
+:::info First time using the Query Agent?
+The Query Agent is only available for Weaviate Cloud instances. See the [full setup guide](../../agents/installation.md) for setup and instantiation details.
 :::
 
 First, you must define the Query Agent class, setup with a client pointing towards your Weaviate cloud cluster.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1147,3 +1147,62 @@ status = 301
 from = "/weaviate/client-libraries/java/java-v5"
 to   = "/weaviate/client-libraries/java"
 status = 301
+
+# Agents rework (PR #410): Personalization and Transformation Agents removed,
+# Query Agent restructured into /agents with guides/reference/recipes/clients.
+# Specific paths first; splats below catch anything else under the removed roots.
+
+[[redirects]]
+from = "/agents/query"
+to   = "/agents"
+status = 301
+
+[[redirects]]
+from = "/agents/query/usage"
+to   = "/agents/guides/ask_mode"
+status = 301
+
+[[redirects]]
+from = "/agents/query/tutorial-ecommerce"
+to   = "/agents/recipes/query-agent-ecommerce-assistant"
+status = 301
+
+[[redirects]]
+from = "/agents/recipes/personalization-agent-get-started-movies"
+to   = "/agents/recipes"
+status = 301
+
+[[redirects]]
+from = "/agents/recipes/personalization-agent-get-started-recipes"
+to   = "/agents/recipes"
+status = 301
+
+[[redirects]]
+from = "/agents/recipes/transformation-agent-get-started"
+to   = "/agents/recipes"
+status = 301
+
+[[redirects]]
+from = "/agents/recipes/transformation-agent-retrieval-benchmark"
+to   = "/agents/recipes"
+status = 301
+
+[[redirects]]
+from = "/agents/personalization"
+to   = "/agents"
+status = 301
+
+[[redirects]]
+from = "/agents/personalization/*"
+to   = "/agents"
+status = 301
+
+[[redirects]]
+from = "/agents/transformation"
+to   = "/agents"
+status = 301
+
+[[redirects]]
+from = "/agents/transformation/*"
+to   = "/agents"
+status = 301

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "remark-math": "^6.0.0",
     "sass": "^1.83.4",
     "uuid": "^13.0.0",
-    "weaviate-agents": "^1.0.0",
+    "weaviate-agents": "^1.4.1",
     "weaviate-client": "^3.12.1"
   },
   "devDependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "python-dotenv>=1.1.1",
     "requests>=2.32.3",
     "tqdm>=4.67.1",
-    "weaviate-agents>=1.1.0",
+    "weaviate-agents>=1.5.0",
     "weaviate-client==4.21.0",
     "weaviate-demo-datasets>=0.7.0",
 ]

--- a/secondaryNavbar.js
+++ b/secondaryNavbar.js
@@ -75,9 +75,9 @@ const secondaryNavbarItems = {
   },
 
   agents: {
-    title: "Weaviate Agents",
+    title: "Query Agent",
     icon: "fa fa-robot",
-    description: "Build and deploy intelligent agents with Weaviate",
+    description: "Run agentic search over your Weaviate Cloud collections",
     link: "/agents",
     links: [
       { label: "Documentation", link: "/agents", sidebar: "agentsSidebar" }

--- a/sidebars.js
+++ b/sidebars.js
@@ -1398,10 +1398,9 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Recipes",
-      className: "sidebar-main-category",
-      collapsible: false,
-      collapsed: false,
+      label: "Tutorials and guides",
+      className: "sidebar-item",
+      collapsed: true,
       link: {
         type: "doc",
         id: "agents/recipes/index",
@@ -1437,10 +1436,10 @@ const sidebars = {
         },
       ],
     },
-    {
-      type: "html",
-      value: "<hr class='sidebar-divider' />",
-    },
+    // {
+    //   type: "html",
+    //   value: "<hr class='sidebar-divider' />",
+    // },
     {
       type: "doc",
       id: "agents/reference/troubleshooting",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -8,15 +8,17 @@ from pathlib import Path
 @pytest.mark.parametrize(
     "script_loc",
     [
-        # "./docs/agents/_includes/code/ask_mode.py",
         "./docs/agents/_includes/code/additional_filters.py",
-        # "./docs/agents/_includes/code/advanced_collections.py",
-        # "./docs/agents/_includes/code/conversations.py",
-        # "./docs/agents/_includes/code/instantiation.py",
-        # "./docs/agents/_includes/code/introduction.py",
-        # "./docs/agents/_includes/code/quickstart.py",
+        "./docs/agents/_includes/code/advanced_collections.py",
+        "./docs/agents/_includes/code/ask_mode.py",
+        "./docs/agents/_includes/code/conversations.py",
+        "./docs/agents/_includes/code/instantiation.py",
+        "./docs/agents/_includes/code/introduction.py",
+        "./docs/agents/_includes/code/query_agent.py",
+        "./docs/agents/_includes/code/quickstart.py",
         "./docs/agents/_includes/code/search_mode.py",
-        # "./docs/agents/_includes/code/system_prompt.py"
+        "./docs/agents/_includes/code/suggest_queries.py",
+        "./docs/agents/_includes/code/system_prompt.py",
     ],
 )
 def test_on_blank_instance_pyv4(script_loc):
@@ -29,15 +31,17 @@ def test_on_blank_instance_pyv4(script_loc):
 @pytest.mark.parametrize(
     "script_loc",
     [
+        "./docs/agents/_includes/code/additional_filters.mts",
+        "./docs/agents/_includes/code/advanced_collections.mts",
         "./docs/agents/_includes/code/ask_mode.mts",
-        # "./docs/agents/_includes/code/additional_filters.mts",
-        # "./docs/agents/_includes/code/advanced_collections.mts",
         "./docs/agents/_includes/code/conversations.mts",
-        # "./docs/agents/_includes/code/instantiation.mts",
-        # "./docs/agents/_includes/code/introduction.mts",
-        # "./docs/agents/_includes/code/quickstart.mts",
-        # "./docs/agents/_includes/code/search_mode.mts",
-        # "./docs/agents/_includes/code/system_prompt.mts"
+        "./docs/agents/_includes/code/instantiation.mts",
+        "./docs/agents/_includes/code/introduction.mts",
+        "./docs/agents/_includes/code/query_agent.mts",
+        "./docs/agents/_includes/code/quickstart.mts",
+        "./docs/agents/_includes/code/search_mode.mts",
+        "./docs/agents/_includes/code/suggest_queries.mts",
+        "./docs/agents/_includes/code/system_prompt.mts",
     ],
 )
 def test_ts(script_loc):

--- a/uv.lock
+++ b/uv.lock
@@ -2040,16 +2040,16 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "1.1.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx-sse" },
     { name = "rich" },
     { name = "weaviate-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ee/d6bdfb66593cd9fcf7efe9c2278539c3d8aa2bc9bee5f6bdf80673196751/weaviate_agents-1.1.0.tar.gz", hash = "sha256:09a09a4e0d1a5039034a54212b7edd87b8b1d2adc8541d59e6d59a63f2aa4a2a", size = 106707, upload-time = "2025-10-14T10:02:39.956Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/1c/cad26eea91555060b2c88ab9b9af9deca41243c67813bb550f86d8d06eb5/weaviate_agents-1.5.0.tar.gz", hash = "sha256:fb61aae5b6658b9e16e72b07699eecd255c16bdacb39824c74520a1a20672669", size = 105783, upload-time = "2026-05-05T12:06:41.059Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/bd/b43e20642d7b432604e614ee503c5fc9017abc7ca1a4d4cd64ab23738d76/weaviate_agents-1.1.0-py3-none-any.whl", hash = "sha256:1184a04ca3119c4a23ab11a1cd512eae8bf23c46db4f32765d8b16a5b8f28aac", size = 44817, upload-time = "2025-10-14T10:02:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a2/d6a55f3748e8b97bac2d7b641a2456684292f9431129c035b90d575f20ce/weaviate_agents-1.5.0-py3-none-any.whl", hash = "sha256:8c2bbaa9fb02aa548821d465591bf1b4cfc426bc632b35c915d583fa90b1e820", size = 47864, upload-time = "2026-05-05T12:06:39.816Z" },
 ]
 
 [[package]]
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "weaviate-agents", specifier = ">=1.1.0" },
+    { name = "weaviate-agents", specifier = ">=1.5.0" },
     { name = "weaviate-client", specifier = "==4.21.0" },
     { name = "weaviate-demo-datasets", specifier = ">=0.7.0" },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,6 +1651,11 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@datastructures-js/deque@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@datastructures-js/deque/-/deque-1.0.8.tgz#7ef2b655821ea24b1677ff01895a8fdb8a26d3c7"
+  integrity sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==
+
 "@dependents/detective-less@^4.1.0":
   version "4.1.0"
   resolved "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-4.1.0.tgz"
@@ -2633,22 +2638,22 @@
   resolved "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@grpc/grpc-js@^1.13.1":
-  version "1.13.4"
-  resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz"
-  integrity sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==
+"@grpc/grpc-js@^1.14.0":
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
   dependencies:
-    "@grpc/proto-loader" "^0.7.13"
+    "@grpc/proto-loader" "^0.8.0"
     "@js-sdsl/ordered-map" "^4.4.2"
 
-"@grpc/proto-loader@^0.7.13":
-  version "0.7.15"
-  resolved "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz"
-  integrity sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==
+"@grpc/proto-loader@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.1.tgz#5a6b290ccbfb1ae2f6775afb74e9898bd8c5d4e8"
+  integrity sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==
   dependencies:
     lodash.camelcase "^4.3.0"
     long "^5.0.0"
-    protobufjs "^7.2.5"
+    protobufjs "^7.5.5"
     yargs "^17.7.2"
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
@@ -3646,33 +3651,32 @@
   resolved "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz"
   integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
 
-"@protobufjs/codegen@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz"
-  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+"@protobufjs/codegen@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.5.tgz#d9315ad7cf3f30aac70bda3c068443dc6f143659"
+  integrity sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==
 
-"@protobufjs/eventemitter@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz"
-  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+"@protobufjs/eventemitter@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz#d512cb26c0ae026091ee2c1167f1be6faf5c842a"
+  integrity sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==
 
-"@protobufjs/fetch@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz"
-  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+"@protobufjs/fetch@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.1.tgz#4d6fc00c8fb64016a5c81b469d549046350f1065"
+  integrity sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
-    "@protobufjs/inquire" "^1.1.0"
 
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
-"@protobufjs/inquire@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz"
-  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+"@protobufjs/inquire@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
+  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
@@ -3684,10 +3688,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz"
   integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
-"@protobufjs/utf8@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
-  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+"@protobufjs/utf8@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
+  integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
 "@rollup/pluginutils@^5.1.3":
   version "5.1.4"
@@ -4778,10 +4782,10 @@ abbrev@1:
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-abort-controller-x@^0.4.0, abort-controller-x@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz"
-  integrity sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==
+abort-controller-x@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/abort-controller-x/-/abort-controller-x-0.5.0.tgz#2c0531a83c7717eccd47435bfe123bccfd34e2b8"
+  integrity sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -8552,10 +8556,10 @@ graphql-request@^6.1.0:
     "@graphql-typed-document-node/core" "^3.2.0"
     cross-fetch "^3.1.5"
 
-graphql@^16.11.0:
-  version "16.11.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz"
-  integrity sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==
+graphql@^16.12.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.0.tgz#f1128a74b16a34d1245c8436bb07b488d87b83e1"
+  integrity sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==
 
 gray-matter@^4.0.3:
   version "4.0.3"
@@ -11609,13 +11613,13 @@ netlify@13.3.3, netlify@^13.3.3:
     p-wait-for "^5.0.0"
     qs "^6.9.6"
 
-nice-grpc-client-middleware-retry@^3.1.11:
-  version "3.1.11"
-  resolved "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.11.tgz"
-  integrity sha512-xW/imz/kNG2g0DwTfH2eYEGrg1chSLrXtvGp9fg2qkhTgGFfAS/Pq3+t+9G8KThcC4hK/xlEyKvZWKk++33S6A==
+nice-grpc-client-middleware-retry@^3.1.13:
+  version "3.1.15"
+  resolved "https://registry.yarnpkg.com/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.15.tgz#dc3ca5ca1664d9527bdafb8484f4fb3cf5dcf196"
+  integrity sha512-fXfNNdtjCQzc3O/w3WsK1AOU+xdE1V7FCm4FEQWS/UUVsV1616S2oryvWqsZAF8aOvuMir8lFtNmgH3DeP+PBg==
   dependencies:
-    abort-controller-x "^0.4.0"
-    nice-grpc-common "^2.0.2"
+    abort-controller-x "^0.5.0"
+    nice-grpc-common "^2.0.3"
 
 nice-grpc-common@^2.0.2:
   version "2.0.2"
@@ -11624,14 +11628,21 @@ nice-grpc-common@^2.0.2:
   dependencies:
     ts-error "^1.0.6"
 
-nice-grpc@^2.1.12:
-  version "2.1.12"
-  resolved "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.12.tgz"
-  integrity sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw==
+nice-grpc-common@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz#f55b2cb438f4882b8603d0d9fad44d3bae6f86a8"
+  integrity sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==
   dependencies:
-    "@grpc/grpc-js" "^1.13.1"
-    abort-controller-x "^0.4.0"
-    nice-grpc-common "^2.0.2"
+    ts-error "^1.0.6"
+
+nice-grpc@^2.1.14:
+  version "2.1.16"
+  resolved "https://registry.yarnpkg.com/nice-grpc/-/nice-grpc-2.1.16.tgz#10f335eeb8c9c5aca85cc04e618a9e86c9d6b4fa"
+  integrity sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==
+  dependencies:
+    "@grpc/grpc-js" "^1.14.0"
+    abort-controller-x "^0.5.0"
+    nice-grpc-common "^2.0.3"
 
 no-case@^3.0.4:
   version "3.0.4"
@@ -13170,23 +13181,23 @@ proto-list@~1.2.1:
   resolved "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
-protobufjs@^7.2.5:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+protobufjs@^7.5.5:
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.1.tgz#6320bb08c3be7dcfc6f9193ee03d3a4643f1eb37"
+  integrity sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/codegen" "^2.0.5"
+    "@protobufjs/eventemitter" "^1.1.1"
+    "@protobufjs/fetch" "^1.1.1"
     "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/inquire" "^1.1.2"
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.1"
     "@types/node" ">=13.7.0"
-    long "^5.0.0"
+    long "^5.3.2"
 
 proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
@@ -15554,6 +15565,11 @@ uuid@^13.0.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz"
   integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
 
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
@@ -15684,24 +15700,25 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-weaviate-agents@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/weaviate-agents/-/weaviate-agents-1.0.0.tgz"
-  integrity sha512-nBjZtJMA4iJw3W950Lx9Zmb37Rp1Quam5BjWitIAtFG90/pL4Hylo7qHYRIu4f4DOXEonBIYbDIwa89VumJfdg==
+weaviate-agents@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/weaviate-agents/-/weaviate-agents-1.4.1.tgz#9b813fc9da987bf99f6d812f5110cf3acb01efe0"
+  integrity sha512-YqNKp63VTdWLnQQl7JGAH0sFBp36j4TgYASK2aka0NrBAtnzwbdEh5Zg+Br/PSVgDplSleYkotE0vq0g012mBw==
 
-weaviate-client@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.9.0.tgz"
-  integrity sha512-7qwg7YONAaT4zWnohLrFdzky+rZegVe76J+Tky/+7tuyvjFpdKgSrdqI/wPDh8aji0ZGZrL4DdGwGfFnZ+uV4w==
+weaviate-client@^3.12.1:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/weaviate-client/-/weaviate-client-3.13.0.tgz#1422f63bdc1e652a2eec691e8ba6cdf3c5920555"
+  integrity sha512-0tB8UbsKoAs6Ax/w0kkGIUtozu5STLlR1FOeLRENQwb4/B8mXqA9UENJfxDA+G98Mz4Otn3gEdHelru9O+MwnQ==
   dependencies:
-    abort-controller-x "^0.4.3"
-    graphql "^16.11.0"
+    "@datastructures-js/deque" "^1.0.8"
+    abort-controller-x "^0.5.0"
+    graphql "^16.12.0"
     graphql-request "^6.1.0"
     long "^5.3.2"
-    nice-grpc "^2.1.12"
-    nice-grpc-client-middleware-retry "^3.1.11"
+    nice-grpc "^2.1.14"
+    nice-grpc-client-middleware-retry "^3.1.13"
     nice-grpc-common "^2.0.2"
-    uuid "^9.0.1"
+    uuid "^14.0.0"
 
 web-namespaces@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary

Full rework of `docs/agents/` to focus on the Query Agent — Personalization and Transformation Agents are removed, the remaining content is reorganized into a clear *Modes / Configuration / Clients / Recipes* layout, and the product is consistently called the **Query Agent** throughout the docs. All 22 agent snippets (Python + TypeScript) run green in `tests/test_agents.py` against `weaviate-agents` Python `1.5.0` / TypeScript `1.4.1`.

Supersedes #410 with all review feedback applied.

## What changed

### Structure (`docs/agents/`)

- Removed `docs/agents/personalization/`, `docs/agents/transformation/`, and `docs/agents/query/` entirely.
- New layout:
  - `index.md`, `installation.md`, `quickstart.md` at the top level.
  - `clients/{index, python, typescript}` — install + import patterns for both client libraries.
  - `guides/{index, ask_mode, search_mode, suggest_queries}` (`research_mode.md` exists but is intentionally de-listed in the sidebar).
  - `reference/{index, instantiation, system_prompt, multi_turn_conversations, additional_filters, advanced_collections, troubleshooting}`.
  - `recipes/` — five Query-Agent recipes: `query-agent-get-started`, `query-agent-ecommerce-assistant`, `query-agent-streamlit-chat`, `query-agent-vs-diy`, `query-agent-as-a-tool`. (Old `personalization-agent-*` and `transformation-agent-*` recipes removed.)
- Every page now opens with a short purpose sentence before the first subheading.
- Stale `<!-- author TODO -->` comments scrubbed; `Client client` / `TypesScript` typos fixed.

### Naming — \"Weaviate Agents\" → \"Query Agent\"

Now that the family is a single product, the docs use \"Query Agent\" consistently. Updated in: the `docs/agents/` pages, `secondaryNavbar.js` section title + description, `docs/weaviate/index.mdx` ecosystem bullet, `docs/cloud/faq.mdx`, `docs/cloud/tools/query-agent.mdx`, `docs/weaviate/client-libraries/python/index.mdx`, `docs/weaviate/search/query-agent.md`, `docs/weaviate/quickstart/local.md`, `docs/weaviate/config-refs/collections.mdx`, `docs/weaviate/best-practices/code-generation.md`, and the contributor-guide style/development examples (also fixed the `qeuery` typo and a broken `/agents/qeuery` example link).

Package names (`weaviate-agents` on npm/PyPI), module paths (`weaviate.agents.query`), external URLs (`weaviateagents.featurebase.app`), and tag taxonomy (`'agents'`) are deliberately preserved.

### Redirects (`netlify.toml`)

11 redirects added so existing bookmarks and search-engine results don't 404:

| Old | New |
|---|---|
| `/agents/query` | `/agents` |
| `/agents/query/usage` | `/agents/guides/ask_mode` |
| `/agents/query/tutorial-ecommerce` | `/agents/recipes/query-agent-ecommerce-assistant` |
| `/agents/recipes/personalization-agent-get-started-{movies,recipes}` | `/agents/recipes` |
| `/agents/recipes/transformation-agent-{get-started,retrieval-benchmark}` | `/agents/recipes` |
| `/agents/personalization` + `/agents/personalization/*` | `/agents` |
| `/agents/transformation` + `/agents/transformation/*` | `/agents` |

Specific paths come before the splat patterns so Netlify matches them first.

### Tests (`tests/test_agents.py`)

- Every snippet under `docs/agents/_includes/code/` is now explicitly listed (no globbing): 11 Python + 11 TypeScript files, 22 tests in total. `util.{py,mts}` stays out as it's the shared helper imported by the others.
- Bumped `weaviate-agents` to Python `>=1.5.0` (`pyproject.toml`) and TypeScript `^1.4.1` (`package.json`), with `uv.lock` and `yarn.lock` regenerated.
- Snippet bugs fixed while wiring this up:
  - `suggest_queries.py` — missing `QueryAgentCollectionConfig` import in the async block.
  - `query_agent.py` / `query_agent.mts` / `search_mode.mts` — diversity-ranking `qa.search(..., diversity_weight=...)` calls now scope to a single collection with a target vector so the agent can resolve a vectorizer.
  - `query_agent.py` — the `UsageAsyncQueryAgent` block referenced an undefined `headers` variable and passed a bare string to `auth_credentials`; now defines `headers = {...}` and uses `Auth.api_key(...)`.
  - `query_agent.{py,mts}` — `SuggestQueries` snippet pointed at a non-existent `IRPAPERS` collection; replaced with `FinancialContracts`.
- Local verified run: **22 / 22 passed in ~10 minutes** against the test WCD cluster.

### Other small cleanups

- `tests/README-INDEXABILITY.md` — updated the deleted `/agents/query/tutorial-ecommerce` URL to the new recipe path.

## Test plan

- [ ] CI `Test Agents` job is green against the new pins (Python `1.5.0`, TypeScript `1.4.1`).
- [ ] `yarn start` — verify the new agents structure renders, redirects fire locally, no missing-image / broken-link warnings on the touched pages.
- [ ] Spot-check redirect targets: `/agents/personalization` → `/agents`, `/agents/query/usage` → `/agents/guides/ask_mode`, `/agents/query/tutorial-ecommerce` → `/agents/recipes/query-agent-ecommerce-assistant`.