### PR TITLE
Move Weaviate MCP server docs to Configuration + FAQ JSON-LD

### DIFF
--- a/docs/weaviate/best-practices/code-generation.md
+++ b/docs/weaviate/best-practices/code-generation.md
@@ -18,7 +18,7 @@ Here are some tips for writing Weaviate client library code with generative AI m
 
 Weaviate provides two [MCP](https://modelcontextprotocol.io/) servers that integrate with AI development tools like Claude Code, Claude Desktop, Cursor, and VS Code:
 
-- **[Weaviate MCP Server](../mcp/mcp-server.mdx)** — Built into Weaviate itself. Lets AI assistants inspect schemas, search data, and modify objects in your Weaviate instance directly. Enable with `MCP_SERVER_ENABLED=true`.
+- **[Weaviate MCP Server](../configuration/mcp-server.mdx)** — Built into Weaviate itself. Lets AI assistants inspect schemas, search data, and modify objects in your Weaviate instance directly. Enable with `MCP_SERVER_ENABLED=true`.
 - **[Weaviate Docs MCP Server](../mcp/docs-mcp-server.mdx)** — A standalone server that gives AI assistants access to Weaviate's documentation, reducing hallucinations when generating Weaviate code.
 
 ### Weaviate Agent Skills

--- a/docs/weaviate/configuration/authz-authn.md
+++ b/docs/weaviate/configuration/authz-authn.md
@@ -113,6 +113,7 @@ With [undifferentiated access](../../deploy/configuration/authorization.md#undif
 - [Configuration: OIDC](/deploy/configuration/oidc.md)
 - [Configuration: RBAC](/weaviate/configuration/rbac/index.mdx)
 - [Configuration: Environment variables - Authentication and Authorization](/deploy/configuration/env-vars/index.md#authentication-and-authorization)
+- [Weaviate MCP server](/weaviate/configuration/mcp-server.mdx) — authenticates via API key and respects RBAC permissions.
 
 ## Questions and feedback
 

--- a/docs/weaviate/configuration/index.mdx
+++ b/docs/weaviate/configuration/index.mdx
@@ -39,6 +39,13 @@ export const configOpsData = [
     link: "/weaviate/configuration/modules",
     icon: "fas fa-puzzle-piece",
   },
+  {
+    title: "MCP server",
+    description:
+      "Enable the built-in Model Context Protocol server so LLMs and IDE assistants can interact with your Weaviate instance.",
+    link: "/weaviate/configuration/mcp-server",
+    icon: "fas fa-robot",
+  },
 ];
 
 <br />

--- a/docs/weaviate/configuration/mcp-server.mdx
+++ b/docs/weaviate/configuration/mcp-server.mdx
@@ -1,6 +1,21 @@
 ---
 title: Weaviate MCP server
-# tags: ["mcp"]
+description: Enable and configure the Weaviate Model Context Protocol (MCP) server so LLMs and IDE assistants like Claude Desktop, Claude Code, Cursor, and VS Code can inspect schemas, run vector and hybrid searches, and modify objects in your Weaviate instance over HTTP.
+image: og/docs/configuration.jpg
+faq:
+  - question: Does Weaviate offer an MCP server?
+    answer: >-
+      Yes. Weaviate ships a built-in Model Context Protocol (MCP) server (preview, available from v1.37.1). Enable it with the MCP_SERVER_ENABLED=true environment variable; it runs on the same port as the REST API at /v1/mcp.
+  - question: Is the MCP server an external library?
+    answer: >-
+      No — it's built into the Weaviate Server binary, not a separate package you install. Setting MCP_SERVER_ENABLED=true exposes the MCP endpoint on the same port as the REST API; nothing extra to run or deploy. The separate "Weaviate Docs MCP server" (Kapa-powered, serves documentation to LLMs) is a distinct product.
+  - question: Which tools does the Weaviate MCP server expose?
+    answer: >-
+      Four tools, gated by RBAC permissions — weaviate-collections-get-config (inspect collection schemas), weaviate-tenants-list (list tenants in a multi-tenant collection), weaviate-query-hybrid (run hybrid vector + keyword searches), and weaviate-objects-upsert (create or update objects, requires write access).
+  - question: How do I request a new MCP tool or feature?
+    answer: >-
+      Open a feature request on the Weaviate GitHub repo at https://github.com/weaviate/weaviate/issues/new/choose. Pick the "Feature request" template and describe the tool, parameter, or capability you'd like the MCP server to expose, with a concrete use case.
+# tags: ["mcp", "configuration"]
 ---
 
 import Tabs from "@theme/Tabs";
@@ -140,10 +155,10 @@ The MCP server is built into Weaviate but is **disabled by default** for securit
 
 To enable and configure the server, set the following [environment variables](/docs/deploy/configuration/env-vars/index.md) in your Weaviate configuration (e.g., `docker-compose.yml`):
 
-| Environment Variable                                                                                | Default | Description                                                                                                                                                                                                    |
-| --------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`MCP_SERVER_ENABLED`](/deploy/configuration/env-vars#MCP_SERVER_ENABLED)                           | `false` | **Required.** Set to `true` to start the MCP server.                                                                                                                                                           |
-| [`MCP_SERVER_WRITE_ACCESS_ENABLED`](/deploy/configuration/env-vars#MCP_SERVER_WRITE_ACCESS_ENABLED) | `false` | When `true`, enables write tools (`weaviate-objects-upsert`). Default is read-only.                                                                                                                            |
+| Environment Variable                                                                                | Default | Description                                                                                                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`MCP_SERVER_ENABLED`](/deploy/configuration/env-vars#MCP_SERVER_ENABLED)                           | `false` | **Required.** Set to `true` to start the MCP server.                                                                                                                                                                                                                                                        |
+| [`MCP_SERVER_WRITE_ACCESS_ENABLED`](/deploy/configuration/env-vars#MCP_SERVER_WRITE_ACCESS_ENABLED) | `false` | When `true`, enables write tools (`weaviate-objects-upsert`). Default is read-only.                                                                                                                                                                                                                         |
 | [`MCP_SERVER_CONFIG_PATH`](/deploy/configuration/env-vars#MCP_SERVER_CONFIG_PATH)                   | `""`    | Path to a YAML file for customizing tool descriptions (useful for prompt engineering the LLM's understanding of your specific data). If not provided or file malformed, the default descriptions from the [source code](https://github.com/weaviate/weaviate/tree/main/adapters/handlers/mcp) will be used. |
 
 ### Permissions
@@ -153,12 +168,12 @@ If you use [RBAC](/weaviate/configuration/rbac/index.mdx) with fine-grained perm
 <details>
   <summary>Per-tool permissions</summary>
 
-| Tool                              | MCP permissions required     | Additional collection permissions |
-| --------------------------------- | ---------------------------- | --------------------------------- |
-| `weaviate-collections-get-config` | `read_mcp`                   | `read_collections`                |
-| `weaviate-tenants-list`           | `read_mcp`                   | `read_data`                       |
-| `weaviate-query-hybrid`           | `read_mcp`                   | `read_data`                       |
-| `weaviate-objects-upsert`         | `create_mcp`, `update_mcp`   | `create_data`, `update_data`      |
+| Tool                              | MCP permissions required   | Additional collection permissions |
+| --------------------------------- | -------------------------- | --------------------------------- |
+| `weaviate-collections-get-config` | `read_mcp`                 | `read_collections`                |
+| `weaviate-tenants-list`           | `read_mcp`                 | `read_data`                       |
+| `weaviate-query-hybrid`           | `read_mcp`                 | `read_data`                       |
+| `weaviate-objects-upsert`         | `create_mcp`, `update_mcp` | `create_data`, `update_data`      |
 
 </details>
 
@@ -271,7 +286,7 @@ Batch inserts or updates objects.
 ## Further resources
 
 - [Vibe coding - Best practices](../best-practices/code-generation.md)
-- [Weaviate Docs MCP server](./docs-mcp-server.mdx)
+- [Weaviate Docs MCP server](../mcp/docs-mcp-server.mdx)
 
 ## Questions and feedback
 

--- a/docs/weaviate/configuration/rbac/manage-roles.mdx
+++ b/docs/weaviate/configuration/rbac/manage-roles.mdx
@@ -649,14 +649,14 @@ language="csharp"
 
 #### Create a role with `MCP` permissions {#mcp-permissions}
 
-The [Weaviate MCP server](/weaviate/mcp/mcp-server.mdx) uses three granular permissions:
+The [Weaviate MCP server](/weaviate/configuration/mcp-server.mdx) uses three granular permissions:
 
 | Permission | Tools |
 | :--------- | :---- |
 | `read_mcp` | `weaviate-collections-get-config`, `weaviate-tenants-list`, `weaviate-query-hybrid` |
 | `create_mcp` + `update_mcp` | `weaviate-objects-upsert` |
 
-MCP tools also require standard collection-level permissions (e.g., `read_data` for search, `create_data` + `update_data` for upsert). See the [MCP server permissions](/weaviate/mcp/mcp-server.mdx#permissions) for the full per-tool breakdown.
+MCP tools also require standard collection-level permissions (e.g., `read_data` for search, `create_data` + `update_data` for upsert). See the [MCP server permissions](/weaviate/configuration/mcp-server.mdx#permissions) for the full per-tool breakdown.
 
 ### Grant additional permissions
 

--- a/docs/weaviate/index.mdx
+++ b/docs/weaviate/index.mdx
@@ -71,8 +71,8 @@ Check out our resources on AI-assisted coding (_Vibe coding_) with Weaviate:
 export const vibeCodingCardsData = [
   {
     id: "new",
-    title: "Weaviate Docs MCP Server",
-    description: "Instant access to Weaviate's documentation directly in your AI development environment. ",
+    title: "Weaviate MCP Server",
+    description: "Enable and configure the Weaviate MCP server so LLMs and IDE assistants can interact with your Weaviate instance. ",
     link: "/weaviate/mcp/docs-mcp-server",
     icon: "fas fa-book",
   },

--- a/docs/weaviate/mcp/docs-mcp-server.mdx
+++ b/docs/weaviate/mcp/docs-mcp-server.mdx
@@ -1,10 +1,20 @@
 ---
 title: Weaviate Docs MCP Server
+description: Connect Claude Desktop, Cursor, VS Code, Claude Code, and ChatGPT Desktop to the Weaviate Docs MCP server (powered by Kapa.ai) to query Weaviate's documentation directly from your AI assistant or IDE.
+image: og/docs/configuration.jpg
 # tags: ["mcp"]
 ---
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+
+:::info Looking for the Weaviate MCP server?
+
+This page is about the **Weaviate _Docs_ MCP server** — a hosted server (powered by Kapa.ai) that lets AI assistants query Weaviate's **documentation**.
+
+If you instead want an MCP server that lets AI assistants interact with **your own Weaviate instance** (inspect schemas, run hybrid searches, upsert objects), see the built-in [Weaviate MCP server](../configuration/mcp-server.mdx).
+
+:::
 
 The **Weaviate Docs MCP Server** brings instant access to Weaviate's documentation directly into your AI development environment. Built on the Model Context Protocol (MCP), this server integrates seamlessly with tools like Claude Desktop and Cursor, allowing you to query Weaviate's documentation without leaving your IDE.
 

--- a/docs/weaviate/more-resources/faq.md
+++ b/docs/weaviate/more-resources/faq.md
@@ -654,7 +654,7 @@ If you need resources from the previous version of Weaviate Academy, check out t
 
 > Yes, Weaviate provides two MCP (Model Context Protocol) servers:
 >
-> - **[Weaviate MCP server](/weaviate/mcp/mcp-server.mdx)** — Built into Weaviate itself. Exposes tools for inspecting schemas, searching data (vector/hybrid), and modifying objects. Runs on the same port as the REST API at `/v1/mcp`. Disabled by default — enable with `MCP_SERVER_ENABLED=true`.
+> - **[Weaviate MCP server](/weaviate/configuration/mcp-server.mdx)** — Built into Weaviate itself. Exposes tools for inspecting schemas, searching data (vector/hybrid), and modifying objects. Runs on the same port as the REST API at `/v1/mcp`. Disabled by default — enable with `MCP_SERVER_ENABLED=true`.
 > - **[Weaviate Docs MCP server](/weaviate/mcp/docs-mcp-server.mdx)** — A standalone server that gives LLMs access to Weaviate's documentation. Useful for AI-assisted development with Weaviate.
 >
 > Both servers use the Streamable HTTP transport and work with MCP clients like Claude Code, Claude Desktop, Cursor, and VS Code.

--- a/netlify.toml
+++ b/netlify.toml
@@ -193,6 +193,13 @@ from = "/weaviate/roadmap*"
 to   = "/weaviate/release-notes"
 status = 301
 
+## MCP server moved from /weaviate/mcp/mcp-server to /weaviate/configuration/mcp-server
+
+[[redirects]]
+from = "/weaviate/mcp/mcp-server"
+to   = "/weaviate/configuration/mcp-server"
+status = 301
+
 ## Deployment redirects
 
 [[redirects]]

--- a/sidebars.js
+++ b/sidebars.js
@@ -103,7 +103,14 @@ const sidebars = {
         type: "doc",
         id: "weaviate/best-practices/code-generation",
       },
-      items: ["weaviate/mcp/mcp-server","weaviate/mcp/docs-mcp-server"],
+      items: [
+        {
+          type: "ref",
+          id: "weaviate/configuration/mcp-server",
+          label: "Weaviate MCP Server",
+        },
+        "weaviate/mcp/docs-mcp-server",
+      ],
     },
     {
       type: "html",
@@ -518,6 +525,11 @@ const sidebars = {
         },
         "weaviate/configuration/hnsw-snapshots",
         "weaviate/configuration/modules",
+        {
+          type: "doc",
+          id: "weaviate/configuration/mcp-server",
+          label: "MCP Server",
+        },
         {
           type: "html",
           value: "<hr class='sidebar-divider' />",

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import clsx from "clsx";
+import Head from "@docusaurus/Head";
 import { useWindowSize } from "@docusaurus/theme-common";
 import { useDoc } from "@docusaurus/plugin-content-docs/client";
 import DocItemPaginator from "@theme/DocItem/Paginator";
@@ -18,6 +19,33 @@ import FeedbackComponent from "@site/src/components/Feedback";
 import PageRatingWidget from "@site/src/components/PageRatingWidget";
 import ContextualMenu from "@site/src/components/ContextualMenu";
 /* ---- END: Customizations ---- */
+
+// Emit a schema.org FAQPage JSON-LD block when the page's frontmatter declares
+// a `faq:` list. Google reads this for entity understanding; rich-result FAQ
+// snippets themselves are restricted post-2024 so don't expect a SERP card.
+function FaqJsonLd({ faq }) {
+  if (!Array.isArray(faq) || faq.length === 0) return null;
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faq
+      .filter((item) => item && item.question && item.answer)
+      .map((item) => ({
+        "@type": "Question",
+        name: item.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: item.answer,
+        },
+      })),
+  };
+  if (data.mainEntity.length === 0) return null;
+  return (
+    <Head>
+      <script type="application/ld+json">{JSON.stringify(data)}</script>
+    </Head>
+  );
+}
 
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
@@ -55,6 +83,7 @@ export default function DocItemLayout({ children }) {
 
   return (
     <>
+      <FaqJsonLd faq={frontMatter.faq} />
       <div className="row">
         <div className={clsx("col", !docTOC.hidden && styles.docItemCol)}>
           <ContentVisibility metadata={metadata} />


### PR DESCRIPTION
## Summary

Restructure the Weaviate MCP server page so it lives in a topic-appropriate location (improves discoverability and SEO), give both MCP pages proper frontmatter for search snippets, and add a small swizzle that emits schema.org FAQPage JSON-LD from a new \`faq:\` frontmatter field.

Motivation: the built-in MCP server page wasn't appearing in Google results for queries like "weaviate mcp server" — it was buried under "AI-assisted (vibe) coding" (topical mismatch), had no \`description\` meta, and only a handful of internal links pointing to it.

## What's changed

### Page moved: \`docs/weaviate/mcp/mcp-server.mdx\` → \`docs/weaviate/configuration/mcp-server.mdx\`

- URL is now \`/weaviate/configuration/mcp-server\` (canonical location alongside other server-side config like auth, RBAC, modules).
- 301 redirect added in \`netlify.toml\` for the old URL.
- The page still surfaces under "AI-assisted (vibe) coding" in the sidebar via a \`type: "ref"\` entry — users land on the canonical page (active state + breadcrumbs follow the new location).
- Listed under "How-to: Configure Weaviate" in the sidebar (after Modules) and gets a card on \`configuration/index.mdx\`.

### Frontmatter metadata on both MCP pages

- \`configuration/mcp-server.mdx\` — added \`description\` (mentions Claude Desktop / Code, Cursor, VS Code; schemas, hybrid search, object modification over HTTP), \`image: og/docs/configuration.jpg\`.
- \`mcp/docs-mcp-server.mdx\` — added \`description\` (lists all five supported clients + Kapa.ai), \`image: og/docs/configuration.jpg\`.
- Added an \`:::info Looking for the Weaviate MCP server?\` admonition at the top of \`docs-mcp-server.mdx\` to disambiguate the two pages and cross-link to the built-in server.

### FAQ frontmatter → schema.org FAQPage JSON-LD

\`src/theme/DocItem/Layout/index.js\` gains a small \`FaqJsonLd\` component that reads \`frontMatter.faq\` and emits a \`<script type="application/ld+json">\` FAQPage block via \`@docusaurus/Head\`. Pages without \`faq:\` render bit-for-bit identically (verified by diffing the built HTML — only the JSON-LD differs).

\`configuration/mcp-server.mdx\` declares four entries:

1. Does Weaviate offer an MCP server?
2. Is the MCP server an external library?
3. Which tools does the Weaviate MCP server expose?
4. How do I request a new MCP tool or feature?

Google has restricted the FAQPage rich-result snippet (post-2024 it's mostly limited to government/health sites), so the SERP card won't appear, but the JSON-LD is still useful as a semantic relevance signal — Google parses it for entity understanding and topical scoring.

### Internal links

Updated existing references that pointed at the old \`/weaviate/mcp/mcp-server\` URL:
- \`best-practices/code-generation.md\`
- \`configuration/rbac/manage-roles.mdx\` (link + anchor)
- \`more-resources/faq.md\`
- \`index.mdx\`

New high-quality links:
- Card on \`configuration/index.mdx\` (the section landing).
- "Further resources" entry on \`configuration/authz-authn.md\` (MCP authenticates via API key + RBAC).

## Test plan

- [x] \`yarn build\` clean (the one remaining anchor warning — \`hnsw_startup_wait_for_vector_cache\` in \`concepts/storage.md\` — is pre-existing and unrelated).
- [x] HTML diff with and without \`faq:\` frontmatter: only the FAQPage JSON-LD block differs, everything else byte-identical.
- [x] Verified the built HTML at \`build/weaviate/configuration/mcp-server.html\` contains both the FAQPage JSON-LD and Docusaurus's own BreadcrumbList JSON-LD.
- [ ] After deploy: paste the live URL into [Google's Rich Results Test](https://search.google.com/test/rich-results) to confirm parsing.
- [ ] After deploy: submit the new URL via Search Console's URL Inspection tool to accelerate re-indexing.

## Follow-up

Companion PR on the standalone repo: [weaviate/mcp-server-weaviate#15](https://github.com/weaviate/mcp-server-weaviate/pull/15) deprecates the old Go implementation and rewrites its README to point here.