### PR TITLE
Add DigitalOcean to model provider integrations table

### DIFF
--- a/docs/weaviate/model-providers/index.md
+++ b/docs/weaviate/model-providers/index.md
@@ -20,10 +20,11 @@ This enables an enhanced developed experience, such as the ability to:
 | --- | --- | --- | --- |
 | [Anthropic](./anthropic/index.md) | - | [Text](./anthropic/generative.md) | - |
 | [Anyscale](./anyscale/index.md) | - | [Text](./anyscale/generative.md) | - |
-| [AWS](./aws/index.md) | [Text](./aws/embeddings.md) | [Text](./aws/generative.md) |
+| [AWS](./aws/index.md) | [Text](./aws/embeddings.md) | [Text](./aws/generative.md) | - |
 | [Cohere](./cohere/index.md) | [Text](./cohere/embeddings.md), [Multimodal](./cohere/embeddings-multimodal.md) | [Text](./cohere/generative.md) | [Reranker](./cohere/reranker.md) |
 | [Contextual AI](./contextualai/index.md) | - | [Text](./contextualai/generative.md) | [Reranker](./contextualai/reranker.md) |
 | [Databricks](./databricks/index.md) | [Text](./databricks/embeddings.md) | [Text](./databricks/generative.md) | - |
+| [DigitalOcean](./digitalocean/index.md) | [Text](./digitalocean/embeddings.md) | - | - |
 | [FriendliAI](./friendliai/index.md) | - | [Text](./friendliai/generative.md) | - |
 | [Google](./google/index.md) | [Text](./google/embeddings.md), [Multimodal](./google/embeddings-multimodal.md) | [Text](./google/generative.md) | - |
 | [Hugging Face](./huggingface/index.md) | [Text](./huggingface/embeddings.md) | - | - |


### PR DESCRIPTION
DigitalOcean was added as a model provider (PR #431) with full docs and a sidebar entry, but was never listed in the API-based integrations table on the model-providers landing page, so it doesn't appear at `/weaviate/model-providers`.

- Add the DigitalOcean (Text embeddings) row to the API-based table
- Fix the AWS row, which was missing its trailing "Others" column cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)