### PR TITLE
Add RQ to rescore metric description in query profiling docs

### DIFF
--- a/docs/weaviate/search/query-profile.md
+++ b/docs/weaviate/search/query-profile.md
@@ -181,7 +181,7 @@ Each search type contains a `details` dict with string key-value pairs. The avai
 | :----- | :---------- |
 | `vector_search_took` | Time spent in vector index search |
 | `knn_search_layer_N_took` | Per-layer HNSW graph traversal time (N = layer number) |
-| `knn_search_rescore_took` | Time rescoring compressed vectors (PQ/BQ/SQ) |
+| `knn_search_rescore_took` | Time rescoring compressed vectors (PQ/SQ/RQ/BQ) |
 | `hnsw_flat_search` | Whether flat (brute-force) search was used instead of HNSW (`"true"` or `"false"`) |
 
 ### Filter metrics


### PR DESCRIPTION
The `knn_search_rescore_took` metric description listed `PQ/BQ/SQ` but omitted RQ, which also rescores. Updated to `PQ/SQ/RQ/BQ`.