### PR TITLE
docs: replace Sandbox with the Weaviate Cloud Free tier

### DIFF
--- a/_includes/sandbox.expiry.mdx
+++ b/_includes/sandbox.expiry.mdx
@@ -1,5 +1,0 @@
-:::note Sandbox expiration
-
-The sandbox is free for 14 days. After 14 days, the sandbox expires and all data is deleted. <br /><br />To retrieve a copy of your sandbox data before it is deleted, use the [cursor API](/weaviate/manage-objects/read-all-objects).<br /><br />To preserve your data and upgrade to a paid instance, [contact us](mailto:support@weaviate.io) for help.
-
-:::

--- a/docs/cloud/embeddings/index.md
+++ b/docs/cloud/embeddings/index.md
@@ -11,7 +11,7 @@ Weaviate Embeddings is a managed embedding inference service for Weaviate Cloud 
 
 :::info
 Weaviate Embeddings is a paid service and only available for use with Weaviate Cloud instances.  
-You can try it out **for free by using a Sandbox cluster**.
+You can try it out **for free on a free cluster**.
 :::
 
 With Weaviate Embeddings, you can generate embeddings for your data and queries directly from a Weaviate Cloud database instance.
@@ -53,12 +53,12 @@ No additional authentication is specifically needed, and the Weaviate Embeddings
 ## Usage limits
 
 <!-- TODO[g-despot] Don't hardcode these values here if possible -->
-Weaviate Embeddings only imposes usage limits on requests for free Sandbox clusters.
-The rate limit for Sandbox clusters is `2000` requests per cluster per day.
+Weaviate Embeddings only imposes usage limits on requests for free clusters.
+The rate limit for free clusters is `2000` requests per cluster per day.
 
 :::info
 If you use a [batch import](/weaviate/manage-objects/import) to vectorize your data, the maximum size is `200` objects per batch. 
-This means that you can generate up to a maximum of `400 000` embeddings (`2000 (requests) * 200 (objects per request)`) within your free Sandbox cluster.
+This means that you can generate up to a maximum of `400 000` embeddings (`2000 (requests) * 200 (objects per request)`) within your free cluster.
 :::
 
 ## Requirements

--- a/docs/cloud/embeddings/quickstart.mdx
+++ b/docs/cloud/embeddings/quickstart.mdx
@@ -82,17 +82,18 @@ To use Weaviate Embeddings, you will need:
 
 <!-- TODO[g-despot]: Update prerequisites with correct client versions -->
 
-- A Weaviate Cloud Sandbox running at least Weaviate `1.28.5`
+- A Weaviate Cloud free cluster running at least Weaviate `1.28.5`
 - A Weaviate client library that supports Weaviate Embeddings:
   - **Python** client version `4.9.5` or higher
   - **JavaScript/TypeScript** client version `3.2.5` or higher
-  - **Go/Java** clients are not yet officially supported; you must pass the `X-Weaviate-Api-Key` and `X-Weaviate-Cluster-Url` headers manually upon instantiation as shown below.
+  - **Java** or **C#** clients
+  - **Go** client is not yet officially supported; you must pass the `X-Weaviate-Api-Key` and `X-Weaviate-Cluster-Url` headers manually upon instantiation as shown below.
 
 ## Step 1: Set up Weaviate
 
 ### 1.1 Create a new cluster
 
-To create a free **Sandbox** cluster in Weaviate Cloud, follow **[these instructions](/cloud/manage-clusters/create)**.
+To create a **free cluster** in Weaviate Cloud, follow **[these instructions](/cloud/manage-clusters/create)**.
 
 import LatestWeaviateVersion from "/_includes/latest-weaviate-version.mdx";
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -142,7 +142,7 @@ Yes. The GraphQL query tool in the Weaviate Cloud Console can connect to **exter
 <details>
 <summary> Answer </summary>
 
-Weaviate updated it's Cloud offering on October 27th, 2025. Before that, **Shared Cloud** clusters were called **Serverless** clusters and **Dedicated Cloud** clusters were called **Enterprise** clusters.
+Weaviate updated its Cloud offering on October 27th, 2025. Before that, **Shared Cloud** clusters were called **Serverless** clusters and **Dedicated Cloud** clusters were called **Enterprise** clusters.
 
 </details>
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -14,7 +14,7 @@ Frequently asked questions (FAQs) about [Weaviate Cloud (WCD)](/go/console?utm_c
 <details>
 <summary> Answer </summary>
 
-Using Weaviate Cloud gives you access to a 14-day free sandbox for testing. You also get access to advanced features like [Weaviate Embeddings](/cloud/embeddings/index.md) and the [Query Agent](/query-agent/index.md), which are not available in all deployment methods.
+Using Weaviate Cloud gives you access to a free cluster that is free forever and ideal for testing and small projects. You also get access to advanced features like [Weaviate Embeddings](/cloud/embeddings/index.md) and the [Query Agent](/query-agent/index.md), which are not available in self-hosted deployment methods. For the current free tier limits, see the [pricing page](https://weaviate.io/pricing).
 
 </details>
 
@@ -102,7 +102,7 @@ Possibly. Contact [support@weaviate.io](mailto:support@weaviate.io) to discuss c
 <details>
 <summary> Answer </summary>
 
-By default, each organization can have up to **six (6)** Shared Cloud clusters and **two (2)** sandbox clusters. If you need more, [contact support](mailto:support@weaviate.io).
+Each user can have one (1) free cluster, and by default each organization can have up to **six (6)** Shared Cloud clusters. If you need more, [contact support](mailto:support@weaviate.io).
 
 </details>
 

--- a/docs/cloud/manage-clusters/create.mdx
+++ b/docs/cloud/manage-clusters/create.mdx
@@ -1,18 +1,22 @@
 ---
 title: Create a cluster
 sidebar_position: 2
-description: "Step-by-step guide to create and configure new Sandbox or Shared Cloud clusters."
+description: "Step-by-step guide to create and configure new free or Shared Cloud clusters."
 image: og/wcd/user_guides.jpg
 ---
 
-[Weaviate Cloud (WCD)](/go/console?utm_content=cloud) provides two instance types.
+[Weaviate Cloud (WCD)](/go/console?utm_content=cloud) provides two cluster types.
 
-- **[Sandbox clusters](#sandbox-clusters)**: Sandbox clusters are small, free clusters designed for learning and experimentation. Sandbox clusters are not scalable and expire after 14 days. You will also have an option to extend their lifetime and convert them into a production ready Shared Cloud cluster.
+- **[Free clusters](#free-clusters)**: Free clusters are free forever and need no credit card, which makes them the easiest way to get started. They are perfect for learning, hobby projects, and small workloads, and you can upgrade to a paid plan at any time without losing your data. For the current free tier limits, see the [pricing page](https://weaviate.io/pricing).
 - **[Shared Cloud clusters](#shared-cloud-clusters)**: Shared Cloud clusters are robust, paid clusters designed for production use.
 
 When you log into the Weaviate Cloud web console, the `Clusters` panel lists your clusters. There are no clusters when you log in to a new account.
 
-## Sandbox clusters
+## Free clusters
+
+Free clusters are the easiest way to start building with Weaviate. They are free forever, need no credit card, and are ideal for learning, hobby projects, and small workloads. Each user can create one free cluster, and you can upgrade to a paid plan at any time without losing your data.
+
+The free tier includes a monthly allowance for the database, [Weaviate Embeddings](/cloud/embeddings/index.md), and the [Query Agent](/query-agent/index.md). For the current limits, see the [pricing page](https://weaviate.io/pricing).
 
 <div
   style={{
@@ -43,18 +47,19 @@ When you log into the Weaviate Cloud web console, the `Clusters` panel lists you
 <br />
 
 <details>
-    <summary>Steps to create a Sandbox cluster</summary>
+    <summary>Steps to create a free cluster</summary>
 
-To create a Sandbox cluster, follow these steps:
+To create a free cluster, follow these steps:
 
 1. In the clusters sidebar, click the plus button.
-2. Select the `Sandbox` option.
+2. Select the `Free` option.
 3. Choose a name for your cluster.
-4. Select a cloud provider (GCP by default).
-5. Configure the `Advanced configuration` settings if needed (auto schema generation and CORS settings).
-6. Click the `Create cluster` button.
+4. The [optimization profile](#optimization-profile) is set to `Cost Optimized` for free clusters.
+5. Select a cloud provider (GCP by default).
+6. Configure the `Advanced configuration` settings if needed (auto schema generation and CORS settings).
+7. Click the `Create cluster` button.
 
-#### Advanced configuration for Shared Cloud clusters
+#### Advanced cluster configuration
 
 The following advanced configuration settings are available:
 
@@ -62,6 +67,12 @@ The following advanced configuration settings are available:
 - `Allow all CORS origins`
 
 </details>
+
+:::note Free cluster lifecycle
+A free cluster runs for as long as you use it. After **7 days of inactivity**, the cluster is **suspended** and your data is preserved. You can reactivate a suspended cluster from the [Weaviate Cloud console](https://console.weaviate.cloud/).
+
+If a cluster stays inactive, it is permanently deleted after **30 days** of total inactivity (about 23 days after it is suspended). Weaviate sends a warning email **1 day before** the cluster is deleted. To keep a cluster running indefinitely, or to run production workloads, [upgrade to a paid plan](https://weaviate.io/pricing).
+:::
 
 ## Shared Cloud clusters
 
@@ -103,10 +114,11 @@ To create a Shared Cloud cluster, follow these steps:
 1. In the clusters sidebar, click the plus button.
 2. Select the `Shared Cloud` option.
 3. Choose a name for your cluster.
-4. Select a cloud provider (GCP by default).
-5. Select if you need high-availability (enabled by default).
-6. Configure the `Advanced configuration` settings if needed (auto schema generation and CORS settings).
-7. Click the `Create cluster` button.
+4. Select an [optimization profile](#optimization-profile) (`Cost Optimized` or `Performance Optimized`).
+5. Select a cloud provider (GCP by default).
+6. Select if you need high-availability (enabled by default).
+7. Configure the `Advanced configuration` settings if needed (auto schema generation and CORS settings).
+8. Click the `Create cluster` button.
 
 #### Advanced configuration for Shared Cloud clusters
 
@@ -116,6 +128,19 @@ The following advanced configuration settings are available:
 - `Allow all CORS origins`
 
 </details>
+
+## Optimization profile
+
+When you create a cluster, the **Optimization profile** sets the default [vector index](/weaviate/concepts/vector-index) and [compression](/weaviate/configuration/compression) for new collections in that cluster. Choose the profile that matches your workload:
+
+- **Cost Optimized**: Uses the **[HFresh](/weaviate/concepts/vector-index#hfresh-index)** vector index for a lower memory footprint and reduced storage costs. Suitable for small or non-latency-sensitive workloads.
+- **Performance Optimized**: Uses the **HNSW** vector index for efficient in-memory retrieval that balances speed and search quality. Suitable for most workloads.
+
+The optimization profile only sets the *default* for new collections. You can still configure the [vector index and compression for each collection](/weaviate/manage-collections/vector-config) when you create it.
+
+:::note Free clusters
+Free clusters support the **Cost Optimized** (HFresh) profile only. To use the **Performance Optimized** (HNSW) profile, [upgrade to a paid plan](https://weaviate.io/pricing).
+:::
 
 ## Authentication
 
@@ -136,7 +161,7 @@ If RBAC is not enabled (before `v1.30`), clusters use the traditional approach w
 - **Admin keys**: Provide read-write access to the database
 - **ReadOnly keys**: Provide read-only access to the database
 
-Shared Cloud clusters can create, delete, edit, and rotate API keys, while Sandbox clusters cannot modify the default keys.
+Shared Cloud clusters can create, delete, edit, and rotate API keys, while free clusters cannot modify the default keys.
 
 ## Weaviate Database version
 
@@ -150,9 +175,7 @@ For more details on Weaviate Cloud versioning, see:
 
 ## Number of clusters
 
-<!-- TODO[g-despot]: Check if this is true.-->
-
-By default, an organization can have up to six (6) shared clusters and two (2) sandbox clusters at the same time. To change these limits, [contact support](mailto:support@weaviate.io).
+Each user can create one (1) free cluster. By default, an organization can have up to six (6) Shared Cloud clusters at the same time. To change these limits, [contact support](mailto:support@weaviate.io).
 
 ## Support & feedback
 

--- a/docs/cloud/manage-clusters/status.mdx
+++ b/docs/cloud/manage-clusters/status.mdx
@@ -102,7 +102,7 @@ You can see the following cluster statistics at the top of the page:
 
 - `Dimensions stored`
 - `Object count`
-- `Cluster expires on` (only for Sandbox cluster)
+- `Cluster expires on` (only for free clusters, based on inactivity)
 
 You can find the following information on the cluster details page:
 
@@ -115,7 +115,7 @@ You can find the following information on the cluster details page:
 - `Cloud provider`
 - `Cloud region`
 - `Created at`
-- `Type` (Shared Cloud or Sandbox)
+- `Type` (Shared Cloud or Free)
 - `Backup retention days` (only for Shared Cloud cluster)
 - `Availability SLA` (only for Shared Cloud cluster)
 

--- a/docs/cloud/platform/billing.mdx
+++ b/docs/cloud/platform/billing.mdx
@@ -1,11 +1,11 @@
 ---
 title: Billing
 sidebar_position: 3
-description: "Billing information for Weaviate Cloud services, including free Sandbox clusters and paid Shared Cloud plans."
+description: "Billing information for Weaviate Cloud services, including free clusters and paid Shared Cloud plans."
 image: og/wcd/user_guides.jpg
 ---
 
-Sandbox clusters are free. You do not need a billing account to create a Sandbox cluster.
+Free clusters are free forever. You do not need a billing account to create a free cluster.
 
 Shared Cloud clusters are charged for resource usage. The monthly charge is determined by your usage and your [support plan](https://weaviate.io/support-plans). You have to have a billing account to create a Shared Cloud cluster.
 

--- a/docs/cloud/platform/create-account.mdx
+++ b/docs/cloud/platform/create-account.mdx
@@ -43,7 +43,7 @@ Go to the [Weaviate Cloud console](/go/console?utm_content=cloud) and follow the
 
 ## Configure billing information
 
-Sandbox instances are free, short-term instances that expire after 14 days. If you are using a Sandbox instance to try out Weaviate, you don't have to set up billing.
+Free clusters are free forever and ideal for learning and small projects. If you are using a free cluster to try out Weaviate, you don't have to set up billing.
 
 Shared Cloud clusters are persistent instances that are suitable for production, development, and testing. Shared Cloud clusters are paid instances. The cost of each instance depends on the instance type and the [support plan](https://weaviate.io/support-plans) you choose. You must configure billing before you can create a Shared Cloud instance. Follow [this guide](/cloud/platform/billing) to set up a billing account.
 

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -84,10 +84,10 @@ Notes:
 
 Weaviate offers the following cluster options:
 
-- **Sandbox clusters**: free short-term cluster for development purposes.
+- **Free clusters**: free-forever cluster, ideal for learning and small projects.
 - **Shared Cloud clusters**: permanent production-ready environment.
 
-Go to the [Weaviate Cloud console](/go/console?utm_content=cloud) and create a free Sandbox instance.
+Go to the [Weaviate Cloud console](/go/console?utm_content=cloud) and create a free cluster.
 
 <div
   style={{
@@ -121,7 +121,7 @@ Go to the [Weaviate Cloud console](/go/console?utm_content=cloud) and create a f
 
 - Cluster provisioning typically takes 1-3 minutes.
 - When the cluster is ready, Weaviate Cloud displays a checkmark (`✔️`) next to the cluster name.
-- Note that Weaviate Cloud adds a random suffix to sandbox cluster names to ensure uniqueness.
+- Note that Weaviate Cloud may add a random suffix to cluster names to ensure uniqueness.
 
 :::
 
@@ -188,7 +188,7 @@ Weaviate supports both REST and gRPC protocols. For Weaviate Cloud deployments, 
 
 :::
 
-Once you have the **REST Endpoint URL** and the **Admin API key**, you can connect to the Sandbox instance and work with Weaviate.
+Once you have the **REST Endpoint URL** and the **Admin API key**, you can connect to your cluster and work with Weaviate.
 
 The example below shows how to connect to Weaviate and perform a basic operation, like checking the cluster status.
 

--- a/docs/cloud/tools/query-tool.mdx
+++ b/docs/cloud/tools/query-tool.mdx
@@ -110,7 +110,7 @@ import QueryToolConsole from "/docs/cloud/img/weaviate-cloud-query-tool-console.
 
 ### Authentication
 
-The query tool connects to Weaviate Cloud sandboxes and Shared Cloud clusters without any additional authentication details.
+The query tool connects to Weaviate Cloud free and Shared Cloud clusters without any additional authentication details.
 
 ### Pass inference keys {#pass-inference-keys}
 

--- a/docs/deploy/index.mdx
+++ b/docs/deploy/index.mdx
@@ -37,7 +37,7 @@ export const deploymentCardsData = [
     bgImage: "/img/site/hex-weaviate.svg",
     bgImageLight: "/img/site/hex-weaviate-light.svg",
     listItems: [
-      "From evaluation (sandbox) to production",
+      "From evaluation (free tier) to production",
       "Shared Cloud (infrastructure managed by Weaviate)",
       "(Optional) Data replication (high-availability)",
       "(Optional) Zero-downtime updates",
@@ -99,7 +99,7 @@ export const deploymentCardsData = [
     bgImage: "/img/site/aws-marketplace-2.svg",
     bgImageLight: "/img/site/aws-marketplace-2.svg",
     listItems: [
-      "From evaluation (sandbox) to production",
+      "From evaluation to production",
       "Shared Cloud (bill through AWS)",
       "Kubernetes (billed through AWS)",
       "Self-hosted on EKS",
@@ -119,7 +119,7 @@ export const deploymentCardsData = [
     bgImage: "/img/site/gcp-marketplace.svg",
     bgImageLight: "/img/site/gcp-marketplace.svg",
     listItems: [
-      "From evaluation (sandbox) to production",
+      "From evaluation to production",
       "Shared Cloud (bill through GCP)",
       "Kubernetes (billed through GCP)",
     ],

--- a/docs/query-agent/index.md
+++ b/docs/query-agent/index.md
@@ -141,7 +141,7 @@ It is designed as a pre-built agentic service for your data, with two main modes
 [You can try the Query Agent without any setup on Weaviate Cloud. Simply go to the 'Agents' tab to start asking questions about data in your collections.](/go/console?utm_content=agents)
 :::
 
-You need a Weaviate Cloud cluster — [a 14-day sandbox is free](https://weaviate.io/deployment/serverless). With a cluster and some data, install [the Python or TypeScript client](./installation.md) and you can run your first query in minutes.
+You need a Weaviate Cloud cluster — [the free tier is free forever](https://weaviate.io/pricing). With a cluster and some data, install [the Python or TypeScript client](./installation.md) and you can run your first query in minutes.
 
 Already have a cluster but no data? Upload via CSV in the cloud console, or [via the Weaviate APIs](/weaviate/manage-objects/create).
 

--- a/docs/query-agent/installation.md
+++ b/docs/query-agent/installation.md
@@ -21,7 +21,7 @@ For example, if the associated Weaviate credentials' user has access to only a s
 
 The Query Agent is available exclusively for use with a Weaviate Cloud instance. [See the page on Weaviate Cloud for more detail](/cloud/index.mdx).
 
-You can try this Weaviate Agent with a free Sandbox instance on [Weaviate Cloud](/go/console?utm_content=agents).
+You can try this Weaviate Agent with a free cluster on [Weaviate Cloud](/go/console?utm_content=agents).
 
 :::note Supported languages
 At this time, the Query Agent clients are available only for Python and JavaScript/TypeScript. Support for other languages will be added in the future.

--- a/docs/query-agent/quickstart.md
+++ b/docs/query-agent/quickstart.md
@@ -18,7 +18,7 @@ This quickstart walks through connecting to a Weaviate Cloud cluster, pointing t
 ## Prerequisites
 
 Ensure you have access to:
-* A **Weaviate Cloud Instance**, such as a [free sandbox instance](/go/console?utm_content=agents).
+* A **Weaviate Cloud Instance**, such as a [free cluster](/go/console?utm_content=agents).
 * Either the **[Python Client](./installation.md#python-client)** or the **[TypeScript Client](./installation.md#javascripttypescript-client)**.
 
 ## Step 1: Start the Query Agent

--- a/docs/query-agent/recipes/query-agent-as-a-tool.md
+++ b/docs/query-agent/recipes/query-agent-as-a-tool.md
@@ -32,7 +32,7 @@ Because the Query Agent is just a Python call (`agent.ask(query).final_answer`),
 
 This recipe assumes:
 
-- A **Weaviate Cloud** cluster — [create a free sandbox here](https://console.weaviate.cloud/).
+- A **Weaviate Cloud** cluster — [create a free cluster here](https://console.weaviate.cloud/).
 - A populated collection. The examples below use `WeaviateBlogChunks` (the Weaviate blog content), but you can substitute your own collection name throughout.
 - The Weaviate client with the `agents` extras:
 

--- a/docs/query-agent/recipes/query-agent-ecommerce-assistant.md
+++ b/docs/query-agent/recipes/query-agent-ecommerce-assistant.md
@@ -30,8 +30,8 @@ To get started, we've prepared two open datasets, available on Hugging Face. The
 
 ## 1. Setting up Weaviate & importing data
 
-To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://weaviate.io/deployment/serverless) account👇
-1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
+To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://console.weaviate.cloud) account👇
+1. [Create a Weaviate Cloud account](https://console.weaviate.cloud) and set up a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
 2. Go to 'Embedding' and enable it, by default, this will make it so that we use `Snowflake/snowflake-arctic-embed-l-v2.0` as the embedding model
 3. Take note of the `WEAVIATE_URL` and `WEAVIATE_API_KEY` to connect to your cluster below
 
@@ -66,7 +66,7 @@ if "WEAVIATE_URL" not in os.environ:
 
 ### Prepare the collections
 
-In the following code blocks, we are pulling our demo datasets from Hugging Face and writing them to new collections in our Weaviate Serverless cluster.
+In the following code blocks, we are pulling our demo datasets from Hugging Face and writing them to new collections in our Weaviate Cloud cluster.
 
 > ❗️ The `QueryAgent` uses the descriptions of collections and properties to decide which ones to use when solving queries, and to access more information about properties. You can experiment with changing these descriptions, providing more detail, and more. It's good practice to provide property descriptions too. For example, below we make sure that the `QueryAgent` knows that prices are all in USD, which is information that would otherwise be unavailable.
 

--- a/docs/query-agent/recipes/query-agent-ecommerce-assistant.md
+++ b/docs/query-agent/recipes/query-agent-ecommerce-assistant.md
@@ -31,7 +31,7 @@ To get started, we've prepared two open datasets, available on Hugging Face. The
 ## 1. Setting up Weaviate & importing data
 
 To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://weaviate.io/deployment/serverless) account👇
-1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [Sandbox](https://docs.weaviate.io/cloud/manage-clusters/create#sandbox-clusters)
+1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
 2. Go to 'Embedding' and enable it, by default, this will make it so that we use `Snowflake/snowflake-arctic-embed-l-v2.0` as the embedding model
 3. Take note of the `WEAVIATE_URL` and `WEAVIATE_API_KEY` to connect to your cluster below
 

--- a/docs/query-agent/recipes/query-agent-get-started.md
+++ b/docs/query-agent/recipes/query-agent-get-started.md
@@ -31,8 +31,8 @@ To follow along, we've prepared four open datasets, available on Hugging Face. W
 
 ## 1. Setting up Weaviate & importing data
 
-To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://weaviate.io/deployment/serverless) account👇
-1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
+To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://console.weaviate.cloud) account👇
+1. [Create a Weaviate Cloud account](https://console.weaviate.cloud) and set up a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
 2. Go to 'Embedding' and enable it, by default, this will make it so that we use `Snowflake/snowflake-arctic-embed-l-v2.0` as the embedding model
 3. Take note of the `WEAVIATE_URL` and `WEAVIATE_API_KEY` to connect to your cluster below
 
@@ -67,7 +67,7 @@ if "WEAVIATE_URL" not in os.environ:
 
 ### Prepare the collections
 
-In the following code blocks, we are pulling our demo datasets from Hugging Face and writing them to new collections in our Weaviate Serverless cluster.
+In the following code blocks, we are pulling our demo datasets from Hugging Face and writing them to new collections in our Weaviate Cloud cluster.
 
 > ❗️ The `QueryAgent` uses the descriptions of collections and properties to decide which ones to use when solving queries, and to access more information about properties. You can experiment with changing these descriptions, providing more detail, and more. It's good practice to provide property descriptions too. For example, below we make sure that the `QueryAgent` knows that prices are all in USD, which is information that would otherwise be unavailable.
 

--- a/docs/query-agent/recipes/query-agent-get-started.md
+++ b/docs/query-agent/recipes/query-agent-get-started.md
@@ -32,7 +32,7 @@ To follow along, we've prepared four open datasets, available on Hugging Face. W
 ## 1. Setting up Weaviate & importing data
 
 To use the Weaviate Query Agent, first, create a [Weaviate Cloud](https://weaviate.io/deployment/serverless) account👇
-1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [Sandbox](https://docs.weaviate.io/cloud/manage-clusters/create#sandbox-clusters)
+1. [Create Serverless Weaviate Cloud account](https://weaviate.io/deployment/serverless) and setup a free [cluster](https://docs.weaviate.io/cloud/manage-clusters/create#free-clusters)
 2. Go to 'Embedding' and enable it, by default, this will make it so that we use `Snowflake/snowflake-arctic-embed-l-v2.0` as the embedding model
 3. Take note of the `WEAVIATE_URL` and `WEAVIATE_API_KEY` to connect to your cluster below
 

--- a/docs/query-agent/recipes/query-agent-streamlit-chat.md
+++ b/docs/query-agent/recipes/query-agent-streamlit-chat.md
@@ -32,7 +32,7 @@ When you run the app, the user types a question like *"recommend me some vintage
 
 ## What you'll need
 
-- A **Weaviate Cloud** cluster — [create a free sandbox here](https://console.weaviate.cloud/). When you create the cluster, enable **Embeddings** so you don't need to provide an external embedding provider's API key.
+- A **Weaviate Cloud** cluster — [create a free cluster here](https://console.weaviate.cloud/). When you create the cluster, enable **Embeddings** so you don't need to provide an external embedding provider's API key.
 - The Weaviate client with the `agents` extras, plus Streamlit and `datasets` (for the one-time data import):
 
 ```bash

--- a/docs/query-agent/recipes/query-agent-vs-diy.md
+++ b/docs/query-agent/recipes/query-agent-vs-diy.md
@@ -22,7 +22,7 @@ The DIY side of this recipe is **deliberately minimal**: six filter operators, b
 
 ## What you'll need
 
-- A **Weaviate Cloud** cluster — [create a free sandbox here](https://console.weaviate.cloud/). When you create the cluster, enable **Embeddings** so you don't need to provide an external embedding provider's API key.
+- A **Weaviate Cloud** cluster — [create a free cluster here](https://console.weaviate.cloud/). When you create the cluster, enable **Embeddings** so you don't need to provide an external embedding provider's API key.
 - The Weaviate client with the `agents` extras, the OpenAI SDK, and `datasets` (for the one-time data import):
 
 ```bash

--- a/docs/weaviate/client-libraries/python/index.mdx
+++ b/docs/weaviate/client-libraries/python/index.mdx
@@ -57,7 +57,7 @@ pip install --pre -U "weaviate-client==4.*"`
 
 The `v4` Python client requires Weaviate `1.23.7` or higher. Generally, we encourage you to use the latest version of the Python client and the Weaviate Database.
 
-In Weaviate Cloud, the Sandboxes are compatible with the `v4` client as of 31 January, 2024. Sandboxes created before this date will not be compatible with the `v4` client.
+In Weaviate Cloud, clusters are compatible with the `v4` client as of 31 January, 2024. Clusters created before this date will not be compatible with the `v4` client.
 
 #### gRPC
 

--- a/docs/weaviate/index.mdx
+++ b/docs/weaviate/index.mdx
@@ -142,7 +142,7 @@ export const deploymentCardsData = [
     bgImage: "/img/site/hex-weaviate.svg",
     bgImageLight: "/img/site/hex-weaviate-light.svg",
     listItems: [
-      "From evaluation (sandbox) to production",
+      "From evaluation (free tier) to production",
       "Shared Cloud (infrastructure managed by Weaviate)",
       "(Optional) Data replication (high-availability)",
       "(Optional) Zero-downtime updates",

--- a/docs/weaviate/quickstart/index.md
+++ b/docs/weaviate/quickstart/index.md
@@ -54,12 +54,12 @@ import PromptStarter from "/src/components/PromptStarter";
 
 ## Prerequisites
 
-A **[Weaviate Cloud](https://console.weaviate.cloud/)** Sandbox instance - you will need an admin **API key** and a **REST endpoint URL** to connect to your instance. See the instructions below for more info. If you don't want to use Weaviate Cloud, check out the [Local Quickstart](local.md) with Docker.
+A **[Weaviate Cloud](https://console.weaviate.cloud/)** free cluster - you will need an admin **API key** and a **REST endpoint URL** to connect to your instance. See the instructions below for more info. If you don't want to use Weaviate Cloud, check out the [Local Quickstart](local.md) with Docker.
 
 <details>
-<summary>How to set up a Weaviate Cloud Sandbox instance</summary>
+<summary>How to set up a Weaviate Cloud free cluster</summary>
 
-Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a free Sandbox instance as shown in the interactive example below.
+Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a free cluster as shown in the interactive example below.
 
 <div
   style={{
@@ -93,7 +93,7 @@ Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a 
 
 - Cluster provisioning typically takes 1-3 minutes.
 - When the cluster is ready, Weaviate Cloud displays a checkmark (`✔️`) next to the cluster name.
-- Note that Weaviate Cloud adds a random suffix to sandbox cluster names to ensure uniqueness.
+- Note that Weaviate Cloud may add a random suffix to cluster names to ensure uniqueness.
 
 :::
 
@@ -143,7 +143,7 @@ Weaviate supports both REST and gRPC protocols. For Weaviate Cloud deployments, 
 
 :::
 
-Once you have the **REST Endpoint URL** and the **admin API key**, you can connect to the Sandbox instance, and work with Weaviate.
+Once you have the **REST Endpoint URL** and the **admin API key**, you can connect to your cluster, and work with Weaviate.
 
 </details>
 

--- a/docs/weaviate/recipes/hybrid_search_mistral_embed.md
+++ b/docs/weaviate/recipes/hybrid_search_mistral_embed.md
@@ -18,7 +18,7 @@ This recipe will show you how to run hybrid search with embeddings from Mistral.
 
 1. Weaviate cluster
 
-   1. You can create a 14-day free sandbox on [WCD](/go/console?utm_content=recipe/)
+   1. You can create a free cluster on [WCD](/go/console?utm_content=recipe/)
    2. [Embedded Weaviate](https://docs.weaviate.io/deploy/installation-guides/embedded)
    3. [Local deployment](https://docs.weaviate.io/deploy/installation-guides/docker-installation)
    4. [Other options](https://docs.weaviate.io/deploy)

--- a/docs/weaviate/recipes/multi-vector-colipali-rag.md
+++ b/docs/weaviate/recipes/multi-vector-colipali-rag.md
@@ -407,7 +407,7 @@ Now, you will need to connect to a running Weaviate vector database cluster.
 
 You can choose one of the following options:
 
-1. **Option 1:** You can create a 14-day free sandbox on the managed service [Weaviate Cloud (WCD)](/go/console?utm_content=recipe/)
+1. **Option 1:** You can create a free cluster on the managed service [Weaviate Cloud (WCD)](/go/console?utm_content=recipe/)
 2. **Option 2:** [Embedded Weaviate](https://docs.weaviate.io/deploy/installation-guides/embedded)
 3. **Option 3:** [Local deployment](https://docs.weaviate.io/deploy/installation-guides/docker-installation)
 4. [Other options](https://docs.weaviate.io/deploy)

--- a/docs/weaviate/recipes/rag_llama_3.1_nemotron_51b_instruct.md
+++ b/docs/weaviate/recipes/rag_llama_3.1_nemotron_51b_instruct.md
@@ -18,7 +18,7 @@ In this demo, we will use an embedding and generative model on NVIDIA to generat
 
 1. Weaviate cluster
 
-   1. You can create a 14-day free sandbox on [WCD](/go/console?utm_content=recipe/)
+   1. You can create a free cluster on [WCD](/go/console?utm_content=recipe/)
    2. [Embedded Weaviate](https://docs.weaviate.io/deploy/installation-guides/embedded)
    3. [Local deployment](https://docs.weaviate.io/deploy/installation-guides/docker-installation)
    4. [Other options](https://docs.weaviate.io/deploy)

--- a/docs/weaviate/recipes/weaviate_embeddings_service.md
+++ b/docs/weaviate/recipes/weaviate_embeddings_service.md
@@ -27,7 +27,7 @@ This notebook will show you how to:
 ## Requirements
 
 1. Weaviate Cloud (WCD) account: You can register [here](/go/console?utm_content=recipe/)
-1. Create a cluster on WCD: A sandbox or serverless cluster is fine. You will need to grab the cluster URL and admin API key
+1. Create a cluster on WCD: A free or Shared Cloud cluster is fine. You will need to grab the cluster URL and admin API key
 1. OpenAI key to access `GPT-4o mini`
 
 ```python

--- a/docs/weaviate/starter-guides/custom-vectors.mdx
+++ b/docs/weaviate/starter-guides/custom-vectors.mdx
@@ -67,7 +67,7 @@ model provider such as Cohere or Hugging Face.
 
 ### Weaviate Instance
 
-Weaviate is open source. You can [run Weaviate](/deploy/index.mdx) locally, in the cloud, or as a service. If you want to follow this guide without setting up an instance of your own, consider using a free, Sandbox instance in [Weaviate Cloud](/cloud/quickstart).
+Weaviate is open source. You can [run Weaviate](/deploy/index.mdx) locally, in the cloud, or as a service. If you want to follow this guide without setting up an instance of your own, consider using a free cluster in [Weaviate Cloud](/cloud/quickstart).
 
 ### Client library
 
@@ -111,7 +111,7 @@ This guide uses a Weaviate Cloud instance to host the collection. To [connect to
 - The Weaviate URL
 - The Weaviate API key
 
-If you are using a Sandbox instance, the URL and API keys are listed in the [details panel](/cloud/manage-clusters/connect.mdx) for your instance.
+If you are using a free cluster, the URL and API keys are listed in the [details panel](/cloud/manage-clusters/connect.mdx) for your instance.
 
 To connect to Weaviate, run the code for your language to create a client object. Re-use the `client` object in the later steps to connect to your instance and run the sample code.
 

--- a/docs/weaviate/starter-guides/which-weaviate.md
+++ b/docs/weaviate/starter-guides/which-weaviate.md
@@ -43,12 +43,12 @@ Here are some recommendations for different use cases.
 
 If you are evaluating Weaviate, we recommend using one of these instance types to get started quickly:
 
-- [Weaviate Cloud (WCD)](/cloud) sandbox
+- [Weaviate Cloud (WCD)](/cloud) free cluster
 - [Embedded Weaviate](/deploy/installation-guides/embedded)
 
 Use an inference-API based text vectorizer with your instance, for example, `text2vec-cohere`, `text2vec-huggingface`, `text2vec-openai`, or `text2vec-google`.
 
-The [Quickstart guide](/weaviate/quickstart) uses a WCD sandbox and an API based vectorizer to run the examples.
+The [Quickstart guide](/weaviate/quickstart) uses a WCD free cluster and an API based vectorizer to run the examples.
 
 ### Development
 

--- a/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
+++ b/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
@@ -78,9 +78,9 @@ import CodeClientInstall from "/_includes/code/quickstart/clients.install.mdx";
 
 <details>
 
-<summary>How to create a Weaviate Cloud Sandbox</summary>
+<summary>How to create a Weaviate Cloud free cluster</summary>
 
-Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a free Sandbox instance.
+Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a free cluster.
 
 <div
   style={{
@@ -114,7 +114,7 @@ Go to the [Weaviate Cloud console](https://console.weaviate.cloud) and create a 
 
 - Cluster provisioning typically takes 1-3 minutes.
 - When the cluster is ready, Weaviate Cloud displays a checkmark (`✔️`) next to the cluster name.
-- Note that Weaviate Cloud adds a random suffix to sandbox cluster names to ensure uniqueness.
+- Note that Weaviate Cloud may add a random suffix to cluster names to ensure uniqueness.
 
 :::
 
@@ -164,7 +164,7 @@ Weaviate supports both REST and gRPC protocols. For Weaviate Cloud deployments, 
 
 :::
 
-Once you have the **REST Endpoint URL** and the **admin API key**, you can connect to the Sandbox instance, and work with Weaviate.
+Once you have the **REST Endpoint URL** and the **admin API key**, you can connect to your cluster, and work with Weaviate.
 
 The example below shows how to connect to Weaviate and perform a basic operation, like checking the cluster status.
 
@@ -401,7 +401,7 @@ The power of RAG comes from the ability to transform your own data. Weaviate hel
 
 In this quickstart guide, you:
 
-- Created a Serverless Weaviate sandbox instance on Weaviate Cloud.
+- Created a free cluster on Weaviate Cloud.
 - Defined a collection and added data.
 - Performed queries, including:
   - Semantic search, and

--- a/docs/weaviate/tutorials/vectorizer-migration.mdx
+++ b/docs/weaviate/tutorials/vectorizer-migration.mdx
@@ -33,7 +33,7 @@ Before starting this tutorial, ensure you have:
 
 :::tip Get started with Weaviate Cloud
 
-Sign up for a free Weaviate Cloud sandbox at [console.weaviate.cloud](/go/console?utm_content=tutorial)
+Sign up for a free Weaviate Cloud cluster at [console.weaviate.cloud](/go/console?utm_content=tutorial)
 
 :::
 


### PR DESCRIPTION
## What

Replaces the retired **Sandbox** cluster concept with the new **Weaviate Cloud Free tier** across the docs, documents the Free cluster lifecycle and the cluster **Optimization profile**, and cleans up stale **Serverless** nomenclature — aligning everything with the current [pricing page](https://weaviate.io/pricing) (Free / Flex / Plus / Premium on Shared or Dedicated Cloud).

## Why

The old Sandbox (free for 14 days, then deleted) has been replaced by a permanently free tier. "Serverless" clusters were renamed to "Shared Cloud" on 2025-10-27. The docs still referenced the old names, the 14-day expiry behavior, and dead URLs.

## Changes

**Free tier (replaces Sandbox)**
- `create.mdx`: rewritten **Free clusters** section — free forever, no credit card, ideal for learning/hobby/small projects, with a pricing-page link and a **Free cluster lifecycle** note (suspended after 7 days of inactivity, deleted after 30 days, warning email 1 day before)
- "one free cluster per user" limit, `Type: Free` in cluster status, plus billing / FAQ / create-account updates
- Swept Sandbox → free cluster across cloud, deploy, query-agent, and weaviate quickstart/tutorials/starter-guides/recipes
- Renamed the heading anchor `#sandbox-clusters` → `#free-clusters` and fixed all inbound links; removed the orphaned `_includes/sandbox.expiry.mdx`

**Optimization profile** (new section in `create.mdx`)
- **Cost Optimized** (HFresh) vs **Performance Optimized** (HNSW) — sets the default vector index and compression for new collections
- Free clusters support Cost Optimized only

**Serverless nomenclature cleanup**
- Query Agent recipes: stale "Serverless" cluster wording → Weaviate Cloud; dead `weaviate.io/deployment/serverless` URLs → console; FAQ "it's" → "its"
- Kept the FAQ historical rename note and unrelated "DigitalOcean Serverless Inference" references

## Testing
- `yarn build-dev` passes with no new broken links/anchors (3 pre-existing warnings are unrelated to this PR)
- `grep` confirms 0 remaining `sandbox` and 0 `deployment/serverless` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)