### PR TITLE
Update Cloud FAQ: cluster autoscaling answer

### DIFF
--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -84,7 +84,7 @@ Yes. Weaviate Cloud automatically updates existing clusters as new Weaviate vers
 <details>
 <summary> Answer </summary>
 
-Not currently. Weaviate Cloud monitors your cluster and flags when resizing may be required, but automatic scaling is not enabled by default.
+Weaviate Cloud runs on automatically scaling infrastructure that adapts the underlying capacity to your workload as it grows, keeping your cluster performant and available without manual intervention. Your cluster is also continuously monitored, and Weaviate Cloud flags when a resize is recommended. [Contact Weaviate Cloud Support](/support) if you anticipate significant growth.
 
 </details>
 


### PR DESCRIPTION
Updates the "Are cluster resources scaled automatically?" answer in the Weaviate Cloud FAQ.

The previous answer ("Not currently... automatic scaling is not enabled by default") was outdated. Weaviate Cloud now runs on automatically scaling infrastructure that adapts underlying capacity to workload as it grows.

### Type of change:

- [x] **Documentation content** updates (non-breaking change to fix/update documentation )
- [ ] **Bug fix** (non-breaking change to fixes an issue with the site)
- [ ] **Feature** or **enhancements** (non-breaking change to add functionality)

### How has this been tested?

<!-- Please select all options that apply -->

- [x] **Local build** - the site works as expected when running `yarn start`
