### PR TITLE
Publish WCD test-cluster restore tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,8 +269,9 @@ _includes/code/csharp/quickstart/bin
 _includes/code/csharp/quickstart/obj
 *.sln
 
-# Exclude WCD backups
-tests/backups/
+# Exclude WCD snapshot data (hundreds of MB), but track the restore tooling
+# (restore.py, README.md). Snapshots live in backup_<timestamp>/ directories.
+tests/backups/backup_*/
 
 # Ignore LLM/agent config files
 .claude/

--- a/tests/backups/README.md
+++ b/tests/backups/README.md
@@ -1,0 +1,223 @@
+# WCD test-cluster restore
+
+Tooling to rebuild the Weaviate Cloud (WCD) cluster the docs CI runs against,
+from a point-in-time snapshot of every collection's schema and objects (with
+their stored vectors and UUIDs).
+
+## What's here
+
+```
+restore.py            # single entrypoint — runs stages 1–3 (see --stage)
+README.md             # this file
+backup_<timestamp>/   # the snapshot — NOT committed (see "The snapshot")
+```
+
+`restore.py` is the only script; the three restore stages are flags on it
+(`--stage`). The snapshot directory is **not committed** — it is hundreds of MB
+(one objects file alone is ~470 MB), so it is gitignored and obtained
+separately (see below).
+
+## The snapshot
+
+A snapshot is a directory named `backup_<timestamp>/` with this layout:
+
+| File pattern                         | Content                                          |
+|--------------------------------------|--------------------------------------------------|
+| `backup_metadata.json`               | Index: every collection's name, MT flag, tenants |
+| `<Collection>_config.json`           | Schema (properties, generative/MT config, …)     |
+| `<Collection>_objects.json`          | Objects, UUIDs, and stored vectors               |
+| `<Collection>_<tenant>_objects.json` | MT objects, one file per tenant                  |
+
+The current baseline, `backup_20251126_164527/`, was taken on 2025-11-26 and
+contains 23 collections (one multi-tenant). Because it is gitignored, it is
+**not in a clean checkout** — ask another maintainer for a copy, or restore from
+wherever your team stores it, and drop it next to `restore.py`.
+
+`restore.py` locates the snapshot in this order:
+
+1. `$WEAVIATE_BACKUP_DIR`, if set, or
+2. the newest `backup_*` directory next to `restore.py`.
+
+Stages 1 and 2 read the snapshot; stage 3 does not (it uses the canonical
+dataset package), so a stage-3-only run needs no snapshot.
+
+### Collections owned by the agents tests
+
+`restore.py` **skips** `ECommerce`, `Weather`, and `FinancialContracts` (the
+`AGENTS_OWNED_COLLECTIONS` set). They are owned by the Query Agent tests
+(`docs/agents/_includes/query_agent.*`), which create them with
+`text2vec-weaviate` named vectors and load their data from HuggingFace — but
+only `if not collections.exists(...)`. The snapshot's lossy copies (no
+vectorizer config) would shadow that and break named-vector queries
+(`WEAVIATE_NAMED_VECTOR_ERROR` / `collection_vectors: []`). So a restore rebuilds
+**20** collections; the agents tests manage the other three. No non-agents test
+depends on the snapshot versions.
+
+## Why three stages
+
+The original backup tool serialized config via `str(...)`, which dropped
+structured details: vectorizer config, cross-references, inverted-index flags.
+Stage 1 alone gives a cluster with all the *data* back, but `near_text`/`hybrid`
+are silently broken because the vectorizer is unset — queries can't be embedded
+at runtime. Stage 2 plugs that hole for the 8 collections the docs tests
+actually search. Stage 3 reseeds Jeopardy from the canonical package because the
+snapshot lost `JeopardyQuestion.hasCategory` too.
+
+```
+--stage 1   restore (bulk replay)
+  ├─ recreates schemas from *_config.json
+  ├─ batch-inserts objects with stored vectors + UUIDs
+  ├─ idempotent (skips collections with objects, recreates empty ones)
+  └─ vectorizer left at "none" → near_vector works, near_text does not
+
+--stage 2   repopulate            (drops + recreates 8 specific collections)
+  ├─ adds text2vec-openai (ada-002) so near_text/hybrid work
+  ├─ adds cross-references + inverted-index flags the original tool lost
+  └─ re-imports preserving stored vectors (no re-embedding cost)
+
+--stage 3   jeopardy reseed       (overwrites Jeopardy from canonical pkg)
+  ├─ ignores the snapshot for JeopardyQuestion + JeopardyCategory
+  └─ uploads weaviate_datasets.JeopardyQuestions10k() with overwrite=True
+```
+
+## Running the restore
+
+```bash
+export WEAVIATE_URL="<cluster host without scheme>"
+export WEAVIATE_API_KEY="<admin api key>"
+export OPENAI_API_KEY="<openai key>"        # stages 2 + 3 only
+
+uv run python tests/backups/restore.py              # all stages (default)
+uv run python tests/backups/restore.py --stage 1    # one stage
+uv run python tests/backups/restore.py --stage 2,3  # a subset
+```
+
+A clean restore on an empty cluster takes a few minutes; stage 1 is the slowest
+because of the 10k-object `JeopardyQuestion` batch insert.
+
+- **Stage 1 is idempotent** — re-running it skips collections that already have
+  objects (and recreates empty/failed ones).
+- **Stages 2 and 3 are destructive** — they delete and recreate the collections
+  they touch.
+
+Stage 1 needs only `WEAVIATE_URL` + `WEAVIATE_API_KEY`. Stages 2 and 3 also need
+`OPENAI_API_KEY` because the recreated collections use `text2vec-openai` as the
+vectorizer (passed via the `X-OpenAI-Api-Key` header). `restore.py` validates
+that the variables required by the selected stages are set before connecting.
+
+## Why ada-002 specifically (don't change this)
+
+The stored vectors in the snapshot are 1536-d `text-embedding-ada-002`. Stage 2
+pins the vectorizer to `text-embedding-ada-002` so that **query-time** embedding
+lands in the same space as the **stored** vectors. Using v4's current default
+(`text-embedding-3-small`) would silently return semantically wrong results —
+the embedding spaces don't overlap.
+
+## What stage 2 fixes per collection
+
+Stage 2 only touches the 8 collections the docs tests semantically search
+(`COLLECTIONS_TO_FIX` in `restore.py`); everything else stays as stage 1
+restored it.
+
+| Collection           | Vectorizer                                            | Other repairs                                                     |
+|----------------------|-------------------------------------------------------|-------------------------------------------------------------------|
+| `JeopardyQuestion`   | `text2vec-openai` (ada-002), single                   | `hasCategory` cross-ref → `JeopardyCategory`                      |
+| `Article`            | single                                                | `inPublication`, `hasAuthors` cross-refs; `index_timestamps=true` |
+| `ArxivPapers`        | single                                                | —                                                                 |
+| `Publication`        | single                                                | `hasArticles` cross-ref → `Article`                               |
+| `WineReview`         | single                                                | `index_null_state=true` (tests filter `IsNull`)                   |
+| `WineReviewMT`       | single (MT)                                           | `index_null_state=true`                                           |
+| `GitBookChunk`       | single                                                | —                                                                 |
+| `WineReviewNV`       | named vectors `title`, `title_country`, `review_body` | `index_null_state=true`                                           |
+
+`WineReviewNV` is the only collection with multiple named vectors; everything
+else uses the legacy single `"default"` vectorizer.
+
+### A wire-format quirk worth knowing
+
+When a collection uses the legacy single-vectorizer form (not named vectors),
+inserts expect an **unnamed** vector. The snapshot stores it as
+`{"default": [...]}` (the named-vector shape). The stage-2 `coerce` closure in
+`restore.py` unwraps the `default` key before batch insert. Without that,
+inserts to those collections fail with a wire-format error.
+
+## Stage 3 — why Jeopardy gets its own path
+
+The snapshot's `JeopardyQuestion` lost the `hasCategory` cross-reference (the
+original backup tool didn't serialize references at all). Stage 2 declares the
+reference, but the per-object reference data isn't in the snapshot, so reads
+would still return empty for `hasCategory`. Stage 3 calls
+`weaviate_datasets.JeopardyQuestions10k().upload_dataset(...)`, which ships clean
+ada-002 vectors **and** the per-object `hasCategory` links wired up.
+
+Stage 3 overwrites stage 2's Jeopardy work (`overwrite=True`). That's
+intentional — stage 2 keeps Jeopardy in its loop because it's the simplest
+re-import for the other 8 collections, and stage 3 then supersedes Jeopardy with
+the canonical source. The cluster ends at exactly 10,000 Jeopardy objects
+(stage 1 imports 10,004 from the snapshot; stage 3 finishes at 10,000).
+
+## Verifying a restore worked
+
+A few quick sanity checks against the restored cluster (run with the same env
+vars):
+
+```python
+import os, weaviate
+from weaviate.classes.init import Auth
+
+c = weaviate.connect_to_weaviate_cloud(
+    cluster_url=os.environ["WEAVIATE_URL"],
+    auth_credentials=Auth.api_key(os.environ["WEAVIATE_API_KEY"]),
+    headers={"X-OpenAI-Api-Key": os.environ["OPENAI_API_KEY"]},
+)
+try:
+    for name, expected in [("JeopardyQuestion", 10000), ("Article", 4403),
+                           ("ArxivPapers", 2000), ("WineReview", 50)]:
+        n = c.collections.get(name).aggregate.over_all(total_count=True).total_count
+        print(f"{name}: {n}{' ✓' if n == expected else f' (expected {expected})'}")
+    # Query-time vectorization works (proves stage 2 ran):
+    r = c.collections.get("JeopardyQuestion").query.near_text("famous scientists", limit=1)
+    print(f"near_text: {r.objects[0].properties.get('question')!r}")
+finally:
+    c.close()
+```
+
+Expected counts after a fresh restore (stages 1 → 2 → 3). `ECommerce`,
+`Weather`, and `FinancialContracts` are intentionally absent — the agents tests
+own them.
+
+| Collection                      | Count             |
+|---------------------------------|-------------------|
+| `JeopardyQuestion`              | 10,000            |
+| `Article`                       | 4,403             |
+| `ArxivPapers`                   | 2,000             |
+| `Recipes`                       | 100               |
+| `WineReview` / `WineReviewNV`   | 50 / 50           |
+| `WineReviewMT`                  | 50 per tenant × 2 |
+| `GitBookChunk` / `JeopardyTiny` | 10 / 10           |
+| `JeopardyCategory`              | 40                |
+| `Movie`                         | 3                 |
+
+## Taking a new snapshot
+
+There is **no snapshot script here** — `restore.py` only *reads* a snapshot. The
+current one was produced by a separate tool (iterating
+`client.collections.list_all()` and dumping properties + objects + vectors per
+collection). If you ever need a newer baseline:
+
+1. Produce the same file layout (`backup_metadata.json` plus per-collection
+   `_config.json` / `_objects.json`) in a new `backup_<timestamp>/` directory.
+2. Be aware of the lossy fields the original tool didn't capture — the schema
+   features in the `EXTRA_SCHEMA` map in `restore.py` (references,
+   `index_timestamps`, `index_null_state`). Either fix the backup tool to
+   serialize them properly, or extend `EXTRA_SCHEMA`.
+3. `restore.py` auto-detects the newest `backup_*` directory, so no code change
+   is needed; or point `$WEAVIATE_BACKUP_DIR` at the new directory explicitly.
+
+## When to restore
+
+- The CI test cluster gets wedged after a failed test run (collections in
+  inconsistent states, half-deleted data, etc.).
+- You're spinning up a fresh WCD cluster for testing and want the same baseline
+  the docs CI uses.
+- You suspect a flaky test is caused by cluster drift, not a real regression.

--- a/tests/backups/restore.py
+++ b/tests/backups/restore.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Restore the docs CI Weaviate Cloud (WCD) test cluster from a snapshot.
+
+The snapshot under ``backup_<timestamp>/`` is a point-in-time export of every
+collection's schema and objects (with stored vectors and UUIDs). The original
+backup tool serialized config with ``str(...)``, which dropped structured
+details (vectorizer config, cross-references, inverted-index flags), so a
+faithful replay needs three stages:
+
+  Stage 1 — restore     Recreate schemas + bulk-insert objects with their stored
+                        vectors and UUIDs. Idempotent (skips collections that
+                        already have objects). Leaves the vectorizer at "none",
+                        so ``near_vector`` works but ``near_text``/``hybrid`` do
+                        not. Needs WEAVIATE_URL + WEAVIATE_API_KEY only.
+
+  Stage 2 — repopulate  Drop + recreate the 8 collections the docs tests
+                        semantically search, pinning text2vec-openai (ada-002)
+                        so query-time embedding lands in the same space as the
+                        stored vectors, plus the cross-refs / inverted-index
+                        flags the original tool lost. DESTRUCTIVE. Needs
+                        OPENAI_API_KEY in addition.
+
+  Stage 3 — jeopardy    Overwrite JeopardyQuestion + JeopardyCategory from the
+                        canonical weaviate-demo-datasets package (the snapshot
+                        lost the per-object hasCategory references). DESTRUCTIVE.
+                        Does NOT read the snapshot. Needs OPENAI_API_KEY.
+
+ECommerce / Weather / FinancialContracts are owned by the Query Agent tests
+(``docs/agents/_includes/query_agent.*``) — they are skipped entirely here so
+the snapshot can't shadow the tests' own ``text2vec-weaviate`` setup.
+
+Usage
+-----
+    export WEAVIATE_URL="<cluster host, no scheme>"
+    export WEAVIATE_API_KEY="<admin api key>"
+    export OPENAI_API_KEY="<openai key>"        # stages 2 + 3 only
+
+    uv run python tests/backups/restore.py              # all stages (default)
+    uv run python tests/backups/restore.py --stage 1    # one stage
+    uv run python tests/backups/restore.py --stage 2,3  # a subset
+
+The snapshot directory is not committed (it is hundreds of MB). It is located
+via $WEAVIATE_BACKUP_DIR, or by auto-detecting the newest ``backup_*`` directory
+next to this script. See README.md for how to obtain it.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+import weaviate
+import weaviate.classes.config as wvc
+from weaviate.classes.init import Auth
+from weaviate.classes.tenants import Tenant
+
+
+# ─────────────────────────────── Configuration ───────────────────────────────
+
+# Backup "data_type" string → client DataType. Shared by stages 1 and 2.
+DATA_TYPE_MAP = {
+    "text": wvc.DataType.TEXT,
+    "text[]": wvc.DataType.TEXT_ARRAY,
+    "int": wvc.DataType.INT,
+    "int[]": wvc.DataType.INT_ARRAY,
+    "number": wvc.DataType.NUMBER,
+    "number[]": wvc.DataType.NUMBER_ARRAY,
+    "boolean": wvc.DataType.BOOL,
+    "date": wvc.DataType.DATE,
+    "uuid": wvc.DataType.UUID,
+    "geoCoordinates": wvc.DataType.GEO_COORDINATES,
+    "object[]": wvc.DataType.OBJECT_ARRAY,
+}
+
+# Python value type → DataType, used to infer object[] nested schemas (stage 1).
+PYTHON_TO_DATATYPE = {
+    str: wvc.DataType.TEXT,
+    int: wvc.DataType.INT,
+    float: wvc.DataType.NUMBER,
+    bool: wvc.DataType.BOOL,
+}
+
+# Owned by the Query Agent tests, which create them with text2vec-weaviate named
+# vectors and load their data from HuggingFace (only `if not exists`). The
+# snapshot's lossy copies would shadow that and break named-vector queries
+# (WEAVIATE_NAMED_VECTOR_ERROR / collection_vectors: []). Skipped in stage 1 and
+# absent from COLLECTIONS_TO_FIX below. No non-agents test depends on them.
+AGENTS_OWNED_COLLECTIONS = {"ECommerce", "Weather", "FinancialContracts"}
+
+# Stage 2: collection name → list of named-vector specs. A spec is either a
+# string (vector name; vectorizes from all text props) or a (name, [props])
+# tuple. A single "default" spec means the legacy single-vector form.
+COLLECTIONS_TO_FIX = {
+    "JeopardyQuestion": ["default"],
+    "Article": ["default"],
+    "ArxivPapers": ["default"],
+    "Publication": ["default"],
+    "WineReview": ["default"],
+    "WineReviewMT": ["default"],
+    "GitBookChunk": ["default"],
+    "WineReviewNV": [
+        ("title", ["title"]),
+        ("title_country", ["title", "country"]),
+        ("review_body", ["review_body"]),
+    ],
+}
+
+# Stage 2: schema details lost by the original backup script (str() of config
+# objects), re-declared so collection-level features work post-recreate.
+EXTRA_SCHEMA = {
+    "Article": {
+        "inverted_index_config": wvc.Configure.inverted_index(index_timestamps=True),
+        "references": [
+            wvc.ReferenceProperty(name="inPublication", target_collection="Publication"),
+            wvc.ReferenceProperty(name="hasAuthors", target_collection="Author"),
+        ],
+    },
+    "JeopardyQuestion": {
+        "references": [
+            wvc.ReferenceProperty(name="hasCategory", target_collection="JeopardyCategory"),
+        ],
+    },
+    # WineReview-family tests filter on `IsNull` (e.g. country IS NULL), which
+    # requires index_null_state=true on the inverted-index config.
+    "WineReview": {
+        "inverted_index_config": wvc.Configure.inverted_index(index_null_state=True),
+    },
+    "WineReviewMT": {
+        "inverted_index_config": wvc.Configure.inverted_index(index_null_state=True),
+    },
+    "WineReviewNV": {
+        "inverted_index_config": wvc.Configure.inverted_index(index_null_state=True),
+    },
+    "Publication": {
+        "references": [
+            wvc.ReferenceProperty(name="hasArticles", target_collection="Article"),
+        ],
+    },
+}
+
+
+# ──────────────────────────── Connection / env ───────────────────────────────
+
+def _require_env(names):
+    """Exit with a clear message if any required environment variable is unset."""
+    missing = [n for n in names if not os.environ.get(n)]
+    if missing:
+        sys.exit(f"Missing required environment variable(s): {', '.join(missing)}")
+
+
+def connect(with_openai):
+    """Open a WCD client. The OpenAI header is attached when stages 2/3 run, so
+    text2vec-openai can vectorize queries and the datasets upload can embed."""
+    headers = None
+    if with_openai:
+        headers = {"X-OpenAI-Api-Key": os.environ["OPENAI_API_KEY"]}
+    return weaviate.connect_to_weaviate_cloud(
+        cluster_url=os.environ["WEAVIATE_URL"],
+        auth_credentials=Auth.api_key(os.environ["WEAVIATE_API_KEY"]),
+        headers=headers,
+    )
+
+
+def resolve_backup_dir():
+    """Locate the snapshot directory: $WEAVIATE_BACKUP_DIR if set, else the
+    newest ``backup_*`` directory next to this script."""
+    env_dir = os.environ.get("WEAVIATE_BACKUP_DIR")
+    if env_dir:
+        if not os.path.isdir(env_dir):
+            sys.exit(f"WEAVIATE_BACKUP_DIR is not a directory: {env_dir}")
+        return env_dir
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates = sorted(d for d in glob.glob(os.path.join(here, "backup_*")) if os.path.isdir(d))
+    if not candidates:
+        sys.exit(
+            "No snapshot found. The snapshot is not committed to the repo "
+            "(it is hundreds of MB). Place a `backup_<timestamp>/` directory "
+            "next to this script, or point $WEAVIATE_BACKUP_DIR at one. "
+            "See tests/backups/README.md for how to obtain it."
+        )
+    return candidates[-1]
+
+
+def load_metadata(backup_dir):
+    with open(os.path.join(backup_dir, "backup_metadata.json")) as f:
+        return json.load(f)
+
+
+# ──────────────────────────── Stage 1: restore ───────────────────────────────
+
+def infer_nested_properties(objects, prop_name):
+    """Infer nested property schema from actual objects for object[] props."""
+    seen = {}
+    for obj in objects:
+        items = obj.get("properties", {}).get(prop_name) or []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            for k, v in item.items():
+                if k not in seen and v is not None:
+                    seen[k] = type(v)
+    props = []
+    for name, py_type in seen.items():
+        dt = PYTHON_TO_DATATYPE.get(py_type, wvc.DataType.TEXT)
+        props.append(wvc.Property(name=name, data_type=dt))
+    return props
+
+
+def detect_named_vectors(objects_file):
+    """Return [(name, dim)] for any named vectors found in the first object."""
+    with open(objects_file) as f:
+        objects = json.load(f)
+    if not objects:
+        return []
+    first_vec = objects[0].get("vector") or {}
+    if not first_vec or list(first_vec.keys()) == ["default"]:
+        return []
+    return [(k, len(v)) for k, v in first_vec.items() if v]
+
+
+def build_restore_properties(config, loaded_objects):
+    """Build the property list for a snapshot collection, inferring nested
+    schemas for object[] properties from the objects themselves."""
+    obj_array_schemas = {}
+    if loaded_objects:
+        for p in config["properties"]:
+            if p["data_type"] == "object[]":
+                obj_array_schemas[p["name"]] = infer_nested_properties(loaded_objects, p["name"])
+    # If any object[] prop has an empty inferred schema, borrow from a sibling.
+    fallback = next((s for s in obj_array_schemas.values() if s), None)
+    for k in list(obj_array_schemas):
+        if not obj_array_schemas[k] and fallback:
+            obj_array_schemas[k] = fallback
+
+    properties = []
+    for p in config["properties"]:
+        dt = DATA_TYPE_MAP.get(p["data_type"])
+        if dt is None:
+            print(f"  WARNING: unknown data_type '{p['data_type']}' for {p['name']}, skipping")
+            continue
+        if p["data_type"] == "object[]":
+            nested = obj_array_schemas.get(p["name"], [])
+            if not nested:
+                print(f"  WARNING: could not infer nested props for {p['name']}, skipping property")
+                continue
+            properties.append(wvc.Property(
+                name=p["name"], data_type=dt, description=p.get("description"),
+                nested_properties=nested,
+            ))
+            print(f"  Nested props for {p['name']}: {[n.name for n in nested]}")
+        else:
+            properties.append(wvc.Property(
+                name=p["name"], data_type=dt, description=p.get("description"),
+            ))
+    return properties
+
+
+def _already_populated(client, name, col_meta, existing):
+    """For idempotency: True if the collection exists with objects (skip it);
+    otherwise delete the empty/failed collection so it can be recreated."""
+    if name not in existing:
+        return False
+    col = client.collections.get(name)
+    if col_meta["is_multi_tenant"]:
+        tenants = col.tenants.get()
+        if tenants:
+            first = list(tenants.keys())[0] if isinstance(tenants, dict) else tenants[0]
+            try:
+                tc = col.with_tenant(first if isinstance(first, str) else first.name)
+                count = tc.aggregate.over_all(total_count=True).total_count
+            except Exception:
+                count = 0
+            if count and count > 0:
+                print(f"\nSkipping {name} (multi-tenant, has objects)")
+                return True
+    else:
+        count = col.aggregate.over_all(total_count=True).total_count
+        if count and count > 0:
+            print(f"\nSkipping {name} ({count} objects already present)")
+            return True
+    print(f"\nDeleting empty/failed {name} to recreate")
+    client.collections.delete(name)
+    existing.discard(name)
+    return False
+
+
+def stage1_restore(client, backup_dir):
+    print("\n========== Stage 1: restore (bulk replay) ==========")
+    metadata = load_metadata(backup_dir)
+    existing = set(client.collections.list_all().keys())
+    print(f"Target cluster has {len(existing)} existing collections: {sorted(existing)}")
+
+    for col_meta in metadata["collections"]:
+        name = col_meta["name"]
+        if name in AGENTS_OWNED_COLLECTIONS:
+            print(f"\nSkipping {name} (agents-owned — created by the Query Agent tests, not the snapshot)")
+            continue
+
+        objects_file = os.path.join(backup_dir, col_meta["objects_file"]) if col_meta.get("objects_file") else ""
+        with open(os.path.join(backup_dir, col_meta["config_file"])) as f:
+            config = json.load(f)
+
+        if _already_populated(client, name, col_meta, existing):
+            continue
+
+        print(f"\nRestoring collection: {name}")
+
+        loaded_objects = None
+        if os.path.exists(objects_file):
+            with open(objects_file) as f:
+                loaded_objects = json.load(f)
+
+        properties = build_restore_properties(config, loaded_objects)
+
+        gen_str = config.get("generative_config") or ""
+        generative_config = wvc.Configure.Generative.openai() if "generative-openai" in gen_str else None
+
+        mt_str = config.get("multi_tenancy_config") or ""
+        mt_config = wvc.Configure.multi_tenancy(enabled=True) if "enabled=True" in mt_str else None
+
+        # Reconstruct named-vector slots (without a vectorizer) when the snapshot
+        # stored multiple named vectors. Single-vector collections stay legacy.
+        named_vectors = None
+        if not col_meta["is_multi_tenant"] and os.path.exists(objects_file):
+            vec_info = detect_named_vectors(objects_file)
+            if vec_info:
+                named_vectors = [wvc.Configure.NamedVectors.none(name=n) for n, _ in vec_info]
+                print(f"  Named vectors: {[n for n, _ in vec_info]}")
+
+        client.collections.create(
+            name=name,
+            description=config.get("description"),
+            properties=properties,
+            generative_config=generative_config,
+            multi_tenancy_config=mt_config,
+            vectorizer_config=named_vectors if named_vectors else None,
+        )
+        print(f"  Created schema with {len(properties)} properties")
+
+        collection = client.collections.get(name)
+        _insert_objects(collection, col_meta, backup_dir, coerce=lambda v: v if v else None)
+
+    print("\n✓ Stage 1 complete")
+
+
+# ─────────────────────────── Stage 2: repopulate ─────────────────────────────
+
+def build_vectorizer_config(specs):
+    """Legacy Vectorizer config (single 'default' spec) or a list of
+    NamedVectors. Pinned to ada-002 to match the snapshot's stored 1536-d
+    vectors — the v4 default (text-embedding-3-small) would query in a different
+    embedding space and return semantically wrong results."""
+    if len(specs) == 1 and specs[0] == "default":
+        return wvc.Configure.Vectorizer.text2vec_openai(model="ada", model_version="002")
+    configs = []
+    for spec in specs:
+        if isinstance(spec, str):
+            configs.append(wvc.Configure.NamedVectors.text2vec_openai(
+                name=spec, model="ada", model_version="002"))
+        else:
+            name, source_props = spec
+            configs.append(wvc.Configure.NamedVectors.text2vec_openai(
+                name=name, source_properties=source_props, model="ada", model_version="002"))
+    return configs
+
+
+def build_repopulate_properties(config):
+    """Property list for a repopulated collection. object[] props are skipped —
+    the searchable collections don't use them."""
+    props = []
+    for p in config["properties"]:
+        dt = DATA_TYPE_MAP.get(p["data_type"])
+        if dt is None or p["data_type"] == "object[]":
+            print(f"  Skipping property {p['name']} (data_type={p['data_type']})")
+            continue
+        props.append(wvc.Property(name=p["name"], data_type=dt, description=p.get("description")))
+    return props
+
+
+def stage2_repopulate(client, backup_dir):
+    print("\n========== Stage 2: repopulate (vectorizer + schema repair) ==========")
+    metadata = load_metadata(backup_dir)
+
+    for col_meta in metadata["collections"]:
+        name = col_meta["name"]
+        if name not in COLLECTIONS_TO_FIX:
+            continue
+
+        print(f"\n=== Fixing {name} ===")
+        with open(os.path.join(backup_dir, col_meta["config_file"])) as f:
+            config = json.load(f)
+
+        properties = build_repopulate_properties(config)
+        vectorizer_config = build_vectorizer_config(COLLECTIONS_TO_FIX[name])
+
+        gen_str = config.get("generative_config") or ""
+        generative_config = wvc.Configure.Generative.openai() if "generative-openai" in gen_str else None
+
+        mt_str = config.get("multi_tenancy_config") or ""
+        mt_config = wvc.Configure.multi_tenancy(enabled=True) if "enabled=True" in mt_str else None
+
+        if client.collections.exists(name):
+            print(f"  Deleting existing {name}")
+            client.collections.delete(name)
+
+        extra = EXTRA_SCHEMA.get(name, {})
+        client.collections.create(
+            name=name,
+            description=config.get("description"),
+            properties=properties,
+            references=extra.get("references"),
+            inverted_index_config=extra.get("inverted_index_config"),
+            vectorizer_config=vectorizer_config,
+            generative_config=generative_config,
+            multi_tenancy_config=mt_config,
+        )
+        vec_names = [s if isinstance(s, str) else s[0] for s in COLLECTIONS_TO_FIX[name]]
+        print(f"  Created with text2vec-openai for vectors: {vec_names}")
+
+        # Legacy single vectorizer expects an unnamed vector, not the
+        # {"default": [...]} dict the snapshot stores — unwrap it on insert.
+        uses_legacy = len(COLLECTIONS_TO_FIX[name]) == 1 and COLLECTIONS_TO_FIX[name][0] == "default"
+
+        def coerce(vec):
+            if not vec:
+                return None
+            if uses_legacy and isinstance(vec, dict):
+                return vec.get("default") or None
+            return vec
+
+        collection = client.collections.get(name)
+        _insert_objects(collection, col_meta, backup_dir, coerce=coerce)
+
+    print("\n✓ Stage 2 complete")
+
+
+# ──────────────────────────── Stage 3: jeopardy ──────────────────────────────
+
+def stage3_jeopardy(client):
+    """Re-ingest JeopardyQuestion + JeopardyCategory from the canonical
+    weaviate-demo-datasets package. It ships clean ada-002 vectors AND the
+    per-object hasCategory cross-references the snapshot lost. Overwrites
+    whatever stages 1/2 produced for these two collections (intentional)."""
+    print("\n========== Stage 3: canonical Jeopardy reseed ==========")
+    import weaviate_datasets as wd
+
+    ds = wd.JeopardyQuestions10k()
+    ds.upload_dataset(client, overwrite=True, batch_size=200)
+
+    for name in ("JeopardyQuestion", "JeopardyCategory"):
+        count = client.collections.get(name).aggregate.over_all(total_count=True).total_count
+        print(f"{name}: {count} objects")
+    print("\n✓ Stage 3 complete")
+
+
+# ──────────────────────────── Shared insert path ─────────────────────────────
+
+def _insert_objects(collection, col_meta, backup_dir, coerce):
+    """Batch-insert a collection's objects from the snapshot, applying `coerce`
+    to each stored vector. Handles both multi-tenant and single-tenant layouts."""
+    if col_meta["is_multi_tenant"]:
+        tenants_info = col_meta.get("tenants", [])
+        collection.tenants.create([Tenant(name=t["tenant_name"]) for t in tenants_info])
+        print(f"  Created {len(tenants_info)} tenants")
+        for tenant_info in tenants_info:
+            tenant_name = tenant_info["tenant_name"]
+            with open(os.path.join(backup_dir, tenant_info["objects_file"])) as f:
+                objects = json.load(f)
+            tenant_col = collection.with_tenant(tenant_name)
+            with tenant_col.batch.dynamic() as batch:
+                for obj in objects:
+                    batch.add_object(
+                        properties=obj["properties"],
+                        uuid=obj["uuid"],
+                        vector=coerce(obj.get("vector")),
+                    )
+            failed = tenant_col.batch.failed_objects
+            print(f"  Tenant {tenant_name}: {len(objects)} objects ({len(failed)} batch errors)")
+            for err in failed[:3]:
+                print(f"    Error: {err.message}")
+    else:
+        with open(os.path.join(backup_dir, col_meta["objects_file"])) as f:
+            objects = json.load(f)
+        with collection.batch.dynamic() as batch:
+            for i, obj in enumerate(objects):
+                batch.add_object(
+                    properties=obj["properties"],
+                    uuid=obj["uuid"],
+                    vector=coerce(obj.get("vector")),
+                )
+                if (i + 1) % 1000 == 0:
+                    print(f"  {i+1}/{len(objects)} objects...")
+        failed = collection.batch.failed_objects
+        print(f"  Inserted {len(objects)} objects ({len(failed)} batch errors)")
+        for err in failed[:3]:
+            print(f"    Error: {err.message}")
+
+
+# ─────────────────────────────────── CLI ─────────────────────────────────────
+
+def parse_stages(value):
+    """Parse --stage ('all' or a comma-separated subset of 1,2,3) → sorted list."""
+    if value.strip().lower() == "all":
+        return [1, 2, 3]
+    stages = []
+    for part in value.split(","):
+        part = part.strip()
+        if part not in {"1", "2", "3"}:
+            raise argparse.ArgumentTypeError(f"invalid stage {part!r}; use 1, 2, 3, or 'all'")
+        stages.append(int(part))
+    return sorted(set(stages))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Restore the docs CI WCD test cluster from a snapshot.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--stage",
+        type=parse_stages,
+        default="all",
+        help="Stages to run: 'all' (default), or a comma-separated subset, e.g. '1' or '2,3'.",
+    )
+    args = parser.parse_args()
+    stages = args.stage if isinstance(args.stage, list) else parse_stages(args.stage)
+
+    need_snapshot = bool({1, 2} & set(stages))
+    need_openai = bool({2, 3} & set(stages))
+
+    required = ["WEAVIATE_URL", "WEAVIATE_API_KEY"]
+    if need_openai:
+        required.append("OPENAI_API_KEY")
+    _require_env(required)
+
+    backup_dir = resolve_backup_dir() if need_snapshot else None
+    if backup_dir:
+        print(f"Using snapshot: {backup_dir}")
+    print(f"Running stage(s): {', '.join(map(str, stages))}")
+
+    client = connect(with_openai=need_openai)
+    try:
+        if 1 in stages:
+            stage1_restore(client, backup_dir)
+        if 2 in stages:
+            stage2_repopulate(client, backup_dir)
+        if 3 in stages:
+            stage3_jeopardy(client)
+        print("\n✓ Restore finished")
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Turns the local-only WCD test-cluster restore scripts into coherent, committable tooling under `tests/backups/`.

- **Consolidated** `restore.py` + `repopulate.py` + `repopulate_jeopardy.py` into a single **`restore.py`** CLI:
  - `--stage all | 1 | 2,3` (default `all`)
  - shared connection / config / batch-insert path (no more duplicated client setup)
  - per-stage env validation (`OPENAI_API_KEY` required only for stages 2/3)
  - snapshot-dir resolution via `$WEAVIATE_BACKUP_DIR` or the newest `backup_*/` directory — no hardcoded timestamp to bump
- **Rewrote `README.md`** for the single CLI and the gitignored-snapshot model (how the snapshot is located; that it is not committed; how to obtain it).
- **Narrowed `.gitignore`** from `tests/backups/` to `tests/backups/backup_*/` so the tooling is tracked while the multi-hundred-MB snapshot data stays out of git.

All prior behavior is preserved: stage-1 idempotency, the legacy-vectorizer wire-format unwrap (`coerce`), `object[]` nested-property inference, named-vector detection, ada-002 pinning, and skipping the agents-owned collections (`ECommerce`, `Weather`, `FinancialContracts`).

## Why

These materials were gitignored, ad-hoc, and split across three scripts with duplicated logic and a hardcoded snapshot path. This makes them a single, documented entrypoint that's safe to track in the repo.

The agents-owned skip also fixes a real failure: restoring the snapshot's lossy `ECommerce` shadowed the Query Agent tests' own `text2vec-weaviate` setup and produced `WEAVIATE_NAMED_VECTOR_ERROR` / `collection_vectors: []`.

## Verification

- `py_compile` passes; `--stage` parsing correct (`all` / `1` / `2,3`; `4` rejected); `--help` renders.
- `git add -n tests/backups/` stages **only** `restore.py` + `README.md` — never the snapshot or `__pycache__`.
- Live non-destructive smoke test (`--stage 1`): auto-detected the snapshot, connected, idempotently skipped all populated collections, and skipped the three agents-owned collections.

The snapshot data itself is intentionally **not** included (it is hundreds of MB and stays gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)