### PR TITLE
docs: fix Boost API examples and supported-query list

### DIFF
--- a/_includes/code/howto/search.boost.py
+++ b/_includes/code/howto/search.boost.py
@@ -81,7 +81,7 @@ response = articles.query.near_text(
     query="transformer architectures",
     limit=5,
     # highlight-start
-    boost=Boost.property(
+    boost=Boost.numeric_property(
         "likes",
         modifier=Boost.Modifier.LOG1P,
         weight=0.7,
@@ -167,8 +167,10 @@ response = articles.query.near_text(
     limit=5,
     # highlight-start
     boost=Boost.blend(
-        Boost.time_decay("published", origin="now", scale=timedelta(days=30), weight=2.0),
-        Boost.property("likes", modifier=Boost.Modifier.LOG1P, weight=1.0),
+        [
+            Boost.time_decay("published", origin="now", scale=timedelta(days=30), weight=2.0),
+            Boost.numeric_property("likes", modifier=Boost.Modifier.LOG1P, weight=1.0),
+        ],
         weight=0.4,
         depth=200,  # rescore the top 200 vector matches
     ),
@@ -222,8 +224,10 @@ response = articles.query.hybrid(
     limit=5,
     # highlight-start
     boost=Boost.blend(
-        Boost.filter(Filter.by_property("category").equal("research"), weight=1.0),
-        Boost.filter(Filter.by_property("draft").equal(True), weight=-2.0),
+        [
+            Boost.filter(Filter.by_property("category").equal("research"), weight=1.0),
+            Boost.filter(Filter.by_property("draft").equal(True), weight=-2.0),
+        ],
         weight=0.3,
     ),
     # highlight-end

--- a/docs/weaviate/search/boost.md
+++ b/docs/weaviate/search/boost.md
@@ -16,7 +16,7 @@ import BoostPreview from '/_includes/feature-notes/boost.mdx';
 
 **Boost** soft-ranks search results — promote or demote matching documents without removing them from the result set. Matching documents move up. Non-matching documents stay in the results but rank lower.
 
-Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, and aggregate queries.
+Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, near-image, and near-media queries.
 
 ## How it works
 


### PR DESCRIPTION
## What

Fixes the Boost search docs page (`/weaviate/search/boost`) and its Python example so the example actually runs, and trims an unsupported claim.

## Changes
- **Example fixes** in `_includes/code/howto/search.boost.py`:
  - `Boost.property(...)` → `Boost.numeric_property(...)` (the `.property` factory doesn't exist on the client — the old example raised `AttributeError`)
  - `Boost.blend(cond1, cond2, ...)` → `Boost.blend([cond1, cond2], ...)` — multiple conditions must be passed as a list per the signature `Boost.blend(boosts, *, weight, depth)`; the old multi-positional form raised `TypeError`
- **Supported-query list** now includes `near-image` and `near-media` (the client supports boost on both).
- **Removed the aggregate mention** — the server accepts a boost on aggregate queries over gRPC, but no client exposes it yet, so it doesn't belong on this client-facing page.

## Verification
The corrected snippet was run end-to-end against **Weaviate 1.38.0** with the dev/1.38 Python client (which adds the Boost API): exit 0, every block executed, all inline assertions held. `yarn build-dev` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)