### PR TITLE
docs: mark Weaviate MCP server GA as of v1.38

### DIFF
--- a/_includes/feature-notes/mcp.mdx
+++ b/_includes/feature-notes/mcp.mdx
@@ -1,3 +1,0 @@
-:::caution Preview — added in `v1.37.1`
-This is a preview feature. The API may change in future releases.
-:::

--- a/_includes/feature-notes/mcp.mdx‎
+++ b/_includes/feature-notes/mcp.mdx‎
@@ -1,0 +1,2 @@
+:::info Added in `v1.38`
+:::

--- a/docs/weaviate/configuration/mcp-server.mdx
+++ b/docs/weaviate/configuration/mcp-server.mdx
@@ -22,9 +22,9 @@ faq:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-:::info Generally available
-The built-in Weaviate MCP server is generally available as of `v1.38` (introduced as a preview in `v1.37.1`). Its enable flags are runtime-configurable from `v1.38` — see [Environment variables](#environment-variables).
-:::
+import MCPPreview from "/_includes/feature-notes/mcp.mdx";
+
+<MCPPreview />
 
 The Weaviate [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server is an implementation of the open standard that enables Large Language Models (LLMs) to interact securely with your Weaviate instance.
 

--- a/docs/weaviate/configuration/mcp-server.mdx
+++ b/docs/weaviate/configuration/mcp-server.mdx
@@ -5,7 +5,7 @@ image: og/docs/configuration.jpg
 faq:
   - question: Does Weaviate offer an MCP server?
     answer: >-
-      Yes. Weaviate ships a built-in Model Context Protocol (MCP) server (preview, available from v1.37.1). Enable it with the MCP_SERVER_ENABLED=true environment variable; it runs on the same port as the REST API at /v1/mcp.
+      Yes. Weaviate ships a built-in Model Context Protocol (MCP) server (generally available as of v1.38; introduced in v1.37.1). Enable it with the MCP_SERVER_ENABLED=true environment variable; it runs on the same port as the REST API at /v1/mcp.
   - question: Is the MCP server an external library?
     answer: >-
       No — it's built into the Weaviate Server binary, not a separate package you install. Setting MCP_SERVER_ENABLED=true exposes the MCP endpoint on the same port as the REST API; nothing extra to run or deploy. The separate "Weaviate Docs MCP server" (Kapa-powered, serves documentation to LLMs) is a distinct product.
@@ -22,9 +22,9 @@ faq:
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-import MCPPreview from "/_includes/feature-notes/mcp.mdx";
-
-<MCPPreview />
+:::info Generally available
+The built-in Weaviate MCP server is generally available as of `v1.38` (introduced as a preview in `v1.37.1`). Its enable flags are runtime-configurable from `v1.38` — see [Environment variables](#environment-variables).
+:::
 
 The Weaviate [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server is an implementation of the open standard that enables Large Language Models (LLMs) to interact securely with your Weaviate instance.
 


### PR DESCRIPTION
## Mark the Weaviate MCP server GA (v1.38)

The built-in Weaviate MCP server is now **generally available as of v1.38** (introduced as a preview in v1.37.1; enable flags are runtime-configurable from v1.38). This aligns the docs with the v1.38 release announcement, which announces the MCP Server as GA.

### Changes
- `docs/weaviate/configuration/mcp-server.mdx` — replaced the `<MCPPreview />` preview caution with a GA availability `:::info` note; updated the FAQ wording from *"(preview, available from v1.37.1)"* to *"(generally available as of v1.38; introduced in v1.37.1)."*
- Removed `_includes/feature-notes/mcp.mdx` — the preview-note include, which was used only by that page (now orphaned).

### Coordination
Pairs with the v1.38 release blog post (**weaviate-io#3636**). Please **merge alongside the v1.38 release going public** — it shouldn't land ahead of the announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
