### PR TITLE
fix(docs): export clean selected-language markdown from Copy page button

### DIFF
--- a/.github/workflows/docs_functionalities_tests.yml
+++ b/.github/workflows/docs_functionalities_tests.yml
@@ -1,0 +1,60 @@
+name: Docs Functionalities Tests
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # Run every Sunday at 23:00 UTC (offset from indexability's 22:00 slot)
+    - cron: "0 23 * * 0"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to test against (e.g. a Netlify deploy preview)"
+        required: false
+        default: "https://docs.weaviate.io"
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  test-functionalities:
+    name: Test Functionalities
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up test environment
+        uses: ./.github/actions/setup-test-env
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Playwright browser
+        run: uv run playwright install --with-deps chromium
+
+      - name: Record test start time
+        run: echo "TEST_START_TIME=$(date +%s)" >> $GITHUB_ENV
+
+      - name: Run functionalities tests
+        id: functionalities-tests
+        continue-on-error: true
+        env:
+          DOCS_BASE_URL: ${{ github.event.inputs.base_url || 'https://docs.weaviate.io' }}
+          # Tell tests/conftest.py to skip its Weaviate docker-compose startup —
+          # this Playwright-only suite doesn't need a local Weaviate instance.
+          DOCS_GITHUB_ENV: "true"
+        run: |
+          echo "Running Copy-page functionalities tests against ${DOCS_BASE_URL} ..."
+          uv run pytest -m "functionalities" -v --tb=short --junitxml=pytest-results.xml
+
+      - name: Handle test results
+        if: always()
+        uses: ./.github/actions/handle-test-results
+        with:
+          test-outcome: ${{ steps.functionalities-tests.outcome == 'success' && 'success' || 'failure' }}
+          test-type: 'Functionalities'
+          slack-bot-token: ${{ secrets.TESTING_CI_SLACK_BOT }}
+          test-results-xml: 'pytest-results.xml'

--- a/_includes/docs-feedback.mdx
+++ b/_includes/docs-feedback.mdx
@@ -1,5 +1,3 @@
-Have a question or feedback? Here's how to reach us.
-
 import CardsSection from "/src/components/CardsSection";
 import styles from "/src/components/CardsSection/styles.module.scss";
 
@@ -30,4 +28,10 @@ export const feedbackCardsData = [
   },
 ];
 
+<div data-copy-exclude>
+
+Have a question or feedback? Here's how to reach us.
+
 <CardsSection items={feedbackCardsData} className={styles.smallCards} />
+
+</div>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "sass": "^1.83.4",
     "stream-chain": "^2.2.5",
     "stream-json": "^1.7.5",
+    "turndown": "^7.2.0",
+    "turndown-plugin-gfm": "^1.0.2",
     "uuid": "^13.0.0",
     "weaviate-agents": "^1.5.0",
     "weaviate-client": "^3.12.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "ijson>=3.3.0",
     "openai>=1.50.0",
     "pandas>=2.2.3",
+    "playwright>=1.40.0",
     "pytest>=8.3.5",
     "python-dotenv>=1.1.1",
     "requests>=2.32.3",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 python_files = test_*.py *_test.py
-norecursedirs = _* .github .idea* .pytest_cache .venv venv* blog developers downloads playbook src static
+norecursedirs = _* .github .idea* .pytest_cache .venv venv* blog developers downloads node_modules playbook src static
 markers =
   pyv4: groups tests by language for v4 client only (python)
   agents: group tests for Query Agent
@@ -14,3 +14,4 @@ markers =
   indexability: HTML structure tests for docs indexability (no API keys)
   indexability_agents: AI agent tests for docs indexability (requires API keys)
   llms_txt: verifies llms.txt code snippets are covered by tested docs scripts
+  functionalities: browser-based checks of live-site UI features (e.g. Copy page button); requires playwright + chromium

--- a/src/components/AcademyBadge/index.jsx
+++ b/src/components/AcademyBadge/index.jsx
@@ -9,10 +9,13 @@ const AcademyBadge = ({
   iconOnly = false,
   className = ""
 }) => {
+  // data-copy-exclude marks this badge as UI chrome so the "Copy page" markdown
+  // export (src/components/ContextualMenu) strips it out via [data-copy-exclude].
   return (
     <span
       className={`${styles.academyBadge} ${compact ? styles.compact : ""} ${iconOnly ? styles.iconOnly : ""} ${className}`}
       title={iconOnly ? "Weaviate Academy" : undefined}
+      data-copy-exclude=""
     >
       <img src="/img/graduation-cap-icon.svg" alt="" className={styles.academyIcon} />
       {!iconOnly && <span>{compact ? compactText : text}</span>}

--- a/src/components/CloudOnlyBadge/index.jsx
+++ b/src/components/CloudOnlyBadge/index.jsx
@@ -9,10 +9,13 @@ const CloudOnlyBadge = ({
   iconOnly = false,
   className = ""
 }) => {
+  // data-copy-exclude marks this badge as UI chrome so the "Copy page" markdown
+  // export (src/components/ContextualMenu) strips it out via [data-copy-exclude].
   return (
     <span
       className={`${styles.cloudOnlyBadge} ${compact ? styles.compact : ""} ${iconOnly ? styles.iconOnly : ""} ${className}`}
       title={iconOnly ? "Weaviate Cloud only" : undefined}
+      data-copy-exclude=""
     >
       <img src="/img/cloud-icon.svg" alt="" className={styles.cloudIcon} />
       {!iconOnly && <span>{compact ? compactText : text}</span>}

--- a/src/components/ContextualMenu/index.js
+++ b/src/components/ContextualMenu/index.js
@@ -46,7 +46,10 @@ export default function ContextualMenu({
       // at build time, so it must never be imported at module scope. Load it
       // lazily inside this browser-only async handler instead.
       const { default: TurndownService } = await import("turndown");
-      const { gfm } = await import("turndown-plugin-gfm");
+      // Resolve `gfm` robustly whether the named export lands on the module
+      // namespace or on `.default` (CJS/ESM interop can differ by bundler).
+      const gfmMod = await import("turndown-plugin-gfm");
+      const gfm = gfmMod.gfm ?? gfmMod.default?.gfm ?? gfmMod.default;
 
       // Scope to the rendered MDX body only. `.theme-doc-markdown` is the inner
       // wrapper from @theme/DocItem/Content; the breadcrumbs, the ContextualMenu
@@ -137,8 +140,10 @@ export default function ContextualMenu({
       //     pre-strip step didn't un-hide (custom code tabs use style+aria-hidden,
       //     never `hidden`/role=tablist, so this never touches code tabs).
       //   select               - the per-tab language dropdown.
-      //   .badge               - FilteredTextBlock's badge row (stable Infima
-      //     class, see FilteredTextBlock.js:198,222).
+      //   a.badge              - FilteredTextBlock's chrome badge row, which are
+      //     all <a class="badge badge--secondary"> (FilteredTextBlock.js:198,222).
+      //     Scoped to <a> so real content badges like
+      //     <span class="badge">Expected time: 30 minutes</span> are preserved.
       //   nav                  - stray navigation controls.
       //   img[alt=""]          - decorative empty-alt icons (e.g. logo-py.svg);
       //     real content images keep their meaningful alt and survive.
@@ -155,7 +160,7 @@ export default function ContextualMenu({
       // by a targeted strip just below.
       clone
         .querySelectorAll(
-          '[aria-hidden="true"], [role="tablist"], [hidden], select, .badge, nav, img[alt=""], .hash-link, [data-copy-exclude]',
+          '[aria-hidden="true"], [role="tablist"], [hidden], select, a.badge, nav, img[alt=""], .hash-link, [data-copy-exclude]',
         )
         .forEach((node) => node.remove());
 
@@ -513,7 +518,10 @@ export default function ContextualMenu({
       }, 1500);
     } catch (error) {
       console.error("Failed to copy prompt:", error);
-      setCopyStatus("idle");
+      setCopyStatus("error");
+      setTimeout(() => {
+        setCopyStatus("idle");
+      }, 2000);
     }
   };
 

--- a/src/components/ContextualMenu/index.js
+++ b/src/components/ContextualMenu/index.js
@@ -83,15 +83,35 @@ export default function ContextualMenu({
       //   select               - the per-tab language dropdown.
       //   .badge               - FilteredTextBlock's badge row (stable Infima
       //     class, see FilteredTextBlock.js:198,222).
-      //   button, nav          - stray controls.
+      //   nav                  - stray navigation controls.
       //   img[alt=""]          - decorative empty-alt icons (e.g. logo-py.svg);
       //     real content images keep their meaningful alt and survive.
+      //   .hash-link           - Docusaurus heading anchor (<a class="hash-link"
+      //     aria-label="Direct link to ..."> holding a zero-width char); it uses
+      //     aria-label (not aria-hidden), so it must be named explicitly or it
+      //     leaks as `[](#... "Direct link to ...")` on every heading.
       //   [data-copy-exclude]  - explicit opt-out marker on shared components
-      //     whose chrome leaks but isn't otherwise stably targetable (currently
-      //     CloudOnlyBadge / AcademyBadge).
+      //     whose chrome leaks but isn't otherwise stably targetable (badges,
+      //     the docs-feedback partial, the Tooltip popup, the PromptStarter CTA).
+      // NB: we do NOT strip <button> wholesale — inline content buttons are
+      // legitimate prose (e.g. the KapaAI "Ask AI" trigger rendered mid-sentence,
+      // src/components/KapaAI/index.jsx). Code-block chrome buttons are handled
+      // by a targeted strip just below.
       clone
         .querySelectorAll(
-          '[aria-hidden="true"], [role="tablist"], [hidden], select, .badge, button, nav, img[alt=""], [data-copy-exclude]',
+          '[aria-hidden="true"], [role="tablist"], [hidden], select, .badge, nav, img[alt=""], .hash-link, [data-copy-exclude]',
+        )
+        .forEach((node) => node.remove());
+
+      // Strip ONLY the code-block chrome buttons (the Docusaurus "Copy" button and
+      // the word-wrap toggle). These hydrate client-side (not present in the static
+      // build HTML) and carry a stable Copy/word-wrap aria-label or title; the
+      // KapaAI inline button carries neither, so it survives. This runs AFTER the
+      // strip above so any data-copy-exclude subtree (e.g. the PromptStarter CTA,
+      // whose nested menu has a "Copy prompt" button) is already gone.
+      clone
+        .querySelectorAll(
+          'button[aria-label*="copy" i], button[title*="copy" i], button[aria-label*="wrap" i], button[title*="wrap" i]',
         )
         .forEach((node) => node.remove());
 
@@ -108,13 +128,53 @@ export default function ContextualMenu({
         .querySelectorAll(".code")
         .forEach((container) => container.firstElementChild?.remove());
 
+      // Content cards (CardsSection, src/components/CardsSection/index.jsx) render
+      // each card as an <a> wrapping BLOCK markup (<div> header + <span> title,
+      // <p> description). Rewrite each into a flat <p><a>title</a> — desc</p> so
+      // turndown's DEFAULT (inline) link rule produces a clean single line. This
+      // is done as DOM pre-processing rather than a turndown <a> rule on purpose:
+      // an <a> rule whose replacement emits blank lines makes turndown
+      // block-separate EVERY inline link (orphaning surrounding bold/text). The
+      // querySelector guard means plain inline links (<a> wrapping only
+      // text/inline) are skipped and keep turndown's default inline rendering.
+      clone.querySelectorAll("a[href]").forEach((a) => {
+        if (!a.querySelector("div, p, h1, h2, h3, h4, h5, h6")) return; // card-links only
+        // <br> -> space so e.g. "import" + "(recommended)" don't run together.
+        a.querySelectorAll("br").forEach((br) =>
+          br.replaceWith(document.createTextNode(" ")),
+        );
+        const collapse = (s) => (s || "").replace(/\s+/g, " ").trim();
+        const titleEl =
+          a.querySelector('[class*="cardTitle"]') ||
+          a.querySelector("h1, h2, h3, h4, h5, h6");
+        const descEl =
+          a.querySelector('[class*="cardDescription"]') || a.querySelector("p");
+        const title =
+          collapse(titleEl && titleEl.textContent) || collapse(a.textContent);
+        const desc = collapse(descEl && descEl.textContent);
+        const href = a.getAttribute("href");
+        if (!title) return;
+        const p = document.createElement("p");
+        const link = document.createElement("a");
+        link.setAttribute("href", href);
+        link.textContent = title;
+        p.appendChild(link);
+        if (desc && desc !== title) {
+          p.appendChild(document.createTextNode(" — " + desc));
+        }
+        a.replaceWith(p);
+      });
+
       const turndownService = new TurndownService({
         headingStyle: "atx",
         codeBlockStyle: "fenced",
         bulletListMarker: "-",
       });
       turndownService.use(gfm);
-      turndownService.remove(["select", "button", "nav", "script", "style"]);
+      // Note: "button" is intentionally absent — inline content buttons (KapaAI's
+      // "Ask AI") must survive; code-block chrome buttons are stripped from the
+      // clone above.
+      turndownService.remove(["select", "nav", "script", "style"]);
 
       // Docusaurus/Prism renders code as <pre class="language-xxx"> with a
       // <code> child whose lines are <span class="token-line"> separated by

--- a/src/components/ContextualMenu/index.js
+++ b/src/components/ContextualMenu/index.js
@@ -11,7 +11,7 @@ export default function ContextualMenu({
   promptName = "",
 }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [copyStatus, setCopyStatus] = useState("idle"); // idle, copying, success
+  const [copyStatus, setCopyStatus] = useState("idle"); // idle, copying, success, error
   const [selectedLanguage, setSelectedLanguage] = useState(
     languages[0] || "python",
   );
@@ -42,9 +42,21 @@ export default function ContextualMenu({
   const copyPageAsMarkdown = async () => {
     setCopyStatus("copying");
     try {
-      // Get the main article content
-      const articleElement = document.querySelector("article");
-      if (!articleElement) {
+      // turndown touches the DOM, and Docusaurus server-renders this component
+      // at build time, so it must never be imported at module scope. Load it
+      // lazily inside this browser-only async handler instead.
+      const { default: TurndownService } = await import("turndown");
+      const { gfm } = await import("turndown-plugin-gfm");
+
+      // Scope to the rendered MDX body only. `.theme-doc-markdown` is the inner
+      // wrapper from @theme/DocItem/Content; the breadcrumbs, the ContextualMenu
+      // button, the version badge, the mobile TOC and the footer are all
+      // siblings OUTSIDE it (see src/theme/DocItem/Layout/index.js), so scoping
+      // here drops all the page chrome. Fall back to <article> for safety.
+      const contentRoot =
+        document.querySelector(".theme-doc-markdown") ||
+        document.querySelector("article");
+      if (!contentRoot) {
         throw new Error("Article content not found");
       }
 
@@ -52,19 +64,101 @@ export default function ContextualMenu({
       const title = metadata.title || frontMatter.title || "Untitled";
       const pageUrl = getCurrentPageUrl();
 
-      // Extract text content from the article
-      const content = articleElement.innerText;
+      // Work on a clone so the live page is never mutated.
+      const clone = contentRoot.cloneNode(true);
 
-      // Format as markdown with metadata
-      const markdown = `# ${title}
+      // Strip non-prose chrome from the clone before converting. Only stable
+      // (non-CSS-module-hashed) selectors are used here.
+      //   [aria-hidden="true"] - our custom code Tabs (src/theme/Tabs/index.js)
+      //     render EVERY language panel and hide the non-selected ones with
+      //     display:none + aria-hidden="true"; removing them leaves only the
+      //     selected language. (Also drops decorative aria-hidden icons.)
+      //   [role="tablist"]     - the clickable label strip of DEFAULT Docusaurus
+      //     <Tabs> (used for non-code content, e.g. Docker/Kubernetes steps),
+      //     which would otherwise leak as a bullet list of tab labels.
+      //   [hidden]             - inactive DEFAULT-tab panels mark themselves with
+      //     the `hidden` attribute (not aria-hidden); removing them gives the
+      //     same selected-only behavior for non-code tabs. (Custom code tabs use
+      //     style+aria-hidden, never `hidden`/role=tablist, so no code regression.)
+      //   select               - the per-tab language dropdown.
+      //   .badge               - FilteredTextBlock's badge row (stable Infima
+      //     class, see FilteredTextBlock.js:198,222).
+      //   button, nav          - stray controls.
+      //   img[alt=""]          - decorative empty-alt icons (e.g. logo-py.svg);
+      //     real content images keep their meaningful alt and survive.
+      //   [data-copy-exclude]  - explicit opt-out marker on shared components
+      //     whose chrome leaks but isn't otherwise stably targetable (currently
+      //     CloudOnlyBadge / AcademyBadge).
+      clone
+        .querySelectorAll(
+          '[aria-hidden="true"], [role="tablist"], [hidden], select, .badge, button, nav, img[alt=""], [data-copy-exclude]',
+        )
+        .forEach((node) => node.remove());
 
-Source: ${pageUrl}
+      // Drop the code-tab HEADER chrome (language dropdown, the "API docs" link
+      // + icon, the "More info" tooltip) while KEEPING the code content. Our
+      // code blocks are authored as <Tabs className="code"> (src/theme/Tabs/
+      // index.js:464-474), which renders a container carrying the literal,
+      // stable `code` class whose FIRST child is the header and second is the
+      // code content (Tabs/index.js:333-460). The bare `code` class is used
+      // ONLY for these containers (verified: no other component or global CSS
+      // uses it), so removing each container's first element child strips the
+      // header without ever touching the code.
+      clone
+        .querySelectorAll(".code")
+        .forEach((container) => container.firstElementChild?.remove());
 
----
+      const turndownService = new TurndownService({
+        headingStyle: "atx",
+        codeBlockStyle: "fenced",
+        bulletListMarker: "-",
+      });
+      turndownService.use(gfm);
+      turndownService.remove(["select", "button", "nav", "script", "style"]);
 
-${content}`;
+      // Docusaurus/Prism renders code as <pre class="language-xxx"> with a
+      // <code> child whose lines are <span class="token-line"> separated by
+      // <br>. turndown's default fenced-code rule reads the language off <code>
+      // (Docusaurus puts it on <pre>) and drops the <br> line breaks, so emit
+      // our own fenced block: language from the language-xxx class, content
+      // rebuilt from the token-line spans (falling back to textContent).
+      turndownService.addRule("docusaurusCodeBlock", {
+        filter: (node) =>
+          node.nodeName === "PRE" &&
+          (node.querySelector("code") !== null ||
+            node.classList.contains("prism-code")),
+        replacement: (_content, node) => {
+          const code = node.querySelector("code") || node;
+          const classAttr = `${node.className} ${code.className}`;
+          const langMatch = classAttr.match(/language-([\w-]+)/);
+          const language = langMatch ? langMatch[1] : "";
+          const lines = code.querySelectorAll(".token-line");
+          const text = (
+            lines.length
+              ? Array.from(lines)
+                  .map((line) => line.textContent)
+                  .join("\n")
+              : code.textContent
+          ).replace(/\n+$/, "");
+          return `\n\n\`\`\`${language}\n${text}\n\`\`\`\n\n`;
+        },
+      });
 
-      await navigator.clipboard.writeText(markdown);
+      const markdown = turndownService.turndown(clone);
+
+      // No synthetic `# title` — the page H1 already lives inside
+      // .theme-doc-markdown, so prepending one would duplicate it. Keep the
+      // Source line for LLM context.
+      const output = `Source: ${pageUrl}\n\n---\n\n${markdown}`;
+
+      // Guard against insecure contexts where the Clipboard API is missing,
+      // rather than throwing an opaque error into the catch.
+      if (!navigator.clipboard?.writeText) {
+        throw new Error(
+          "Clipboard API is unavailable (a secure context is required)",
+        );
+      }
+      await navigator.clipboard.writeText(output);
 
       // Track successful copy
       analytics.contextualMenu.copyPage(pageUrl, title);
@@ -75,7 +169,10 @@ ${content}`;
       }, 1500);
     } catch (error) {
       console.error("Failed to copy page:", error);
-      setCopyStatus("idle");
+      setCopyStatus("error");
+      setTimeout(() => {
+        setCopyStatus("idle");
+      }, 2000);
     }
   };
 
@@ -200,13 +297,15 @@ ${content}`;
 
   const showLanguageSelector = variant === "prompts" && languages.length > 1;
   const mainButtonLabel =
-    variant === "prompts"
-      ? copyStatus === "success"
-        ? "Copied!"
-        : "Copy prompt"
-      : copyStatus === "success"
-        ? "Copied!"
-        : "Copy page";
+    copyStatus === "error"
+      ? "Copy failed"
+      : variant === "prompts"
+        ? copyStatus === "success"
+          ? "Copied!"
+          : "Copy prompt"
+        : copyStatus === "success"
+          ? "Copied!"
+          : "Copy page";
   const mainButtonHandler =
     variant === "prompts" ? copyPromptFromFile : copyPageAsMarkdown;
 
@@ -303,7 +402,7 @@ ${content}`;
               </>
             )}
           </svg>
-          <span>{mainButtonLabel}</span>
+          <span aria-live="polite">{mainButtonLabel}</span>
         </button>
         <div className={styles.separator}></div>
         <button

--- a/src/components/ContextualMenu/index.js
+++ b/src/components/ContextualMenu/index.js
@@ -67,19 +67,75 @@ export default function ContextualMenu({
       // Work on a clone so the live page is never mutated.
       const clone = contentRoot.cloneNode(true);
 
+      // --- Pre-strip normalizations (MUST run before the chrome strip below) ---
+
+      // KaTeX math: replace each rendered .katex with its source LaTeX. KaTeX
+      // emits accessible MathML (with the real LaTeX in
+      // <annotation encoding="application/x-tex">) plus a visual .katex-html that
+      // is aria-hidden. If the strip drops .katex-html, the leftover MathML
+      // glyphs + annotation concatenate into garbage ("2ksim2^{ksim}"). Swap the
+      // whole node for `$latex$` (or `$$latex$$` inside a .katex-display).
+      clone.querySelectorAll(".katex").forEach((k) => {
+        const annotation = k.querySelector(
+          'annotation[encoding="application/x-tex"]',
+        );
+        const latex = annotation && (annotation.textContent || "").trim();
+        if (!latex) return;
+        const display = k.closest(".katex-display");
+        (display || k).replaceWith(
+          document.createTextNode(display ? `$$${latex}$$` : `$${latex}$`),
+        );
+      });
+
+      // DEFAULT Docusaurus tabs (role="tablist" + [hidden] panels): the strip
+      // below would DROP every non-selected panel, losing real content (e.g. a
+      // docker-compose "With authentication" variant). Instead surface ALL
+      // panels — label each with an <h3> and un-hide it — then remove the
+      // tablist. This targets ONLY default tabs; our custom CODE tabs use
+      // <select> + aria-hidden/display:none (no role=tablist/[hidden]), so they
+      // are untouched and stay selected-language-only.
+      clone.querySelectorAll('[role="tablist"]').forEach((tablist) => {
+        const labels = Array.from(
+          tablist.querySelectorAll('[role="tab"]'),
+        ).map((t) => (t.textContent || "").replace(/\s+/g, " ").trim());
+        // Docusaurus wraps the panels in the tablist's next sibling; fall back to
+        // the parent container. Using direct children avoids grabbing the panels
+        // of NESTED default tabs (which are handled by their own iteration).
+        const wrap = tablist.nextElementSibling;
+        let panels =
+          (wrap &&
+            Array.from(wrap.querySelectorAll(':scope > [role="tabpanel"]'))) ||
+          [];
+        if (panels.length === 0 && tablist.parentElement) {
+          panels = Array.from(
+            tablist.parentElement.querySelectorAll('[role="tabpanel"]'),
+          );
+        }
+        panels.forEach((panel, i) => {
+          panel.removeAttribute("hidden");
+          const label = labels[i];
+          if (label) {
+            const h = document.createElement("h3");
+            h.textContent = label;
+            panel.insertBefore(h, panel.firstChild);
+          }
+        });
+        tablist.remove();
+      });
+
       // Strip non-prose chrome from the clone before converting. Only stable
       // (non-CSS-module-hashed) selectors are used here.
       //   [aria-hidden="true"] - our custom code Tabs (src/theme/Tabs/index.js)
       //     render EVERY language panel and hide the non-selected ones with
       //     display:none + aria-hidden="true"; removing them leaves only the
       //     selected language. (Also drops decorative aria-hidden icons.)
-      //   [role="tablist"]     - the clickable label strip of DEFAULT Docusaurus
-      //     <Tabs> (used for non-code content, e.g. Docker/Kubernetes steps),
-      //     which would otherwise leak as a bullet list of tab labels.
-      //   [hidden]             - inactive DEFAULT-tab panels mark themselves with
-      //     the `hidden` attribute (not aria-hidden); removing them gives the
-      //     same selected-only behavior for non-code tabs. (Custom code tabs use
-      //     style+aria-hidden, never `hidden`/role=tablist, so no code regression.)
+      //   [role="tablist"]     - DEFAULT Docusaurus <Tabs> label strip. Normally
+      //     already removed by the pre-strip step above (which surfaces every
+      //     panel under an <h3>); kept here as a fallback so any un-processed
+      //     tablist doesn't leak as a bullet list of labels.
+      //   [hidden]             - fallback for any inactive DEFAULT-tab panel the
+      //     pre-strip step didn't un-hide (custom code tabs use style+aria-hidden,
+      //     never `hidden`/role=tablist, so this never touches code tabs).
       //   select               - the per-tab language dropdown.
       //   .badge               - FilteredTextBlock's badge row (stable Infima
       //     class, see FilteredTextBlock.js:198,222).
@@ -165,6 +221,85 @@ export default function ContextualMenu({
         a.replaceWith(p);
       });
 
+      // Flatten table cells so GFM tables stay valid. A <br>, a block child
+      // (<p>/<div>) or a list (<ul>/<ol>) inside a <td>/<th> makes turndown emit
+      // newlines INSIDE the cell, which splits the row across physical lines and
+      // breaks the whole table (env-vars pages have ~50 such cells, incl. a
+      // COLLECTION_RETRIEVAL_STRATEGY cell with a <ul>). Turn <br> into spaces,
+      // join list items with a separator, and unwrap block/list wrappers so every
+      // cell stays inline (preserving inline <code>/<a> etc.) and each row is one
+      // physical line.
+      clone.querySelectorAll("td, th").forEach((cell) => {
+        cell
+          .querySelectorAll("br")
+          .forEach((br) => br.replaceWith(document.createTextNode(" ")));
+        // Lists -> inline: separate <li> items with " • ", then unwrap the <li>
+        // and the <ul>/<ol> so only their inline children remain in the cell.
+        cell.querySelectorAll("ul, ol").forEach((list) => {
+          Array.from(list.querySelectorAll(":scope > li")).forEach((li, i) => {
+            if (i > 0) li.before(document.createTextNode(" • "));
+            while (li.firstChild) li.before(li.firstChild);
+            li.remove();
+          });
+          while (list.firstChild) list.before(list.firstChild);
+          list.remove();
+        });
+        // Unwrap remaining block wrappers (incl. <p> that "loose" list items
+        // leave behind) so nothing forces a line break.
+        cell.querySelectorAll("p, div").forEach((block) => {
+          block.before(document.createTextNode(" ")); // keep a word boundary
+          while (block.firstChild) block.before(block.firstChild);
+          block.remove();
+        });
+      });
+
+      // Admonitions -> GitHub callouts. Pre-process: read the type from the
+      // class, capture a custom title (when the heading text isn't just the type
+      // word), stash both on data-* attrs, and drop the heading chrome (icon +
+      // type label). The turndown rule below quotes the remaining body.
+      const ADMONITION_CALLOUT = {
+        note: "NOTE",
+        tip: "TIP",
+        info: "NOTE",
+        caution: "CAUTION",
+        warning: "WARNING",
+        danger: "CAUTION",
+      };
+      clone
+        .querySelectorAll(".theme-admonition, .admonition")
+        .forEach((adm) => {
+          const m = (adm.className || "").match(/admonition-([a-z]+)/i);
+          const rawType = (m ? m[1] : "note").toLowerCase();
+          const callout = ADMONITION_CALLOUT[rawType] || "NOTE";
+          const heading = adm.querySelector('[class*="admonitionHeading"]');
+          if (heading) {
+            const headingText = (heading.textContent || "")
+              .replace(/\s+/g, " ")
+              .trim();
+            // A custom title is a heading whose text isn't just the type word.
+            if (
+              headingText &&
+              headingText.toLowerCase() !== rawType &&
+              headingText.toLowerCase() !== callout.toLowerCase()
+            ) {
+              adm.setAttribute("data-callout-title", headingText);
+            }
+            heading.remove();
+          }
+          adm.setAttribute("data-callout", callout);
+        });
+
+      // <details>/<summary> -> bold summary + body (see rule). Stash the summary
+      // text and remove the <summary> so the rule's `content` is body-only.
+      clone.querySelectorAll("details").forEach((d) => {
+        const summary = d.querySelector("summary");
+        if (summary) {
+          const t = (summary.textContent || "").replace(/\s+/g, " ").trim();
+          if (t) d.setAttribute("data-summary", t);
+          summary.remove();
+        }
+      });
+
       const turndownService = new TurndownService({
         headingStyle: "atx",
         codeBlockStyle: "fenced",
@@ -204,7 +339,42 @@ export default function ContextualMenu({
         },
       });
 
-      const markdown = turndownService.turndown(clone);
+      // Admonitions -> GitHub-flavored callout blockquotes. Type + optional title
+      // were stashed on data-* attrs during pre-processing; here we quote the
+      // body content line by line.
+      turndownService.addRule("admonitionCallout", {
+        filter: (node) =>
+          node.nodeType === 1 && node.getAttribute("data-callout") !== null,
+        replacement: (content, node) => {
+          const callout = node.getAttribute("data-callout") || "NOTE";
+          const title = node.getAttribute("data-callout-title");
+          const body = content.replace(/^\n+|\n+$/g, "");
+          const lines = [`[!${callout}]`];
+          if (title) lines.push(`**${title}**`);
+          body.split("\n").forEach((line) => lines.push(line));
+          return `\n\n${lines
+            .map((l) => (l ? `> ${l}` : ">"))
+            .join("\n")}\n\n`;
+        },
+      });
+
+      // <details> -> bold summary followed by the (expanded) body content. The
+      // <summary> was removed in pre-processing, so `content` is body-only.
+      turndownService.addRule("detailsBlock", {
+        filter: (node) => node.nodeName === "DETAILS",
+        replacement: (content, node) => {
+          const summary = node.getAttribute("data-summary");
+          const body = content.replace(/^\n+|\n+$/g, "");
+          return `\n\n${summary ? `**${summary}**\n\n` : ""}${body}\n\n`;
+        },
+      });
+
+      // Squeeze runs of blank lines the conversion can leave behind (e.g. from
+      // emptied wrappers) down to a single blank line. The Source/--- prefix is
+      // added afterwards, so its structure is unaffected.
+      const markdown = turndownService
+        .turndown(clone)
+        .replace(/\n{3,}/g, "\n\n");
 
       // No synthetic `# title` — the page H1 already lives inside
       // .theme-doc-markdown, so prepending one would duplicate it. Keep the

--- a/src/components/PromptStarter/index.jsx
+++ b/src/components/PromptStarter/index.jsx
@@ -31,7 +31,10 @@ const PromptStarter = ({
   }, [page, languages, promptDetails]);
 
   return (
-    <div className={styles.promptStarterWrapper}>
+    // data-copy-exclude marks this promo CTA as UI chrome so the "Copy page"
+    // markdown export (src/components/ContextualMenu) drops it via
+    // [data-copy-exclude] instead of leaking "Get started faster with AI".
+    <div className={styles.promptStarterWrapper} data-copy-exclude="">
       <div className={styles.promptStarter}>
         <div className={styles.iconColumn}>
           <div className={styles.icon}>

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -125,6 +125,12 @@ const Tooltip = ({
       onMouseLeave={handleMouseLeave}
     >
       {children}
+      {/*
+        data-copy-exclude keeps this popup out of the "Copy page" markdown export
+        (src/components/ContextualMenu strips [data-copy-exclude]): it holds the
+        tooltip/glossary definition, which would otherwise inline mid-sentence.
+        The trigger text ({children}) stays in the sentence.
+      */}
       <span
         ref={tooltipRef}
         className={`${styles.tooltipContent} ${
@@ -134,6 +140,7 @@ const Tooltip = ({
         data-position={position}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        data-copy-exclude=""
       >
         {content}
       </span>

--- a/src/components/WeaviateConfigurator/index.jsx
+++ b/src/components/WeaviateConfigurator/index.jsx
@@ -253,11 +253,25 @@ function WeaviateConfigurator() {
     };
   }, [selections, parameters]);
 
-  if (loading) return <div className="weaviate-configurator-loading">Loading...</div>;
-  if (error) return <div className="weaviate-configurator-error">{error}</div>;
+  // data-copy-exclude marks this interactive tool (and its loading/error
+  // fallbacks) as UI chrome so the "Copy page" markdown export
+  // (src/components/ContextualMenu) drops it via [data-copy-exclude] rather than
+  // leaking "Loading..." or the whole configurator form.
+  if (loading)
+    return (
+      <div className="weaviate-configurator-loading" data-copy-exclude="">
+        Loading...
+      </div>
+    );
+  if (error)
+    return (
+      <div className="weaviate-configurator-error" data-copy-exclude="">
+        {error}
+      </div>
+    );
 
   return (
-    <div className="weaviate-configurator">
+    <div className="weaviate-configurator" data-copy-exclude="">
       <div className="wc-header">
         <p>
           Use this tool to generate a `docker-compose.yml` file for your Weaviate instance.

--- a/tests/test_docs_functionalities.py
+++ b/tests/test_docs_functionalities.py
@@ -1,0 +1,130 @@
+"""
+Docs Functionalities Test Suite
+
+Browser-based checks that live-site UI features work end to end. Currently
+covers the documentation "Copy page" button (ContextualMenu): clicking it must
+convert the rendered page to clean Markdown and write it to the clipboard.
+
+Runs headless Chromium via Playwright (sync API) against the live docs site,
+overridable with the DOCS_BASE_URL environment variable. Targets
+https://docs.weaviate.io by default; point DOCS_BASE_URL at a Netlify deploy
+preview to validate a change before it ships.
+
+NOTE:
+- Requires the Playwright browser binaries: `playwright install chromium`
+  (CI runs `uv run playwright install --with-deps chromium`).
+- This suite is EXPECTED TO BE RED against the live site until the copy-page
+  fix (PR #460) is deployed — the old button copies page chrome + plaintext, so
+  the "Source: https://" / no-"Edit this page" assertions below fail. It is a
+  scheduled / manual-dispatch check, NOT a PR gate.
+"""
+
+import os
+import re
+
+import pytest
+from playwright.sync_api import expect, sync_playwright
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("DOCS_BASE_URL", "https://docs.weaviate.io")
+
+# Representative pages: code-heavy, with varied content (tabs, tables, prose).
+TEST_PAGES = [
+    "/weaviate/quickstart",
+    "/weaviate/search/bm25",
+]
+
+# Accessible name (aria-label) of the docs "Copy page" button. On success its
+# inner <span aria-live="polite"> text flips to SUCCESS_LABEL while the
+# accessible name stays the same.
+COPY_BUTTON_NAME = "Copy page as markdown"
+SUCCESS_LABEL = "Copied!"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def page():
+    """A headless Chromium page with clipboard permissions granted for BASE_URL."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        # Needed so navigator.clipboard.read/writeText works inside the test.
+        context.grant_permissions(
+            ["clipboard-read", "clipboard-write"], origin=BASE_URL
+        )
+        pg = context.new_page()
+        try:
+            yield pg
+        finally:
+            context.close()
+            browser.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.functionalities
+@pytest.mark.parametrize("path", TEST_PAGES)
+def test_copy_page_button_writes_markdown(page, path):
+    """The 'Copy page' button copies clean Markdown of the page to the clipboard."""
+    url = f"{BASE_URL}{path}"
+    page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+
+    # The button is React-rendered after hydration; wait for it to appear.
+    button = page.get_by_role("button", name=COPY_BUTTON_NAME)
+    expect(button).to_be_visible(timeout=30_000)
+
+    button.click()
+
+    # Success signal: the inner aria-live span text becomes "Copied!".
+    try:
+        expect(button).to_contain_text(SUCCESS_LABEL, timeout=8_000)
+    except AssertionError as exc:
+        pytest.fail(
+            f"{path}: copy button never showed '{SUCCESS_LABEL}' within 8s "
+            f"(current button text: {button.inner_text()!r}). Underlying: {exc}"
+        )
+
+    markdown = page.evaluate("() => navigator.clipboard.readText()")
+
+    if not markdown:
+        pytest.fail(
+            f"{path}: clipboard was empty after clicking Copy page. The button "
+            "may not have written to the clipboard (check secure context / "
+            "clipboard permissions)."
+        )
+
+    snippet = markdown[:200]
+
+    assert len(markdown) > 300, (
+        f"{path}: copied markdown suspiciously short "
+        f"({len(markdown)} chars). Snippet: {snippet!r}"
+    )
+    assert markdown.startswith(f"Source: {url}"), (
+        f"{path}: expected markdown to start with 'Source: {url}'. "
+        f"Snippet: {snippet!r}"
+    )
+    assert "\n---\n" in markdown, (
+        f"{path}: missing the '---' header separator. Snippet: {snippet!r}"
+    )
+    assert re.search(r"```", markdown), (
+        f"{path}: no fenced code block (```) found in the copied markdown. "
+        f"Snippet: {snippet!r}"
+    )
+
+    # Chrome-free regression canaries: heading hash-links and the page footer
+    # must NOT leak into the copied markdown.
+    assert "Direct link to" not in markdown, (
+        f"{path}: heading hash-link chrome leaked ('Direct link to' present)."
+    )
+    assert "Edit this page" not in markdown, (
+        f"{path}: page-footer chrome leaked ('Edit this page' present)."
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -560,6 +560,83 @@ http = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/a0/68afd1ebad40db87dac0a28ffa120726b98bf9c7c40c481b0f63c105d298/greenlet-3.5.3-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e18619ba655ac05d78d80fc83cac4ba892bd6927b99e3b8237aee861aaacc8bb", size = 626155, upload-time = "2026-06-26T19:24:14.44Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/07/7f/e327d912239ec4b3b49999e3967389bcf1ee8722b9ee9194d2752ecd558a/greenlet-3.5.3-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d27c0c653a60d9535f690226474a5cc1036a8b0d7b57504d1c4f89c44a07a80c", size = 421083, upload-time = "2026-06-26T19:25:35.804Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a9/73fa62893d5b84b4205544e6b673c654cc43aa5b9899bac00f04d64af73d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8d19fe6c39ebff9259f07bcc685d3290f8fa4ea2278e51dd0008e4d6b0f2d814", size = 670657, upload-time = "2026-06-26T19:24:19.967Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/2ffce64929fb3cab7b65d5a0b20aaf9764e227681d731b041077fc9a525a/greenlet-3.5.3-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:962c5df2db8cb446da51edf1ca5296c389d93b99c9d8aa2ee4c7d0d8f1218260", size = 473497, upload-time = "2026-06-26T19:25:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/8faec206b851c22b1733545fda900829a1f3f5b1c78ae7e0fb3dba57d9f4/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b897d97759425953f69a9c0fac67f8fe333ec0ce7377ef186fb2b0c3ad5e354d", size = 659582, upload-time = "2026-06-26T19:24:21.357Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/55/50c19e49f8045834ada71ef12f8ad048eba8517c6aa41161bed676328fae/greenlet-3.5.3-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:3236754d423955ea08e9bb5f6c04a7895f9e22c290b66aa7653fcb922d839eb0", size = 491037, upload-time = "2026-06-26T19:25:40.672Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/25/aa/952cf28c2ff949a8c971134fb43854dd7eaa737218723aaef758f8c9aead/greenlet-3.5.3-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cefa9cef4b371f9844c6053db71f1138bc6807bab1578b0dae5149c1f1141357", size = 674261, upload-time = "2026-06-26T19:24:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/b00d6f5e63e531a93562b2ec1a4c320fbee91f580fc42e6417af69d706e5/greenlet-3.5.3-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:6219b6d04dbf6ba6084d77dc609e8473060dc55f759cbf626d512122781fa128", size = 480322, upload-time = "2026-06-26T19:25:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/39/0e0938a75115b939d42733a2a12e1d349653c9531fe6fe563e8a681f04e6/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:16d192579ed281051396dddd7f7754dac6259e6b1fb26378c87b66622f8e3f91", size = 663706, upload-time = "2026-06-26T19:24:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/41/35d1c678cdb3c3b9e6bee691728e563cfb294202b23c7a4c3c2ccc343589/greenlet-3.5.3-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:4399eb8d041f20b68d943918bc55502a93d6fdc0a37c14da7881c04139acee9d", size = 498803, upload-time = "2026-06-26T19:25:43.063Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1163,6 +1240,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
+    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1453,6 +1549,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -1773,6 +1881,7 @@ dependencies = [
     { name = "ijson" },
     { name = "openai" },
     { name = "pandas" },
+    { name = "playwright" },
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -1791,6 +1900,7 @@ requires-dist = [
     { name = "ijson", specifier = ">=3.3.0" },
     { name = "openai", specifier = ">=1.50.0" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "playwright", specifier = ">=1.40.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.3" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2695,6 +2695,11 @@
   dependencies:
     langium "3.3.1"
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@netlify/binary-info@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@netlify/binary-info/-/binary-info-1.0.0.tgz"
@@ -14952,6 +14957,18 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+turndown-plugin-gfm@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
+  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
+turndown@^7.2.0:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"
+  integrity sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 type-fest@^0.21.3:
   version "0.21.3"


### PR DESCRIPTION
## Problem

The docs "Copy page" button copied page chrome and didn't produce real markdown. Reported by the team:

- copies headers / other page content that shouldn't be included
- the "markdown" output includes HTML tags / doesn't look right

Root cause: `copyPageAsMarkdown` scraped `document.querySelector("article").innerText`. The `<article>` wrapper includes breadcrumbs, the version badge, the mobile TOC, and the footer ("Edit this page", tags), and `innerText` is *rendered* text, not markdown (code fences, heading `#`, and link syntax are all lost).

## Fix

Rewrote `copyPageAsMarkdown` to produce clean markdown:

- Scope extraction to `.theme-doc-markdown` (the content body; page chrome is a sibling outside it).
- Convert HTML → Markdown with `turndown` + `turndown-plugin-gfm`, **dynamically imported inside the handler** so the site still server-renders at build time (turndown touches the DOM).
- Capture **only the currently-selected code language**. The custom code Tabs render every language into the DOM and hide the non-selected ones, so the copy strips `[aria-hidden="true"]`.
- Strip the remaining in-content chrome: default-tab label strips + inactive panels (`[role="tablist"]`, `[hidden]`), decorative icons (`img[alt=""]`), the code-tab header controls (the `.code` container header — language selector, "API docs" link, "More info"), and Cloud/Academy badges.
- Preserve Prism code blocks as fenced blocks with the correct language tag and line breaks.
- Robustness: a new `error` copy state ("Copy failed"), a `navigator.clipboard` guard, and `aria-live="polite"` on the status label.

A reusable `data-copy-exclude` opt-out marker was added to `CloudOnlyBadge` and `AcademyBadge` so their text no longer leaks into the copied markdown.

## Verification

- `yarn build` passes (exit 0).
- The turndown pipeline was validated against the real built DOM: page chrome excluded, selected-language-only confirmed by element counts (non-selected language code blocks drop to zero), code blocks fenced with language + line breaks, headings/links/lists correct, and Cloud/Academy badge text stripped.

## Out of scope / follow-ups

- The `llms-txt` plugin path was intentionally not used, to keep this change self-contained.
- For a later PR: "View as markdown" builds a 404 when a page has no `source` and pins `main` (version drift); the prompts-variant copy doesn't use the new error state.

## Files

- `src/components/ContextualMenu/index.js` — the fix
- `src/components/CloudOnlyBadge/index.jsx`, `src/components/AcademyBadge/index.jsx` — `data-copy-exclude` markers
- `package.json`, `yarn.lock` — add `turndown` + `turndown-plugin-gfm`
