### PR TITLE
fix(docs): resolve ||site.*|| version tokens in imported _includes partials

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,6 +34,16 @@ const config = {
       onBrokenMarkdownImages: "throw",
     },
     mermaid: true,
+    // Interpolate ||site.*|| tokens on raw file content, for every md/mdx file.
+    // The remark-replace plugin below only runs on docs pages; partials imported
+    // from _includes/ are compiled by Docusaurus' MDX *fallback* loader, which
+    // does not receive the docs preset's remarkPlugins, so ||site.*|| tokens in
+    // those partials (e.g. code snippets in the quickstart install tabs) were
+    // never interpolated. This preprocessor covers every file, including
+    // fallback-loaded partials. It shares one implementation with the plugin and
+    // is idempotent, so it does not affect pages the plugin already handles.
+    preprocessor: ({ fileContent, filePath }) =>
+      remarkReplace.replaceSiteTokens(fileContent, filePath),
   },
 
   i18n: {

--- a/src/remark/remark-replace.js
+++ b/src/remark/remark-replace.js
@@ -15,17 +15,24 @@ const siteConfig = readSiteConfig();
 // pattern to match: ||site.some_name|| in markdown
 const pattern = /[|]{2}[ ]*site\.([a-z_]*)[ ]*[|]{2}/g
 
-const interpolate = (value, vfile) => {
+// Shared token replacement. Used by the remark plugin (below) for docs pages,
+// and by the site's markdown.preprocessor (docusaurus.config.js) so that the
+// same ||site.*|| interpolation also runs on imported partials from _includes/,
+// which are compiled by Docusaurus' MDX *fallback* loader and therefore never
+// see this remark plugin. Keeping one implementation avoids drift.
+const replaceSiteTokens = (value, sourcePath) => {
   // replace the pattern with config variables
   return value.replaceAll(pattern, (_, name) => {
     // display a warning if config variable is missing
     if (siteConfig[name] == undefined) {
-      console.warn('\x1b[33m%s', vfile.path, '\x1b[0m');
+      console.warn('\x1b[33m%s', sourcePath, '\x1b[0m');
       console.warn(`Couldn't find`, '\x1b[31m', `||site.${name}||`, '\x1b[0m');
     }
     return siteConfig[name]
   })
 }
+
+const interpolate = (value, vfile) => replaceSiteTokens(value, vfile.path)
 
 const valueNodes = ['text', 'jsx', 'code', 'inlineCode'];
 const valueNodeFilter = (node) => 
@@ -51,3 +58,6 @@ const plugin = (options) => {
 };
 
 module.exports = plugin;
+// Exposed so docusaurus.config.js `markdown.preprocessor` can reuse the exact
+// same interpolation on raw file content (covers fallback-loaded partials).
+module.exports.replaceSiteTokens = replaceSiteTokens;


### PR DESCRIPTION
## Problem

`||site.java_client_version||` rendered as a literal token (instead of the version) on 5 pages — `cloud/quickstart`, `weaviate/quickstart`, `cloud/embeddings/quickstart`, `weaviate/quickstart/local`, `weaviate/tutorials/quick-tour-of-weaviate`. It was the only unresolved `||site.*||` token in the whole build.

## Root cause

`remark-replace` (which interpolates `||site.*||`) is registered only in the **docs preset's `remarkPlugins`**, which apply to files inside the docs plugin's content dirs. Partials imported from `_includes/` are outside those dirs, so Docusaurus compiles them with its **MDX *fallback* loader** — which is not passed any `remarkPlugins`. As a result, `remark-replace` never ran on partials, and any `||site.*||` token in a partial (here, the Java Maven `<version>` in the quickstart install tabs) stayed literal. (The same token resolves on the Java client-library docs page only because that's a docs page, not a partial.)

## Fix

Route the same interpolation through the global `markdown.preprocessor` hook, which runs on the raw content of **every** md/mdx file, including fallback-loaded partials:

- `src/remark/remark-replace.js`: extract the interpolation into a shared, exported `replaceSiteTokens(value, sourcePath)` (single source of truth; the remark plugin now delegates to it — behavior unchanged).
- `docusaurus.config.js`: add `markdown.preprocessor` that calls `replaceSiteTokens` on each file's content.

Raw-content replacement is a superset of the plugin's node-scoped replacement and is idempotent, so no previously-resolving token can stop resolving.

## Verification

`yarn build` exits 0. All 5 target pages now render the resolved Java version; no `||site.*||` token leaks anywhere in the build; and previously-resolving tokens (`weaviate_version`, `python_client_version`, `typescript_client_version`, the Java docs page) still resolve with no regressions.
