### PR TITLE
fix(ci): unblock docs CI — use GITHUB_TOKEN for version fetch + skip bot-blocked link

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     env:
-      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+      GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_BOT: ${{ secrets.SLACK_BOT }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       GOOGLE_CONTAINER_ID: ${{ secrets.GOOGLE_CONTAINER_ID }}
@@ -26,7 +26,7 @@ jobs:
           yarn install
       - name: Update versions from GitHub
         env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node _build_scripts/update-config-versions.js
       - name: Build Docusarus project

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -21,7 +21,7 @@ jobs:
           yarn install
       - name: Update versions from GitHub
         env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node _build_scripts/update-config-versions.js
       - name: Build a dev version

--- a/_build_scripts/link-validator.js
+++ b/_build_scripts/link-validator.js
@@ -51,6 +51,7 @@ const domainsToIgnore = [
     'https://static.scarf.sh',
     'https://www.snowflake.com',
     'https://stackoverflow.com/',
+    'https://www.tim-kleyersburg.de/', // 403s automated requests (site loads fine in a browser); community PHP client author link
     'https://towardsdatascience.com/',
     'https://voyageai.com/',
     'https://weaviateagents.featurebase.app',


### PR DESCRIPTION
## What was broken

Every docs PR's **PR links validation** check was failing, and so was the path used by production **Build and deploy**. Two independent causes:

### 1. Expired `GH_API_TOKEN` (the real blocker)
The custom PAT in `secrets.GH_API_TOKEN` expired/was revoked. `_build_scripts/update-config-versions.js` sent `Bearer <expired>` to the GitHub API, got **401 Unauthorized**, exhausted its retries, and killed the job at the *Update versions from GitHub* step — **before link validation ever ran**. This affected both `pull_requests.yaml` and `branch.yaml` (production deploy).

Verified on the live endpoint:
| Auth | `api.github.com/repos/weaviate/weaviate/releases` |
|---|---|
| valid bearer (what `GITHUB_TOKEN` gives) | 200 |
| expired/bad bearer (current state) | 401 |
| no token | 200 |

**Fix:** switch the three `secrets.GH_API_TOKEN` references to the built-in `secrets.GITHUB_TOKEN`, matching what `llms_txt_tests.yml` already does successfully for the same script. The env var name `GH_API_TOKEN` is unchanged, so the build script needs no edit. `GITHUB_TOKEN` never expires and needs no rotation.

### 2. `tim-kleyersburg.de` false positive
The community PHP-client author link returns 200 in a browser but 403s GitHub-runner traffic (bot protection). Added it to the shared `domainsToIgnore` list, matching the existing convention for `db-engines.com` and similar.

## Testing
- Live-endpoint auth behavior confirmed (table above).
- `node --check` on `link-validator.js`; the new ignore entry matches the target URL and not `docs.weaviate.io`.
- This PR's own CI is the end-to-end test: the *Update versions* step should now pass (fix 1) and link validation should pass with the ignore in place (fix 2).