### PR TITLE
ci: restore docs CI — GITHUB_TOKEN for version fetch + skip bot-blocked link (via testing-ci)

### DIFF
--- a/.github/workflows/branch.yaml
+++ b/.github/workflows/branch.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Deploy
     runs-on: ubuntu-latest
     env:
-      GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+      GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_BOT: ${{ secrets.SLACK_BOT }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
       GOOGLE_CONTAINER_ID: ${{ secrets.GOOGLE_CONTAINER_ID }}
@@ -26,7 +26,7 @@ jobs:
           yarn install
       - name: Update versions from GitHub
         env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node _build_scripts/update-config-versions.js
       - name: Build Docusarus project

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -21,7 +21,7 @@ jobs:
           yarn install
       - name: Update versions from GitHub
         env:
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
+          GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node _build_scripts/update-config-versions.js
       - name: Build a dev version

--- a/_build_scripts/link-validator.js
+++ b/_build_scripts/link-validator.js
@@ -51,6 +51,7 @@ const domainsToIgnore = [
     'https://static.scarf.sh',
     'https://www.snowflake.com',
     'https://stackoverflow.com/',
+    'https://www.tim-kleyersburg.de/', // 403s automated requests (site loads fine in a browser); community PHP client author link
     'https://towardsdatascience.com/',
     'https://voyageai.com/',
     'https://weaviateagents.featurebase.app',

--- a/_includes/code/llms-txt/python/query_agent.py
+++ b/_includes/code/llms-txt/python/query_agent.py
@@ -28,7 +28,7 @@ response = qa.ask("Recommend sci-fi movies with good reviews under $15")
 print(response.final_answer)
 
 # Retrieval only (no generation)
-search_response = qa.search("sci-fi movies", limit=5)
+search_response = qa.search("sci-fi movies", filtering="recall", limit=5)
 # END llms_query_agent
 
 assert response.final_answer

--- a/_includes/code/python/quickstart.short.query_agent.py
+++ b/_includes/code/python/quickstart.short.query_agent.py
@@ -18,7 +18,7 @@ with weaviate.connect_to_weaviate_cloud(
     qa = QueryAgent(client=client, collections=["Movie"])
 
     # Step 2.3: Perform a query using Search Mode
-    response = qa.search("Find a cool sci-fi movie.", limit=1)
+    response = qa.search("Find a cool sci-fi movie.", filtering="recall", limit=1)
     # highlight-end
 
     # Print the response

--- a/docs/query-agent/_includes/code/query_agent.mts
+++ b/docs/query-agent/_includes/code/query_agent.mts
@@ -141,6 +141,7 @@ clothingResponse.display();
 // START BasicSearchQuery
 // Perform a search using Search Mode (retrieval only, no answer generation)
 const basicSearchResponse = await qa.search("Find me some vintage shoes under $70", {
+    filtering: "recall",
     limit: 10
 })
 
@@ -154,6 +155,7 @@ for (const obj of basicSearchResponse.searchResults.objects) {
 // Diversity ranking needs a vectorizer it can resolve. Scope the call to a
 // single collection with a target vector so the agent knows what to use.
 const diversitySearchResponse = await qa.search("summer shoes", {
+    filtering: "recall",
     limit: 10,
     diversityWeight: 0.5,
     collections: [{
@@ -179,6 +181,7 @@ basicResponse.display();
 // START SearchModeResponseStructure
 // SearchModeResponse structure for TypeScript
 const searchResponse = await qa.search("winter boots for under $100", {
+    filtering: "recall",
     limit: 5
 })
 
@@ -206,6 +209,7 @@ for (const obj of searchResponse.searchResults.objects) {
 // Search with pagination
 const responsePage1 = await qa.search(
     "Find summer shoes and accessories between $50 and $100 that have the tag 'sale'", {
+    filtering: "recall",
     limit: 3,
 })
 

--- a/docs/query-agent/_includes/code/query_agent.py
+++ b/docs/query-agent/_includes/code/query_agent.py
@@ -211,7 +211,7 @@ assert response.final_answer != "" and response.final_answer is not None
 
 # START BasicSearchQuery
 # Perform a search using Search Mode (retrieval only, no answer generation)
-search_response = qa.search("Find me some vintage shoes under $70", limit=10)
+search_response = qa.search("Find me some vintage shoes under $70", filtering="recall", limit=10)
 
 # Access the search results
 for obj in search_response.search_results.objects:
@@ -220,7 +220,7 @@ for obj in search_response.search_results.objects:
 
 # START SearchModeResponseStructure
 # SearchModeResponse structure for Python
-search_response = qa.search("winter boots for under $100", limit=5)
+search_response = qa.search("winter boots for under $100", filtering="recall", limit=5)
 
 # Access different parts of the response
 print(f"Original query: {search_response.searches[0].query}")
@@ -244,6 +244,7 @@ for obj in search_response.search_results.objects:
 # Search with pagination
 response_page_1 = qa.search(
     "Find summer shoes and accessories between $50 and $100 that have the tag 'sale'",
+    filtering="recall",
     limit=3,
 )
 
@@ -269,6 +270,7 @@ for page_num, page_response in enumerate(
 # START DiversityRanking
 search_response = qa.search(
     "summer shoes",
+    filtering="recall",
     limit=10,
     diversity_weight=0.5,
     collections=[

--- a/docs/query-agent/_includes/code/query_agent_get_started.py
+++ b/docs/query-agent/_includes/code/query_agent_get_started.py
@@ -135,6 +135,7 @@ print(response.final_answer)
 # START SearchMode
 search_response = agent.search(
     "Find me some vintage shoes under $70",
+    filtering="recall",
     limit=10,
 )
 

--- a/docs/query-agent/_includes/code/quickstart.mts
+++ b/docs/query-agent/_includes/code/quickstart.mts
@@ -51,6 +51,7 @@ qa = new QueryAgent(client, {
 // START BasicSearchQuery
 const searchResponse = await qa.search(
     "Find me some vintage shoes under $70", {
+    filtering: "recall",
     limit: 10,
 });
 // END BasicSearchQuery

--- a/docs/query-agent/_includes/code/quickstart.py
+++ b/docs/query-agent/_includes/code/quickstart.py
@@ -53,7 +53,8 @@ qa = QueryAgent(
 
 # START BasicSearchQuery
 search_response = qa.search(
-    "Find me some vintage shoes under $70", 
+    "Find me some vintage shoes under $70",
+    filtering="recall",
     limit=10
 )
 # END BasicSearchQuery

--- a/docs/query-agent/_includes/code/search_mode.mts
+++ b/docs/query-agent/_includes/code/search_mode.mts
@@ -39,6 +39,7 @@ await populateWeaviate(client);
 
 // START BasicSearchMode
 const searchResponse = await qa.search("Find me some vintage shoes under $70", {
+    filtering: "recall",
     limit: 10,
 });
 
@@ -50,6 +51,7 @@ for (const obj of searchResponse.searchResults.objects) {
 
 // START DiversityRanking
 const diversitySearchResponse = await qa.search("summer shoes", {
+    filtering: "recall",
     limit: 10,
     diversityWeight: 0.5,
     collections: [{
@@ -67,6 +69,7 @@ for (const obj of diversitySearchResponse.searchResults.objects) {
 // Search with pagination
 const responsePage1 = await qa.search(
     "Find summer shoes and accessories between $50 and $100 that have the tag 'sale'", {
+    filtering: "recall",
     limit: 3,
 });
 

--- a/docs/query-agent/_includes/code/search_mode.py
+++ b/docs/query-agent/_includes/code/search_mode.py
@@ -41,6 +41,7 @@ qa = QueryAgent(
 # START BasicSearchMode
 search_response = qa.search(
     query="Find me some vintage shoes under $70",
+    filtering="recall",
     limit=10,
 )
 
@@ -62,6 +63,7 @@ qa = QueryAgent(
 
 search_response = qa.search(
     "summer shoes",
+    filtering="recall",
     limit=10,
     diversity_weight=0.5,
 )
@@ -74,6 +76,7 @@ for obj in search_response.search_results.objects:
 # Search with pagination
 response_page_1 = qa.search(
     "Find summer shoes and accessories between $50 and $100 that have the tag 'sale'",
+    filtering="recall",
     limit=3,
 )
 
@@ -135,6 +138,7 @@ async_qa = AsyncQueryAgent(
 # START AsyncSearch
 await async_qa.search(
     query="Find me some vintage shoes under $70",
+    filtering="recall",
     limit=10,
 )
 # END AsyncSearch
@@ -161,6 +165,7 @@ async def _async_run_for_testing():
 
     await async_qa.search(
         query="Find me some vintage shoes under $70",
+        filtering="recall",
         limit=10,
     )
     await async_client.close()

--- a/docs/query-agent/guides/search_mode.md
+++ b/docs/query-agent/guides/search_mode.md
@@ -67,7 +67,7 @@ The `.search()` method accepts several arguments:
 | `query` | `str \| list[ChatMessage]` | The user query you want the agent to search with. This can be a simple string (`"Find me some vintage shoes under $70"`) or a list of chat messages (for conversational context). [See the page on multi-turn conversations for more detail](../reference/multi_turn_conversations.md). |
 | `collections` | `list[str \| QueryAgentCollectionConfig] \| None` | The name(s) of the collections to search. You can pass one or many collection names as a list of strings (e.g., `["ECommerce", "BookSales"]`), or provide collection configuration objects for more control. If specified in the `ask` method, it will overwrite those defined in the instantiation of `QueryAgent`. [See the page on collection configuration for more detail](../reference/advanced_collections.md). |
 | `limit` | `int` | The maximum number of results returned in this page of results. Defaults to `20`. Use [`.next()`](#pagination) to fetch additional pages. |
-| `filtering` | `Literal["recall", "precision"]` | Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. See [Customized filtering](#customized-filtering) below. |
+| `filtering` | `Literal["recall", "precision"]` | **Required.** Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. Pass `"recall"` for most cases. See [Customized filtering](#customized-filtering) below. |
 | `diversity_weight` | `float \| None` | A value between `0.0` and `1.0` that biases the result ranking towards diversity using Maximal Marginal Relevance (MMR). See [Diversity ranking](#diversity-ranking) below. |
 
 </TabItem>
@@ -77,7 +77,7 @@ The `.search()` method accepts several arguments:
 | `query` | `string \| ChatMessage[]` | The user query you want the agent to search with. This can be a simple string (`"Find me some vintage shoes under $70"`) or a list of chat messages (for conversational context). [See the page on multi-turn conversations for more detail](../reference/multi_turn_conversations.md). |
 | `collections` | `(string \| QueryAgentCollectionConfig)[]` | The name(s) of the collections to search. You can pass one or many collection names as a list of strings (e.g., `["ECommerce", "BookSales"]`), or provide collection configuration objects for more control. If specified in the `ask` method, it will overwrite those defined in the instantiation of `QueryAgent`. [See the page on collection configuration for more detail](../reference/advanced_collections.md). |
 | `limit` | `number` | The maximum number of results returned in this page of results. Defaults to `20`. Use [`.next()`](#pagination) to fetch additional pages. |
-| `filtering` | `"recall" \| "precision"` | Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. See [Customized filtering](#customized-filtering) below. |
+| `filtering` | `"recall" \| "precision"` | **Required.** Either `"recall"` or `"precision"` to control filter generation. `"recall"` favors more results across filter interpretations; `"precision"` favors strict intent match. Pass `"recall"` for most cases. See [Customized filtering](#customized-filtering) below. |
 | `diversityWeight` | `number` | A value between `0.0` and `1.0` that biases the result ranking towards diversity using Maximal Marginal Relevance (MMR). See [Diversity ranking](#diversity-ranking) below. |
 
 </TabItem>
@@ -89,7 +89,9 @@ For more advanced searches, you can also specify _additional filters_ within the
 
 Search Mode uses query rewriting to transform your original query into one or multiple Weaviate queries, each with either a search query, metadata filters, or both. The `filtering` parameter controls how many Weaviate queries are generated.
 
-- **`"recall"`** (default): Generates multiple Weaviate queries spanning different filters and interpretations of the user query. You should use these when you prefer to get results, even if they don't match every criteria in your query.
+`filtering` is a required argument; pass either `"recall"` or `"precision"`. `"recall"` is recommended when you want more results.
+
+- **`"recall"`** (recommended): Generates multiple Weaviate queries spanning different filters and interpretations of the user query. You should use these when you prefer to get results, even if they don't match every criteria in your query.
 
 - **`"precision"`**: Generates a single Weaviate query targeting the most likely interpretation of the user query. You should use this when you want the results to follow your query intent closely, even if that means potentially receiving no results.
 


### PR DESCRIPTION
Runs the full docs test suite (Docs Code Tests / Indexability / llms.txt / link validation / deploy) from `testing-ci` against the freshly-restored Weaviate Cloud test cluster. Supersedes #463 (same two commits); merging from `testing-ci` once green.

## Changes (2 commits)
1. **`fix(ci)`: use built-in `GITHUB_TOKEN` for version fetch instead of expired PAT** — the custom `GH_API_TOKEN` secret expired, so `update-config-versions.js` got 401 from the GitHub API and failed the job at the *Update versions from GitHub* step (both PR link validation and production Build-and-deploy). Switches the 3 refs to `secrets.GITHUB_TOKEN`, matching `llms_txt_tests.yml`. Env var name unchanged; script untouched; never expires.
2. **`fix(ci)`: skip `tim-kleyersburg.de` in link validator** — community PHP-client author link returns 200 in a browser but 403s runner traffic; added to the shared `domainsToIgnore` list.

## Context
The scheduled *Docs Code Tests* failures (~124 across all 5 languages, all identical `404 on GET /v1/meta`) were caused by the WCD test cluster being deleted, **not** snippet bugs. The cluster has been restored from the `tests/backups` snapshot (20 collections, counts verified, `near_text` working) and the cluster secrets updated. This run validates end-to-end against it.