### PR TITLE
docs: make server-side batching the default import method

### DIFF
--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Clone and build Java client SNAPSHOT
         run: |
-          JAVA_BRANCH="${{ inputs.java_client_branch || '6.2.0' }}"
+          JAVA_BRANCH="${{ inputs.java_client_branch || '6.2.1' }}"
           echo "📦 Building Java client SNAPSHOT from branch: $JAVA_BRANCH"
           git clone --depth 1 -b "$JAVA_BRANCH" https://github.com/weaviate/java-client.git /tmp/java-client
           cd /tmp/java-client

--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -456,7 +456,7 @@ jobs:
 
       - name: Clone and build Java client SNAPSHOT
         run: |
-          JAVA_BRANCH="${{ inputs.java_client_branch || '6.2.1' }}"
+          JAVA_BRANCH="${{ inputs.java_client_branch || '6.3.0' }}"
           echo "📦 Building Java client SNAPSHOT from branch: $JAVA_BRANCH"
           git clone --depth 1 -b "$JAVA_BRANCH" https://github.com/weaviate/java-client.git /tmp/java-client
           cd /tmp/java-client

--- a/_includes/code/csharp/ManageObjectsImportTest.cs
+++ b/_includes/code/csharp/ManageObjectsImportTest.cs
@@ -126,9 +126,43 @@ public class ManageObjectsImportTest : IAsyncLifetime
         Assert.Equal(5, result.TotalCount);
     }
 
-    // START ServerSideBatchImportExample
-    // Coming soon
-    // END ServerSideBatchImportExample
+    [Fact]
+    public async Task TestServerSideBatchImport()
+    {
+        await BeforeEach();
+        await client.Collections.Create(
+            new CollectionCreateParams
+            {
+                Name = "MyCollection",
+                VectorConfig = Configure.Vector("default", v => v.SelfProvided()),
+            }
+        );
+
+        // START ServerSideBatchImportExample
+        var dataRows = Enumerable
+            .Range(0, 5)
+            .Select(i => new { title = $"Object {i + 1}" })
+            .ToList();
+
+        var collection = client.Collections.Use("MyCollection");
+
+        // Use `Batch.InsertMany` for server-side batching. The client sends
+        // data in batches at a rate controlled by the server.
+        // highlight-start
+        var response = await collection.Batch.InsertMany(dataRows);
+        // highlight-end
+
+        var failedObjects = response.Where(r => r.Error != null).ToList();
+        if (failedObjects.Any())
+        {
+            Console.WriteLine($"Number of failed imports: {failedObjects.Count}");
+            Console.WriteLine($"First failed object: {failedObjects.First().Error}");
+        }
+        // END ServerSideBatchImportExample
+
+        var result = await collection.Aggregate.OverAll(totalCount: true);
+        Assert.Equal(5, result.TotalCount);
+    }
 
     [Fact]
     public async Task TestBatchImportWithID()

--- a/_includes/code/howto/manage-data.import.ts
+++ b/_includes/code/howto/manage-data.import.ts
@@ -335,11 +335,11 @@ try {
 {
 // START ServerSideBatchImportExample
 const dataObjects = [
-  { title: 'Object 1' },
-  { title: 'Object 2' },
-  { title: 'Object 3' },
-  { title: 'Object 4' },
-  { title: 'Object 5' },
+  { properties: { title: 'Object 1' } },
+  { properties: { title: 'Object 2' } },
+  { properties: { title: 'Object 3' } },
+  { properties: { title: 'Object 4' } },
+  { properties: { title: 'Object 5' } },
 ]
 
 const myCollection = client.collections.use('MyCollection')
@@ -352,6 +352,14 @@ const result = await myCollection.data.ingest(dataObjects)
 
 console.log(result)
 // END ServerSideBatchImportExample
+
+// Verify the import (not shown in the docs snippet): all 5 objects and
+// their `title` property must have persisted.
+const check = await myCollection.query.fetchObjects({ limit: 5 })
+if (check.objects.length !== 5)
+  throw new Error(`SSB import: expected 5 objects, got ${check.objects.length}`)
+if (!check.objects.every((o) => typeof o.properties.title === 'string' && o.properties.title.length > 0))
+  throw new Error('SSB import did not persist the title property')
 }
 
 await client.collections.delete('MyCollection');

--- a/_includes/code/howto/manage-data.import.ts
+++ b/_includes/code/howto/manage-data.import.ts
@@ -319,7 +319,7 @@ console.log(`Finished importing ${counter} articles.`);
 // ==================================================
 // ===== Server-side (automatic) batch import =====
 // ==================================================
-/*
+
 // Clean slate
 try {
   await client.collections.delete('MyCollection');
@@ -355,7 +355,7 @@ console.log(result)
 }
 
 await client.collections.delete('MyCollection');
-*/
+
 // ===========================
 // ===== Batch with gRPC =====
 // ===========================

--- a/_includes/code/java-v6/pom.xml
+++ b/_includes/code/java-v6/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.weaviate</groupId>
       <artifactId>client6</artifactId>
-      <version>6.2.1-SNAPSHOT</version>
+      <version>6.2.1</version>
     </dependency>
 
     <!-- JUnit 5 for testing -->

--- a/_includes/code/java-v6/pom.xml
+++ b/_includes/code/java-v6/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>io.weaviate</groupId>
       <artifactId>client6</artifactId>
-      <version>6.2.1</version>
+      <version>6.3.0</version>
     </dependency>
 
     <!-- JUnit 5 for testing -->

--- a/_includes/code/java-v6/src/test/java/ManageObjectsImportTest.java
+++ b/_includes/code/java-v6/src/test/java/ManageObjectsImportTest.java
@@ -3,6 +3,7 @@ import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.ReferenceProperty;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
 import io.weaviate.client6.v1.api.collections.data.BatchReference;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
@@ -108,11 +109,47 @@ class ManageObjectsImportTest {
     client.collections.delete("MyCollection");
   }
 
-  //@Test
+  @Test
   void testServerSideBatchImport() throws IOException {
+    // Define and create the class
+    client.collections.create("MyCollection",
+        col -> col.vectorConfig(VectorConfig.selfProvided()));
+
     // START ServerSideBatchImportExample
-    // Coming soon
+    List<Map<String, Object>> dataRows = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      dataRows.add(Map.of("title", "Object " + (i + 1)));
+    }
+
+    var collection = client.collections.use("MyCollection");
+
+    // Use `batch.start()` for server-side batching. The client sends data
+    // in batches at a rate controlled by the server. The batch is flushed
+    // and closed automatically when the try-with-resources block exits.
+    // highlight-start
+    BatchContext<Map<String, Object>> batch = collection.batch.start();
+    try (batch) {
+      for (Map<String, Object> dataRow : dataRows) {
+        batch.add(WeaviateObject.<Map<String, Object>>of(
+            obj -> obj.properties(dataRow)));
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    // highlight-end
+
+    // numberOfErrors() reports objects that could not be imported.
+    if (batch.numberOfErrors() > 0) {
+      System.err
+          .println("Number of failed imports: " + batch.numberOfErrors());
+    }
     // END ServerSideBatchImportExample
+
+    var result =
+        collection.aggregate.overAll(agg -> agg.includeTotalCount(true));
+    assertThat(result.totalCount()).isEqualTo(5);
+
+    client.collections.delete("MyCollection");
   }
 
   @Test

--- a/docs/weaviate/concepts/data-import.mdx
+++ b/docs/weaviate/concepts/data-import.mdx
@@ -19,7 +19,7 @@ Weaviate offers two flexible methods for importing data in bulk: **client-side b
 
 :::tip
 
-For **code examples**, check out the [How-to: Batch import](../manage-objects/import.mdx) guide. Currently, only the Python client supports server-side batch imports.
+For **code examples**, check out the [How-to: Batch import](../manage-objects/import.mdx) guide. Server-side batch imports are supported by the Python, TypeScript, Java, and C# clients. The Go client does not yet support them; use client-side batching instead.
 
 :::
 
@@ -40,7 +40,7 @@ Weaviate's server-side batching, also known as **automatic batching**, aims to p
 When an automatic batch import is initiated, the client opens a persistent connection to the server for the duration of the batch job.
 
 - **Client sends data**: Your client sends objects to the server in chunks, at a rate that is based on server-provided feedback.
-- **Server manages queues**: The server places incoming objects into an internal. The queue is decoupled the network communication from the actual database ingestion (like vectorization and storage).
+- **Server manages queues**: The server places incoming objects into an internal queue. This queue decouples the network communication from the actual database ingestion (like vectorization and storage).
 - **Dynamic backpressure**: The server continuously monitors its internal queue size. It calculates an exponential moving average (EMA) of its workload and tells the client the ideal number of objects to send in the next chunk. This feedback loop allows the system to self-regulate, maximizing throughput without overwhelming the server.
 - **Asynchronous errors**: If an error occurs while processing an object (e.g., validation fails), the server sends the error message back to the client over a separate, dedicated stream without interrupting the flow of objects.
 

--- a/docs/weaviate/manage-objects/import.mdx
+++ b/docs/weaviate/manage-objects/import.mdx
@@ -106,11 +106,12 @@ Here's how to import objects into a collection named `MyCollection` using [serve
     />
   </TabItem>
   <TabItem value="ts" label="JavaScript/TypeScript">
-
-```typescript
-// TypeScript support coming soon
-```
-
+    <FilteredTextBlock
+      text={TSCode}
+      startMarker="// START ServerSideBatchImportExample"
+      endMarker="// END ServerSideBatchImportExample"
+      language="ts"
+    />
   </TabItem>
     <TabItem value="go" label="Go">
 
@@ -120,11 +121,12 @@ Here's how to import objects into a collection named `MyCollection` using [serve
 
   </TabItem>
   <TabItem value="java" label="Java">
-
-```java
-// Java support coming soon
-```
-
+    <FilteredTextBlock
+      text={JavaV6Code}
+      startMarker="// START ServerSideBatchImportExample"
+      endMarker="// END ServerSideBatchImportExample"
+      language="java"
+    />
   </TabItem>
   <TabItem value="csharp" label="C#">
     <FilteredTextBlock

--- a/docs/weaviate/manage-objects/import.mdx
+++ b/docs/weaviate/manage-objects/import.mdx
@@ -17,22 +17,72 @@ import CSharpCode from '!!raw-loader!/_includes/code/csharp/ManageObjectsImportT
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/manage-data.import_test.go';
 import SkipLink from '/src/components/SkipValidationLink'
 
-[Batch imports](../tutorials/import.mdx) are an efficient way to add multiple data objects and cross-references.
+[Batch imports](../tutorials/import.mdx) are an efficient way to add multiple data objects and cross-references. For most use cases, we recommend **server-side batching** as the starting point: the server tells the client how much data to send next, so you don't have to tune batch parameters yourself. When you need manual control over the batch size and concurrency — or you are using a client that does not yet support server-side batching — use [manual batching](#manual-batching) instead.
+
+## Server-side batching
+
+import SsbStatus from '/_includes/feature-notes/ssb-status.mdx';
+
+<SsbStatus/>
+
+With [server-side batch imports](../concepts/data-import.mdx#server-side-batching) (also called "automatic" batching), the client sends data in batch sizes determined by feedback from the server. This simplifies your code and helps the server manage its own load. The following example adds objects to a collection named `MyCollection`.
+
+Server-side batching uses the [gRPC API](#use-the-grpc-api), which current client versions enable by default.
+
+<Tabs className="code" groupId="languages">
+  <TabItem value="py" label="Python">
+    <FilteredTextBlock
+      text={PyCode}
+      startMarker="# START ServerSideBatchImportExample"
+      endMarker="# END ServerSideBatchImportExample"
+      language="py"
+    />
+  </TabItem>
+  <TabItem value="ts" label="JavaScript/TypeScript">
+    <FilteredTextBlock
+      text={TSCode}
+      startMarker="// START ServerSideBatchImportExample"
+      endMarker="// END ServerSideBatchImportExample"
+      language="ts"
+    />
+  </TabItem>
+  <TabItem value="go" label="Go">
+
+The Go client does not support server-side batching; use [manual batching](#manual-batching) instead.
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+    <FilteredTextBlock
+      text={JavaV6Code}
+      startMarker="// START ServerSideBatchImportExample"
+      endMarker="// END ServerSideBatchImportExample"
+      language="java"
+    />
+  </TabItem>
+  <TabItem value="csharp" label="C#">
+    <FilteredTextBlock
+      text={CSharpCode}
+      startMarker="// START ServerSideBatchImportExample"
+      endMarker="// END ServerSideBatchImportExample"
+      language="csharp"
+    />
+  </TabItem>
+</Tabs>
+
+## Manual batching
+
+Use manual (client-side) batching when you want to control the batch size and concurrency yourself, or when using a client that does not yet support server-side batching (such as the Go client). The following example adds objects to the `MyCollection` collection.
 
 <details>
   <summary>Additional information</summary>
 
-To create a bulk import job, follow these steps:
+To create a bulk import job manually, follow these steps:
 
 1. Initialize a batch object.
 1. Add items to the batch object.
 1. Ensure that the last batch is sent (flushed).
 
 </details>
-
-## Basic import
-
-The following example adds objects to the `MyCollection` collection.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -88,56 +138,6 @@ Find out more about error handling on the Python client [reference page](/weavia
   </TabItem>
 </Tabs>
 
-## Server-side batching
-
-import SsbStatus from '/_includes/feature-notes/ssb-status.mdx';
-
-<SsbStatus/>
-
-Here's how to import objects into a collection named `MyCollection` using [server-side batch imports](../concepts/data-import.mdx#server-side-batching). The client will send data in batch sizes using feedback from the server.
-
-<Tabs className="code" groupId="languages">
-  <TabItem value="py" label="Python">
-    <FilteredTextBlock
-      text={PyCode}
-      startMarker="# START ServerSideBatchImportExample"
-      endMarker="# END ServerSideBatchImportExample"
-      language="py"
-    />
-  </TabItem>
-  <TabItem value="ts" label="JavaScript/TypeScript">
-    <FilteredTextBlock
-      text={TSCode}
-      startMarker="// START ServerSideBatchImportExample"
-      endMarker="// END ServerSideBatchImportExample"
-      language="ts"
-    />
-  </TabItem>
-    <TabItem value="go" label="Go">
-
-```go
-// Go support coming soon
-```
-
-  </TabItem>
-  <TabItem value="java" label="Java">
-    <FilteredTextBlock
-      text={JavaV6Code}
-      startMarker="// START ServerSideBatchImportExample"
-      endMarker="// END ServerSideBatchImportExample"
-      language="java"
-    />
-  </TabItem>
-  <TabItem value="csharp" label="C#">
-    <FilteredTextBlock
-      text={CSharpCode}
-      startMarker="// START ServerSideBatchImportExample"
-      endMarker="// END ServerSideBatchImportExample"
-      language="csharp"
-    />
-  </TabItem>
-</Tabs>
-
 ## Use the gRPC API
 
 The [gRPC API](../api/index.mdx) is faster than the REST API. Use the gRPC API to improve import speeds.
@@ -171,7 +171,7 @@ The Java client v6 uses gRPC by default.
 
 To use the gRPC API with the Go client, add the `GrpcConfig` field to your client connection code. Update `Secured` if you use an encrypted connection.<br/><br/>
 
-```java
+```go
 cfg := weaviate.Config{
   Host:   fmt.Sprintf("localhost:%v", "8080"),
   Scheme: "http",


### PR DESCRIPTION
## What

Makes **server-side batching (SSB) the default, recommended way to import data** on the batch-import how-to page, and fills in the SSB code snippets for every client that supports it. SSB shipped in Weaviate v1.36; the concepts page already called it "the recommended approach," but the how-to page still led with client-side batching and only Python had an SSB snippet.

### Import page restructure (`manage-objects/import.mdx`)
- **Server-side batching is now the first section**, framed as the recommended starting point "for most use cases."
- The old "Basic import" (client-side) is demoted to **"Manual batching"** — the alternative for manual control or for the Go client. Client-side batching stays valid, not obsolete.
- The **Go** tab points to manual batching ("the Go client does not support server-side batching") instead of "coming soon".
- A one-line note that SSB uses the gRPC API (enabled by default), cross-linking the gRPC section.

### SSB snippets added (were "coming soon")
| Client | Server-side batching API |
|---|---|
| Python | `collection.batch.stream()` (already documented) |
| TypeScript | `collection.data.ingest()` |
| Java v6 | `collection.batch.start()` → `BatchContext` |
| C# | `collection.Batch.InsertMany()` |
| Go | — no client API yet (uses manual batching) |

### Fixes found while making the snippets actually run
- **TS**: `data.ingest()` silently dropped properties when passed bare objects on an untyped collection (imported empty objects). Switched to the `{ properties: { title } }` DataObject wrapper + a `fetchObjects()` assertion. (The underlying client inconsistency is tracked separately for the TS client.)
- **Java tests**: the `java-v6` examples module depended on an unpublished `6.2.1-SNAPSHOT` while CI built `6.2.0` (which lacks `text2vec-digitalocean` + tokenize APIs), so the whole module failed to compile. Pinned the pom + CI to the released **`6.3.0`**.
- **concepts/data-import.mdx**: corrected the stale "only the Python client supports server-side batch imports" (now Python/TS/Java/C#; Go not yet) + a broken sentence.

## Verification

All three new snippets were compiled and run end-to-end against a live **Weaviate 1.38** (auto-schema on, matching CI) with the CI-pinned clients (TS `3.13.1`, Java `client6 6.3.0`, C# `1.1.1`):
- TS `data.ingest` → 5 objects, titles persisted (assertion passes; fails on the old bare shape).
- Java `6.3.0` → whole `java-v6` module compiles (all 44 test classes), `testServerSideBatchImport` passes.
- C# `Batch.InsertMany` → 5 objects, title persisted.
- `yarn build-dev` succeeds; `validate-links-dev` shows **0 new** broken links (new `#manual-batching`/`#use-the-grpc-api` anchors resolve; the preserved lower anchors still serve their inbound links).

## Notes
- Out of scope (flagged for later): the Python client-library reference page still teaches `batch.dynamic()`/`fixed_size()` without mentioning `stream()`; the tutorial and Python best-practices pages already lead SSB-first.
