### PR TITLE
docs(deploy): DigitalOcean Managed Weaviate → public preview

### DIFF
--- a/docs/deploy/faqs/index.md
+++ b/docs/deploy/faqs/index.md
@@ -37,7 +37,17 @@ This [page](../installation-guides/gcp-marketplace.md) will walk you through all
 
 </details>
 
-#### Q4: Is there a recommended limit for collections?
+#### Q4: How do I run Weaviate as a managed service on DigitalOcean?
+
+<details>
+
+<summary> Answer </summary>
+
+This [page](../installation-guides/digitalocean.md) will walk you through running Weaviate as a fully managed service operated by DigitalOcean. 
+
+</details>
+
+#### Q5: Is there a recommended limit for collections?
 
 <details>
 
@@ -49,7 +59,7 @@ If you plan to create more than **20** collections, you may want to consider mul
 
 </details>
 
-#### Q5: What are some common issues that occur during deployment?
+#### Q6: What are some common issues that occur during deployment?
 
 <details>
 
@@ -68,7 +78,7 @@ For further information, the [troubleshooting page](./troubleshooting.md) will h
 
 </details>
 
-#### Q6: What's the difference between Weaviate and other databases?
+#### Q7: What's the difference between Weaviate and other databases?
 
 <details>
 
@@ -77,7 +87,7 @@ For further information, the [troubleshooting page](./troubleshooting.md) will h
 Weaviate has complex processes which means that ingestion and deletion require more steps than other types of databases. Data ingestion tends to take longer than a traditional database because of vectorization and deleting objects can be expensive due to the embedding costs. 
 </details>
 
-#### Q7: Do my resources free up immediately after deleting objects?
+#### Q8: Do my resources free up immediately after deleting objects?
 
 <details>
 
@@ -87,7 +97,7 @@ No, it does not happen instantaneously. When you delete objects a tombstone is c
 
 </details>
 
-#### Q8: What's the difference between client timeouts and module timeouts?
+#### Q9: What's the difference between client timeouts and module timeouts?
 
 <details>
 

--- a/docs/deploy/index.mdx
+++ b/docs/deploy/index.mdx
@@ -132,7 +132,7 @@ export const deploymentCardsData = [
     tabs: [
       { label: "Evaluation", active: true },
       { label: "Development", active: true },
-      { label: "Production", active: false },
+      { label: "Production", active: true },
     ],
     header: "DigitalOcean",
     bgImage: "/img/site/digitalocean.svg",

--- a/docs/deploy/index.mdx
+++ b/docs/deploy/index.mdx
@@ -141,7 +141,7 @@ export const deploymentCardsData = [
       "Fully managed by DigitalOcean",
       "Provisioned via the DigitalOcean API",
       "Daily backups, TLS on every connection",
-      "Currently in private preview",
+      "Currently in public preview",
     ],
     button: {
       text: "Deploy Weaviate on DigitalOcean",

--- a/docs/deploy/installation-guides/digitalocean.md
+++ b/docs/deploy/installation-guides/digitalocean.md
@@ -73,4 +73,5 @@ For usage from here on out, see the standard [search](/weaviate/search), [manage
 - [DigitalOcean Managed Weaviate docs](https://docs.digitalocean.com/products/vector-databases/weaviate/)
 - [Announcing Managed Weaviate on DigitalOcean (public preview)](https://www.digitalocean.com/blog/public-preview-managed-weaviate)
 - [Connect to a custom Weaviate instance](/weaviate/connections/connect-custom)
+- [DigitalOcean model provider (Serverless Inference)](/weaviate/model-providers/digitalocean)
 - [How-to guides](/weaviate/guides)

--- a/docs/deploy/installation-guides/digitalocean.md
+++ b/docs/deploy/installation-guides/digitalocean.md
@@ -15,8 +15,8 @@ import CSharpCode from "!!raw-loader!/\_includes/code/csharp/ConnectionTest.cs";
 
 [**DigitalOcean Managed Weaviate**](https://docs.digitalocean.com/products/vector-databases/weaviate/) is a fully managed offering of the Weaviate open-source vector database, operated by DigitalOcean. Clusters are provisioned, secured, backed up, and patched by DigitalOcean. You are responsible for your data, your schema, and the application that reads and writes to the cluster.
 
-:::caution Private preview
-DigitalOcean Managed Weaviate is in **private preview**. APIs, plans, regions, and Control Panel surfaces may change before general availability.
+:::caution Public preview
+DigitalOcean Managed Weaviate is in **public preview**.
 :::
 
 ## Provisioning
@@ -71,5 +71,6 @@ For usage from here on out, see the standard [search](/weaviate/search), [manage
 ## Further resources
 
 - [DigitalOcean Managed Weaviate docs](https://docs.digitalocean.com/products/vector-databases/weaviate/)
+- [Announcing Managed Weaviate on DigitalOcean (public preview)](https://www.digitalocean.com/blog/public-preview-managed-weaviate)
 - [Connect to a custom Weaviate instance](/weaviate/connections/connect-custom)
 - [How-to guides](/weaviate/guides)

--- a/docs/deploy/installation-guides/index.md
+++ b/docs/deploy/installation-guides/index.md
@@ -18,7 +18,7 @@ To install and configure Weaviate, see the following:
 - **[Kubernetes](/deploy/installation-guides/k8s-installation.md)**: Kubernetes is ideal for scalable, production deployments.
 - **[AWS Marketplace](./aws-marketplace.md)**: Deploy Weaviate directly from the AWS Marketplace.
 - **[GCP Marketplace](./gcp-marketplace.md)**: Deploy Weaviate directly from the Google Cloud Marketplace.
-- **[DigitalOcean Managed Weaviate](./digitalocean.md)**: Run Weaviate as a managed service on DigitalOcean (private preview).
+- **[DigitalOcean Managed Weaviate](./digitalocean.md)**: Run Weaviate as a managed service on DigitalOcean (public preview).
 - **[Snowpark Container Services](docs/deploy/installation-guides/spcs-integration.mdx)** Deploy Weaviate in Snowflake's Snowpark environment.
 - **[Embedded Weaviate](docs/deploy/installation-guides/embedded.md)**: Experimental. Embedded Weaviate is a client based tool.
 

--- a/docs/weaviate/model-providers/digitalocean/index.md
+++ b/docs/weaviate/model-providers/digitalocean/index.md
@@ -9,6 +9,10 @@ image: og/docs/model-provider-integrations.jpg
 
 [DigitalOcean's Serverless Inference](https://docs.digitalocean.com/products/inference/how-to/use-serverless-inference/) hosts a curated set of open-weight embedding and language models behind a single OpenAI-compatible API. Weaviate integrates with DigitalOcean's embedding endpoint so you can vectorize and search data using DigitalOcean-hosted models directly from your Weaviate instance.
 
+:::note
+Looking to *host* Weaviate on DigitalOcean? See [DigitalOcean Managed Weaviate](/deploy/installation-guides/digitalocean).
+:::
+
 ## Integrations with DigitalOcean
 
 ### Embedding models for vector search

--- a/docs/weaviate/starter-guides/which-weaviate.md
+++ b/docs/weaviate/starter-guides/which-weaviate.md
@@ -19,6 +19,7 @@ Weaviate can be deployed in the following ways:
 - [Embedded Weaviate](/deploy/installation-guides/embedded.md)
 - [Docker-Compose](/deploy/installation-guides/docker-installation.md)
 - [Weaviate Cloud (WCD)](/deploy/installation-guides/weaviate-cloud.md)
+- [DigitalOcean Managed Weaviate](/deploy/installation-guides/digitalocean.md), a fully managed Weaviate service operated by DigitalOcean
 - [Self-managed Kubernetes](/deploy/installation-guides/k8s-installation.md)
 - [Hybrid SaaS](https://weaviate.io/pricing)
 
@@ -86,12 +87,13 @@ Keep in mind two other factors, which are cost, and their footprint.
 For production deployments, consider one of these hosting models:
 
 - [Weaviate Cloud (WCD)](/cloud)
+- [DigitalOcean Managed Weaviate](/deploy/installation-guides/digitalocean.md)
 - [Self-managed Kubernetes](/deploy/installation-guides/k8s-installation.md)
 - [Hybrid SaaS](/cloud)
 
 All of these options are scalable. Kubernetes and Hybrid SaaS offer the most configuration flexibility.
 
-A WCD-based solution is the easiest way to deploy Weaviate in terms of setup and maintenance. A self-managed Kubernetes deployment combines flexibility and scalability.
+A WCD-based solution is the easiest way to deploy Weaviate in terms of setup and maintenance. A self-managed Kubernetes deployment combines flexibility and scalability. DigitalOcean Managed Weaviate is a fully managed option operated by DigitalOcean, a good fit for teams already on DigitalOcean or who want managed hosting outside Weaviate Cloud.
 
 If you need additional configuration control, but you don't want to manage your Weaviate deployment, Hybrid SaaS offers a best-of-both-worlds solution.
 

--- a/docs/weaviate/starter-guides/which-weaviate.md
+++ b/docs/weaviate/starter-guides/which-weaviate.md
@@ -19,7 +19,7 @@ Weaviate can be deployed in the following ways:
 - [Embedded Weaviate](/deploy/installation-guides/embedded.md)
 - [Docker-Compose](/deploy/installation-guides/docker-installation.md)
 - [Weaviate Cloud (WCD)](/deploy/installation-guides/weaviate-cloud.md)
-- [DigitalOcean Managed Weaviate](/deploy/installation-guides/digitalocean.md), a fully managed Weaviate service operated by DigitalOcean
+- [DigitalOcean Managed Weaviate](/deploy/installation-guides/digitalocean.md)
 - [Self-managed Kubernetes](/deploy/installation-guides/k8s-installation.md)
 - [Hybrid SaaS](https://weaviate.io/pricing)
 


### PR DESCRIPTION
DigitalOcean Managed Weaviate moved from **private** to **public** preview (announced 2026-07-09). This updates the deploy docs to match.

## Changes
- `deploy/installation-guides/digitalocean.md` — flip the admonition to **Public preview**; remove the pre-GA caveat ("APIs, plans, regions, and Control Panel surfaces may change before general availability."); add the announcement link under **Further resources**.
- `deploy/index.mdx` — DigitalOcean deployment card: "Currently in private preview" → "Currently in public preview".
- `deploy/installation-guides/index.md` — installation-methods list: "(private preview)" → "(public preview)".

## Notes for the reviewer
- The deployment card's **Production** tab (`active: false`) was intentionally left unchanged — flipping it is a production-readiness claim, out of scope for this wording update. Happy to flip it in a follow-up if the offering is considered production-suitable.
- No new page or nav slot was needed — the DigitalOcean deploy page and its sidebar category already existed (previously staged as private preview).

Announcement: https://www.digitalocean.com/blog/public-preview-managed-weaviate
