### PR TITLE
docs: reference updates for Weaviate 1.39

### DIFF
--- a/_includes/feature-notes/boost.mdx
+++ b/_includes/feature-notes/boost.mdx
@@ -1,3 +1,2 @@
-:::caution Preview — added in `v1.38`
-This is a preview feature. The API may change in future releases.
+:::info Added in `v1.39`
 :::

--- a/docs/deploy/configuration/monitoring.md
+++ b/docs/deploy/configuration/monitoring.md
@@ -282,14 +282,6 @@ These metrics track Write-Ahead Log (WAL) recovery operations during startup.
 | `schema_reads_leader_seconds`     | Duration of schema reads that are passed to the leader        | `type` | `Summary` |
 | `schema_wait_for_version_seconds` | Duration of waiting for a schema version to be reached        | `type` | `Summary` |
 
-#### Schema transactions (deprecated)
-
-| Metric                       | Description                                                                             | Labels                | Type      |
-| ---------------------------- | --------------------------------------------------------------------------------------- | --------------------- | --------- |
-| `schema_tx_opened_total`     | Total number of opened schema transactions                                              | `ownership`           | `Counter` |
-| `schema_tx_closed_total`     | Total number of closed schema transactions. A close must be either successful or failed | `ownership`, `status` | `Counter` |
-| `schema_tx_duration_seconds` | Mean duration of a tx by status                                                         | `ownership`, `status` | `Summary` |
-
 #### RAFT metrics (internal)
 
 | Metric                                                        | Description                                                                                                                          | Labels                    | Type      |

--- a/docs/weaviate/search/bm25.md
+++ b/docs/weaviate/search/bm25.md
@@ -16,7 +16,7 @@ import GoCode from '!!raw-loader!/\_includes/code/howto/go/docs/mainpkg/search-b
 import JavaV6Code from "!!raw-loader!/\_includes/code/java-v6/src/test/java/SearchKeywordTest.java";
 import CSharpCode from "!!raw-loader!/\_includes/code/csharp/SearchKeywordTest.cs";
 import GQLCode from '!!raw-loader!/\_includes/code/howto/search.bm25.gql.py';
-import BoostPreview from '/_includes/feature-notes/boost.mdx';
+import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 `Keyword` search, also called "BM25 (Best match 25)" or "sparse vector" search, returns objects that have the highest BM25F scores.
 
@@ -767,7 +767,7 @@ Set the tokenization method to `trigram` at the property level when creating you
 
 ## Soft-rank with Boost
 
-<BoostPreview/>
+<BoostNote/>
 
 Keyword (BM25) queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
 

--- a/docs/weaviate/search/boost.md
+++ b/docs/weaviate/search/boost.md
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 import PyCode from '!!raw-loader!/_includes/code/howto/search.boost.py';
-import BoostPreview from '/_includes/feature-notes/boost.mdx';
+import BoostNote from '/_includes/feature-notes/boost.mdx';
 
-<BoostPreview/>
+<BoostNote/>
 
 **Boost** soft-ranks search results — promote or demote matching documents without removing them from the result set. Matching documents move up. Non-matching documents stay in the results but rank lower.
 

--- a/docs/weaviate/search/hybrid.md
+++ b/docs/weaviate/search/hybrid.md
@@ -16,7 +16,7 @@ import GoCode from '!!raw-loader!/\_includes/code/howto/go/docs/mainpkg/search-h
 import JavaV6Code from "!!raw-loader!/\_includes/code/java-v6/src/test/java/SearchHybridTest.java";
 import CSharpCode from "!!raw-loader!/\_includes/code/csharp/SearchHybridTest.cs";
 import GQLCode from '!!raw-loader!/\_includes/code/howto/search.hybrid.gql.py';
-import BoostPreview from '/_includes/feature-notes/boost.mdx';
+import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 `Hybrid` search combines the results of a vector search and a keyword (BM25F) search by fusing the two result sets.
 
@@ -1041,7 +1041,7 @@ import TokenizationNote from '/\_includes/tokenization.mdx'
 
 ## Soft-rank with Boost
 
-<BoostPreview/>
+<BoostNote/>
 
 Hybrid queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property.
 

--- a/docs/weaviate/search/rerank.md
+++ b/docs/weaviate/search/rerank.md
@@ -16,7 +16,7 @@ import SimilarityPyCode from '!!raw-loader!/_includes/code/howto/search.similari
 import SimilarityPyCodeV3 from '!!raw-loader!/_includes/code/howto/search.similarity-v3.py';
 import SimilarityTSCode from '!!raw-loader!/_includes/code/howto/search.similarity.ts';
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/mainpkg/search-rerank_test.go';
-import BoostPreview from '/_includes/feature-notes/boost.mdx';
+import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 Reranking modules reorder the search result set according to a different set of criteria or a different (e.g. more expensive) algorithm.
 
@@ -199,7 +199,7 @@ The response should look like this:
 
 ## Soft-rank with Boost
 
-<BoostPreview/>
+<BoostNote/>
 
 For lightweight result reordering based on filters, property values, or time / numeric decay — without calling an external rerank model — use [Boost](./boost.md). Rerank and Boost can be used independently. Pick rerank when you need a smarter model to re-rank the top-N, and Boost when you want to bias by simple signals already on the objects.
 

--- a/docs/weaviate/search/similarity.md
+++ b/docs/weaviate/search/similarity.md
@@ -15,7 +15,7 @@ import TSCode from '!!raw-loader!/\_includes/code/howto/search.similarity.ts';
 import GoCode from '!!raw-loader!/\_includes/code/howto/go/docs/mainpkg/search-similarity_test.go';
 import JavaV6Code from "!!raw-loader!/\_includes/code/java-v6/src/test/java/SearchSimilarityTest.java";
 import CSharpCode from "!!raw-loader!/\_includes/code/csharp/SearchSimilarityTest.cs";
-import BoostPreview from '/_includes/feature-notes/boost.mdx';
+import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 Vector search returns the objects with most similar vectors to that of the query.
 
@@ -719,7 +719,7 @@ A larger candidate set (higher top-level `limit`) gives MMR more results to choo
 
 ## Soft-rank with Boost
 
-<BoostPreview/>
+<BoostNote/>
 
 Vector search queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
 


### PR DESCRIPTION
First round of 1.39 docs. Targets `v1-39/main` so it ships at GA, not before.

- Removed the `schema_tx_opened_total`, `schema_tx_closed_total` and `schema_tx_duration_seconds` metrics, deleted from core in 1.39. This was the whole `Schema transactions (deprecated)` subsection; no inbound anchors.
- Boost API promoted from preview to GA. The note renders on five pages, so the `BoostPreview` import alias was renamed to `BoostNote` to match.

Site build passes.

Note on the Boost label: it reads `Added in v1.39` to match the other feature notes. Boost's proto shipped in v1.38.0, so strictly it was added in 1.38 and goes GA in 1.39. Flagged and accepted as the established convention.