### PR TITLE
docs: signal REST Search API and gRPC-Web on the GraphQL page (Phase 0)

### DIFF
--- a/_includes/rest-search-note.ga.mdx
+++ b/_includes/rest-search-note.ga.mdx
@@ -1,0 +1,5 @@
+{/* DRAFT - GA phase. Not imported anywhere yet. Swap into rest-search-note.mdx at GA. */}
+
+:::info Querying over plain HTTP
+Weaviate's client libraries query over gRPC. For environments that can't use a client library, for example no-code and BI tools, or languages without an official client such as PHP and Ruby, the **REST Search API** provides stable plain-HTTP search endpoints that mirror these GraphQL queries, and is the recommended option for HTTP-only stacks. Browser and edge (for example Cloudflare Workers) support is available via gRPC-Web in the TypeScript client. See the [REST Search API](/weaviate/api/rest) to get started.
+:::

--- a/_includes/rest-search-note.mdx
+++ b/_includes/rest-search-note.mdx
@@ -1,0 +1,19 @@
+{/*
+  SINGLE SOURCE OF TRUTH: this partial is the one place the "REST Search API"
+  signal is worded. It is imported wherever the signal appears, so the wording
+  is edited here once and updates every page that shows it.
+
+  PHASE TRANSITIONS (kept explicit so the future edit is mechanical):
+
+  (a) GA SWAP: When REST Search + gRPC-Web reach GA, replace this file's body
+      with the contents of rest-search-note.ga.mdx (drop 'experimental'/'off by
+      default'; frame REST Search as recommended for HTTP-only stacks).
+
+  (b) gRPC-WEB LINE: When the TypeScript gRPC-Web client (TS PR #307, package
+      @weaviate/web) ships, change 'is also coming to the TypeScript client' to
+      present tense and link the package.
+*/}
+
+:::info Querying over plain HTTP
+Weaviate's client libraries query over gRPC. If your environment can't use a client library, for example no-code and BI tools, or languages without an official client such as PHP and Ruby, an **experimental REST Search API** (v1.39+) offers plain-HTTP search endpoints that mirror these GraphQL queries. Browser and edge (for example Cloudflare Workers) support via gRPC-Web is also coming to the TypeScript client. See the [REST Search API](/weaviate/api/rest) to try it.
+:::

--- a/docs/weaviate/api/graphql/_drafts/choosing-a-search-api.md
+++ b/docs/weaviate/api/graphql/_drafts/choosing-a-search-api.md
@@ -1,0 +1,141 @@
+---
+title: Choosing a search API
+draft: true
+---
+
+**DRAFT, not published, pending sign-off.**
+
+<!--
+DRAFT, not published, pending sign-off.
+This file lives under `_drafts/` so Docusaurus does not build it (underscore-prefixed
+folders are excluded from the docs plugin). Do NOT add it to `sidebars.js`.
+The near-text field casing, response shape, and merged-endpoint set below are confirmed
+against shipped source (origin/stable/v1.38, which carries PR #12227). The gRPC-Web
+TypeScript preview is an early-access branch install (`@weaviate/web`, TS PR #307) around
+the 1.39 release, not yet a published package.
+Companion proposal at the repo root: `search-api-docs-restructuring-proposal.md`.
+-->
+
+# Choosing a search API
+
+## Which query API should I use, and why
+
+Weaviate exposes the same search capabilities through more than one wire protocol. This
+page is a decision aid: it tells you which one to reach for, and states plainly what each
+one can and cannot do. The short version:
+
+- If you can run one of the official client libraries, use it. It talks to Weaviate over
+  gRPC and is the primary, full-parity path, with typed generated clients and strong
+  on-the-wire performance.
+- If your stack can only reach Weaviate over plain HTTP, the REST Search API is the
+  fallback. It takes native-JSON request bodies with no URL encoding, and it is a
+  deliberate subset that is experimental today.
+- GraphQL is the established query API. It remains available and covers the full query
+  surface. Use it where it already fits your stack.
+
+## When to use which
+
+| Path | Reach for it when | Coverage | Status |
+|---|---|---|---|
+| **Official client library over gRPC** | You can run one of the official clients (Python, JS/TS, Go, Java, C#), including edge and serverless JavaScript through the gRPC-Web preview. | Full parity. This is the primary path. | Stable, recommended default. |
+| **REST Search API** | Your stack reaches Weaviate over plain HTTP and cannot use gRPC: no-code platforms, BI tools, and languages with no official client (for example PHP, Ruby). | Deliberate subset. This is a fallback. | Experimental, off by default. Near-text available now, more operators on the way. |
+| **GraphQL** | You already query over GraphQL, or you want one flexible query language that covers the full surface today. | Established, full-featured. | Available. |
+
+The gRPC-Web path for edge and serverless JavaScript is early access. Around the 1.39
+release it is available by installing the `@weaviate/web` package from the gRPC-Web preview
+branch, rather than as a published release. Treat it as preview until a package release
+follows.
+
+### What each path is good at
+
+- **Official client over gRPC:** typed, generated clients (request and response shapes are
+  code, not hand-built strings) and strong on-the-wire performance. This is the fastest
+  path to correct, maintainable queries.
+- **REST Search API:** native-JSON request bodies with no URL encoding of filters or
+  queries, and reach into places gRPC cannot go (no-code platforms, BI tools, and
+  HTTP-only languages).
+
+## GraphQL to REST field mapping (near-text)
+
+The REST Search API uses camelCase request-body fields. The near-text operator is available
+now at `POST /v1/search/{collection}/near-text` (the collection sits in the middle of the
+path, and the operator is kebab-case). The mapping from the GraphQL near-text form:
+
+| GraphQL (near-text) | REST request-body field |
+|---|---|
+| nearText concepts ["x","y"] | "query": ["x", "y"] |
+| nearText targetVectors ["title_vec"] | "targetVector": "title_vec" |
+| where {WhereFilter} | "where": { same JSON, unencoded } |
+| field selection title, hasAuthor.name | "returnProperties": ["title", "hasAuthor.name"] |
+| _additional { distance score } | "returnMetadata": ["distance", "score"] |
+| autocut | "autoLimit" |
+| tenant | "tenant" |
+| consistencyLevel | "consistencyLevel" |
+| generate singleResult { prompt } / groupedResult { task } | "singlePrompt" / "groupedTask" |
+
+Notes on the mapping:
+
+- `id` is returned at the top level of each hit, not inside `returnMetadata`. Do not put
+  `"id"` in `returnMetadata`.
+- The metadata names available in `returnMetadata` (camelCase) are: `distance`,
+  `certainty`, `score`, `explainScore`, `creationTime`, `lastUpdateTime`.
+- `singlePrompt` and `groupedTask` are reserved: the retrieval-augmented generation (RAG)
+  parameters are accepted in the schema but currently return `422` not-yet-supported.
+- The bm25 and hybrid operators (with their query-properties, alpha, and fusion-type
+  controls) arrive with those endpoints. Their exact request-field names are fixed when
+  those endpoints land, so they are not listed here yet.
+
+### Response shape
+
+The REST response drops the GraphQL `data.Get.<Collection>` envelope. The top-level wrapper
+is a `results` array plus a `tookMs` timing field, and each hit is an envelope:
+
+```json
+{
+  "results": [
+    {
+      "id": "<uuid>",
+      "properties": { },
+      "references": { },
+      "metadata": { }
+    }
+  ],
+  "tookMs": 0
+}
+```
+
+Selected data properties sit under `properties`, one hop of references under `references`,
+and retrieval metadata under `metadata` (no leading underscore). `id` is always present at
+the top level of each hit. Compared with GraphQL, `_additional` becomes `metadata`, and
+there is no snake_case form anywhere: it is `metadata`, not `_metadata`, and `tookMs`, not
+`took_ms`.
+
+## What the REST Search API does not do
+
+State these plainly to any reader evaluating REST as an alternative:
+
+- It is **currently experimental and off by default**. Endpoints are opt-in.
+- It is **POST-only** right now.
+- It is **growing**. Near-text is available now; bm25, hybrid, near-object, and aggregate
+  are on the way; the RAG parameters (`singlePrompt` / `groupedTask`) are reserved and
+  currently return `422` not-yet-supported.
+- It **deliberately does not cover** the following. These are intentional scope-outs, not
+  bugs:
+  - raw `nearVector`
+  - media search (image, audio, and similar)
+  - multi-target vector weighting
+  - hybrid sub-searches
+  - `moveTo` / `moveAway` on near-text
+  - vectors returned in metadata
+  - multi-hop references (only one hop of references is returned)
+  - `Explore`
+
+If you need raw-vector search or media search, use an official client. Those workloads
+belong on the clients, not on the REST subset.
+
+## Summary
+
+Use an official client over gRPC when you can: it is the primary, full-parity path, with
+typed clients and strong performance. Reach for the REST Search API when your stack cannot
+speak gRPC, and expect a growing subset. GraphQL remains available as the established query
+language for the cases where it already fits.

--- a/docs/weaviate/api/graphql/index.md
+++ b/docs/weaviate/api/graphql/index.md
@@ -6,6 +6,7 @@ image: og/docs/api.jpg
 # tags: ['GraphQL references']
 ---
 
+import RestSearchNote from '/_includes/rest-search-note.mdx';
 
 ## API
 
@@ -14,6 +15,8 @@ Weaviate offers [GraphQL](https://graphql.org/) and gRPC APIs for queries.
 We recommend using a Weaviate [client library](../../client-libraries/index.mdx), which abstracts away the underlying API calls and makes it easier to integrate Weaviate into your application.
 
 However, you can query Weaviate directly using GraphQL with a POST request to the `/graphql` endpoint, or write your own `gRPC` calls based on the [gRPC](../grpc.md) protobuf specification.
+
+<RestSearchNote />
 
 
 ## All references

--- a/search-api-docs-restructuring-proposal.md
+++ b/search-api-docs-restructuring-proposal.md
@@ -1,0 +1,145 @@
+<!--
+DRAFT, not published, pending sign-off.
+This file sits at the repository root, OUTSIDE the Docusaurus content root (`docs/docs/`),
+so it is never built into the site. It is an internal planning document.
+It describes changes; it does NOT implement them. Nothing here has been applied to
+`sidebars.js` or to any published page.
+-->
+
+# DRAFT: Search API docs restructuring proposal
+
+**DRAFT, not published, pending sign-off. Internal planning document. Implements nothing.**
+
+## Purpose
+
+Describe, without implementing, how the Weaviate search documentation could be restructured
+so that the official clients (over gRPC) and the REST Search API become the primary,
+front-and-center query paths, while the GraphQL reference is clearly scoped and
+cross-linked rather than the default landing point.
+
+The driver is positive: Weaviate now offers two strong query paths alongside GraphQL. The
+official clients over gRPC give typed, generated clients and strong performance, and the
+REST Search API gives native-JSON request bodies with reach into HTTP-only stacks that
+gRPC cannot serve. The documentation should surface these as the primary choices. This is a
+documentation-structure change. Any future change to GraphQL itself is a separate
+leadership decision and is out of scope here.
+
+Companion seed document (unbuilt draft):
+`docs/weaviate/api/graphql/_drafts/choosing-a-search-api.md`.
+
+## Target information architecture
+
+Today the search reference is organized under a single category whose label leads with
+GraphQL:
+
+- `Search API - GraphQL/gRPC` (category)
+  - Object-level queries (`get`)
+  - Aggregate
+  - Search operators
+  - Conditional filters
+  - Additional operators
+  - Additional properties
+  - Explore
+
+The proposed end-state is a unified **Search** section where the client/gRPC path and the
+REST Search API are primary, and GraphQL is a clearly labeled reference that is
+cross-linked rather than the default:
+
+- **Search** (category)
+  - **Choosing a search API** (the decision aid; seeded from the `_drafts` comparison)
+  - **Clients over gRPC** (primary; links to the client-libraries and gRPC references)
+  - **REST Search API** (the HTTP-only alternative; labeled as a subset and, while it
+    remains so, as experimental)
+  - **GraphQL reference** (scoped; retains `get`, `aggregate`, `search-operators`,
+    `filters`, `additional-operators`, `additional-properties`, `explore`, with a neutral
+    cross-link up to "Choosing a search API")
+  - **GraphQL to REST/gRPC migration** (the migration page; seeded from the cheat-sheet in
+    the `_drafts` comparison)
+
+The intent is ordering and framing, not deletion. Every existing GraphQL page keeps its URL
+and its content in this end-state. The GraphQL reference is repositioned in prominence, not
+removed.
+
+## How `sidebars.js` WOULD change (description only; do NOT make this edit)
+
+The relevant block today lives in `sidebars.js` inside the API sidebar, roughly:
+
+```
+{
+  type: "category",
+  label: "Search API - GraphQL/gRPC",
+  link: { type: "doc", id: "weaviate/api/graphql/index" },
+  items: [
+    "weaviate/api/graphql/get",
+    "weaviate/api/graphql/aggregate",
+    "weaviate/api/graphql/search-operators",
+    "weaviate/api/graphql/filters",
+    "weaviate/api/graphql/additional-operators",
+    "weaviate/api/graphql/additional-properties",
+    "weaviate/api/graphql/explore",
+  ],
+},
+```
+
+The eventual edit (to be made later, under sign-off, not now) would:
+
+1. Rename the category label from `Search API - GraphQL/gRPC` to a neutral `Search`.
+2. Add, above the GraphQL items, entries for the new primary pages: the "Choosing a search
+   API" decision aid, a "Clients over gRPC" entry, and a "REST Search API" entry.
+3. Nest the existing GraphQL entries under a `GraphQL reference` sub-grouping so they read
+   as one reference among several, rather than as the whole of search.
+4. Add a `GraphQL to REST/gRPC migration` entry once that page exists.
+
+No IDs are removed and no page files are moved in this plan, so the change stays reversible:
+reverting the label and re-flattening the `items` array restores today's structure exactly.
+
+This proposal does NOT make any of these edits. It only describes them.
+
+## Future "GraphQL to REST/gRPC migration" page
+
+A dedicated migration page would be seeded from the cheat-sheet already drafted in
+`docs/weaviate/api/graphql/_drafts/choosing-a-search-api.md` (the near-text GraphQL to REST
+field mapping table plus the response-shape note). That draft is the seed; the migration
+page would expand it into worked before-and-after examples, and would grow the mapping as
+the bm25, hybrid, near-object, and aggregate endpoints land.
+
+## Staged, reversible rollout
+
+Each phase is additive and reversible. No phase moves or deletes a published page.
+
+**Phase 0 (now).** The two `_drafts` seeds stay unbuilt. Nothing is published, and
+`sidebars.js` is untouched. This is a staging phase only.
+
+**Phase 1 (at REST Search API GA).** Publish the "Choosing a search API" comparison and the
+"GraphQL to REST/gRPC migration" page, and reframe the search sidebar so the clients over
+gRPC and the REST Search API read as the primary paths and the GraphQL reference is scoped
+and cross-linked. This is the phase where the `sidebars.js` reframe described above would
+land. Existing GraphQL pages keep their URLs and content.
+
+Any future change to GraphQL itself is a separate leadership decision and is out of scope
+for this document.
+
+## What must NOT be done yet
+
+Until sign-off moves us past Phase 0, the following are explicitly out of bounds:
+
+- **No sidebar reordering.** `sidebars.js` is not to be edited. The "how it would change"
+  section above is a description, not a change.
+- **No moving or renaming published pages.** Every current GraphQL reference page keeps its
+  path and content.
+- **No deprecation notices.** No "deprecated", "sunset", "end of life", or "will be
+  removed" language on any published page, and no commentary on the future of GraphQL.
+- **No publishing of the `_drafts` seeds.** They remain under an underscore-prefixed folder,
+  excluded from the build, until sign-off.
+- **No timeline claims.** No dates anywhere.
+
+## Fact-check status of the seed draft
+
+The near-text facts in the seed draft (`choosing-a-search-api.md`) are confirmed against
+shipped source (origin/stable/v1.38, which carries PR #12227): camelCase request-body
+fields; the endpoint `POST /v1/search/{collection}/near-text`; the response wrapper
+`{ "results": [...], "tookMs": <number> }` with per-hit `id` / `properties` / `references`
+/ `metadata` envelopes; near-text as the one merged operator with bm25, hybrid, near-object,
+and aggregate on the way; and the gRPC-Web TypeScript preview as an early-access branch
+install rather than a published package. No open verification markers remain in the seed
+draft.


### PR DESCRIPTION
Phase 0 of the GraphQL alternatives comms plan: make GraphQL users aware that non-GraphQL query paths exist, framed additively, with **no** deprecation/removal/timeline language.

## Live change (the only thing that renders)
- `docs/weaviate/api/graphql/index.md` renders a gentle `:::info` note near the top pointing HTTP-only stacks (no-code, BI, PHP, Ruby) at the experimental REST Search API and the coming gRPC-Web TypeScript support.
- `_includes/rest-search-note.mdx` is the note's single source of truth. Its top comment documents the two one-line phase transitions (GA wording swap, gRPC-Web present-tense line).

This passed an editor gate against the comms plan do-NOT-say list and a build check.

## Staged, does NOT build (for later phases, review-optional)
- `_includes/rest-search-note.ga.mdx` — pre-written GA-swap wording, imported nowhere.
- `docs/weaviate/api/graphql/_drafts/choosing-a-search-api.md` — "Choosing a search API" comparison. `_drafts/` is excluded from the build.
- `search-api-docs-restructuring-proposal.md` — repo-root planning doc, outside the content tree, not built.

## Notes for the reviewer
- The note names no API field names, so it is immune to the camelCase/snake_case question. The staged comparison draft uses the confirmed camelCase shape.
- The restructuring proposal is internal planning; if you would rather it not live in the public docs repo, drop that one file from this PR.