### PR TITLE
Use server-side batching in the quickstart import step

### DIFF
--- a/_includes/code/csharp/QuickstartLocalTest.cs
+++ b/_includes/code/csharp/QuickstartLocalTest.cs
@@ -95,7 +95,7 @@ public class QuickstartLocalTest
         if (insertResponse.HasErrors)
         {
             Console.WriteLine($"Number of failed imports: {insertResponse.Errors.Count()}");
-            // `Objects` holds one entry per object, in the order they were sent
+            // `Objects` holds one entry per object; `Index` is the position of the object in the input
             foreach (var entry in insertResponse.Objects.Where(o => o.Error is not null))
             {
                 Console.WriteLine($"Failed object at index {entry.Index}: {entry.Error.Message}");
@@ -103,7 +103,7 @@ public class QuickstartLocalTest
         }
         else
         {
-            Console.WriteLine($"Successfully inserted {insertResponse.Objects.Count()} objects.");
+            Console.WriteLine($"Successfully inserted {insertResponse.Count} objects.");
         }
         // END Import
 

--- a/_includes/code/csharp/QuickstartLocalTest.cs
+++ b/_includes/code/csharp/QuickstartLocalTest.cs
@@ -87,21 +87,25 @@ public class QuickstartLocalTest
             );
         }
 
-        // Call InsertMany with the list of objects converted to an array
-        var insertResponse = await questions.Data.InsertMany(questionsToInsert.ToArray());
+        // `Batch.InsertMany` imports the list using server-side batching
+        var insertResponse = await questions.Batch.InsertMany(questionsToInsert);
         // highlight-end
-        // END Import
 
         // Check for errors
         if (insertResponse.HasErrors)
         {
             Console.WriteLine($"Number of failed imports: {insertResponse.Errors.Count()}");
-            Console.WriteLine($"First failed object error: {insertResponse.Errors.First()}");
+            // `Objects` holds one entry per object, in the order they were sent
+            foreach (var entry in insertResponse.Objects.Where(o => o.Error is not null))
+            {
+                Console.WriteLine($"Failed object at index {entry.Index}: {entry.Error.Message}");
+            }
         }
         else
         {
             Console.WriteLine($"Successfully inserted {insertResponse.Objects.Count()} objects.");
         }
+        // END Import
 
         // START NearText
         // highlight-start

--- a/_includes/code/csharp/QuickstartTest.cs
+++ b/_includes/code/csharp/QuickstartTest.cs
@@ -103,7 +103,7 @@ public class QuickstartTest
         if (insertResponse.HasErrors)
         {
             Console.WriteLine($"Number of failed imports: {insertResponse.Errors.Count()}");
-            // `Objects` holds one entry per object, in the order they were sent
+            // `Objects` holds one entry per object; `Index` is the position of the object in the input
             foreach (var entry in insertResponse.Objects.Where(o => o.Error is not null))
             {
                 Console.WriteLine($"Failed object at index {entry.Index}: {entry.Error.Message}");
@@ -111,7 +111,7 @@ public class QuickstartTest
         }
         else
         {
-            Console.WriteLine($"Successfully inserted {insertResponse.Objects.Count()} objects.");
+            Console.WriteLine($"Successfully inserted {insertResponse.Count} objects.");
         }
         // END Import
 

--- a/_includes/code/csharp/QuickstartTest.cs
+++ b/_includes/code/csharp/QuickstartTest.cs
@@ -95,21 +95,25 @@ public class QuickstartTest
             );
         }
 
-        // Call InsertMany with the list of objects converted to an array
-        var insertResponse = await questions.Data.InsertMany(questionsToInsert.ToArray());
+        // `Batch.InsertMany` imports the list using server-side batching
+        var insertResponse = await questions.Batch.InsertMany(questionsToInsert);
         // highlight-end
-        // END Import
 
         // Check for errors
         if (insertResponse.HasErrors)
         {
             Console.WriteLine($"Number of failed imports: {insertResponse.Errors.Count()}");
-            Console.WriteLine($"First failed object error: {insertResponse.Errors.First()}");
+            // `Objects` holds one entry per object, in the order they were sent
+            foreach (var entry in insertResponse.Objects.Where(o => o.Error is not null))
+            {
+                Console.WriteLine($"Failed object at index {entry.Index}: {entry.Error.Message}");
+            }
         }
         else
         {
             Console.WriteLine($"Successfully inserted {insertResponse.Objects.Count()} objects.");
         }
+        // END Import
 
         // START NearText
         // highlight-start

--- a/_includes/code/csharp/quickstart/QuickstartCreate.cs
+++ b/_includes/code/csharp/quickstart/QuickstartCreate.cs
@@ -65,8 +65,8 @@ namespace WeaviateProject.Examples
                 },
             };
 
-            // Insert objects using InsertMany
-            var insertResponse = await movies.Data.InsertMany(dataObjects.ToArray());
+            // Insert the objects using server-side batching
+            var insertResponse = await movies.Batch.InsertMany(dataObjects);
 
             if (insertResponse.HasErrors)
             {

--- a/_includes/code/csharp/quickstart/QuickstartCreateVectors.cs
+++ b/_includes/code/csharp/quickstart/QuickstartCreateVectors.cs
@@ -92,8 +92,8 @@ namespace WeaviateProject.Examples
                 ),
             };
 
-            // Insert the objects with vectors
-            var insertResponse = await movies.Data.InsertMany(dataToInsert);
+            // Insert the objects with vectors using server-side batching
+            var insertResponse = await movies.Batch.InsertMany(dataToInsert);
 
             if (insertResponse.HasErrors)
             {

--- a/_includes/code/csharp/quickstart/QuickstartLocalCreate.cs
+++ b/_includes/code/csharp/quickstart/QuickstartLocalCreate.cs
@@ -70,8 +70,8 @@ namespace WeaviateProject.Examples
                 },
             };
 
-            // Insert objects using InsertMany
-            var insertResponse = await movies.Data.InsertMany(dataObjects.ToArray());
+            // Insert the objects using server-side batching
+            var insertResponse = await movies.Batch.InsertMany(dataObjects);
 
             if (insertResponse.HasErrors)
             {

--- a/_includes/code/csharp/quickstart/QuickstartLocalCreateVectors.cs
+++ b/_includes/code/csharp/quickstart/QuickstartLocalCreateVectors.cs
@@ -76,8 +76,8 @@ namespace WeaviateProject.Examples
                 ),
             };
 
-            // Insert the objects with vectors
-            var insertResponse = await movies.Data.InsertMany(dataToInsert);
+            // Insert the objects with vectors using server-side batching
+            var insertResponse = await movies.Batch.InsertMany(dataToInsert);
             if (insertResponse.HasErrors)
             {
                 Console.WriteLine($"Errors during import: {insertResponse.Errors}");

--- a/_includes/code/java-v6/src/test/java/QuickstartLocalTest.java
+++ b/_includes/code/java-v6/src/test/java/QuickstartLocalTest.java
@@ -3,7 +3,8 @@ import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.Generative;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.WeaviateObject;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -94,16 +95,21 @@ class QuickstartLocalTest {
       questionsToInsert.add(properties);
     });
 
-    // Call insertMany with the list of objects
-    InsertManyResponse insertResponse = questions.data.insertMany(questionsToInsert.toArray(new Map[0]));
+    // `batch.start()` opens a server-side batch
+    BatchContext<Map<String, Object>> batch = questions.batch.start();
+    // Closing the batch sends the remaining objects and waits for the results
+    try (batch) {
+      for (Map<String, Object> properties : questionsToInsert) {
+        batch.add(WeaviateObject.<Map<String, Object>>of(o -> o.properties(properties)));
+      }
+    }
     // highlight-end
 
     // Check for errors
-    if (!insertResponse.errors().isEmpty()) {
-      System.err.printf("Number of failed imports: %d\n", insertResponse.errors().size());
-      System.err.printf("First failed object error: %s\n", insertResponse.errors().get(0));
+    if (batch.numberOfErrors() > 0) {
+      System.err.printf("Number of failed imports: %d\n", batch.numberOfErrors());
     } else {
-      System.out.printf("Successfully inserted %d objects.\n", insertResponse.uuids().size());
+      System.out.printf("Successfully inserted %d objects.\n", questionsToInsert.size());
     }
     // END Import
     // client.collections.delete(collectionName);

--- a/_includes/code/java-v6/src/test/java/QuickstartTest.java
+++ b/_includes/code/java-v6/src/test/java/QuickstartTest.java
@@ -3,7 +3,8 @@ import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.Generative;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.WeaviateObject;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -115,16 +116,21 @@ class QuickstartTest {
       questionsToInsert.add(properties);
     });
 
-    // Call insertMany with the list of objects
-    InsertManyResponse insertResponse = questions.data.insertMany(questionsToInsert.toArray(new Map[0]));
+    // `batch.start()` opens a server-side batch
+    BatchContext<Map<String, Object>> batch = questions.batch.start();
+    // Closing the batch sends the remaining objects and waits for the results
+    try (batch) {
+      for (Map<String, Object> properties : questionsToInsert) {
+        batch.add(WeaviateObject.<Map<String, Object>>of(o -> o.properties(properties)));
+      }
+    }
     // highlight-end
 
     // Check for errors
-    if (!insertResponse.errors().isEmpty()) {
-      System.err.printf("Number of failed imports: %d\n", insertResponse.errors().size());
-      System.err.printf("First failed object error: %s\n", insertResponse.errors().get(0));
+    if (batch.numberOfErrors() > 0) {
+      System.err.printf("Number of failed imports: %d\n", batch.numberOfErrors());
     } else {
-      System.out.printf("Successfully inserted %d objects.\n", insertResponse.uuids().size());
+      System.out.printf("Successfully inserted %d objects.\n", questionsToInsert.size());
     }
     // END Import
     // client.collections.delete(collectionName);

--- a/_includes/code/java-v6/src/test/java/quickstart/QuickstartCreate.java
+++ b/_includes/code/java-v6/src/test/java/quickstart/QuickstartCreate.java
@@ -5,7 +5,8 @@ import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.WeaviateObject;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
 
 import java.util.List;
 import java.util.Map;
@@ -54,18 +55,24 @@ public class QuickstartCreate {
               "A meek Hobbit and his companions set out on a perilous journey to destroy a powerful ring and save Middle-earth.",
               "genre", "Fantasy"));
 
-      // Insert objects using insertMany
+      // Insert the objects using server-side batching
       CollectionHandle<Map<String, Object>> movies =
           client.collections.use(collectionName);
-      InsertManyResponse insertResponse =
-          movies.data.insertMany(dataObjects.toArray(new Map[0]));
+      BatchContext<Map<String, Object>> batch = movies.batch.start();
+      // Closing the batch sends the remaining objects and waits for the results
+      try (batch) {
+        for (Map<String, Object> properties : dataObjects) {
+          batch.add(
+              WeaviateObject.<Map<String, Object>>of(o -> o.properties(properties)));
+        }
+      }
 
-      if (!insertResponse.errors().isEmpty()) {
-        System.err.println("Errors during import: " + insertResponse.errors());
+      if (batch.numberOfErrors() > 0) {
+        System.err
+            .println("Number of failed imports: " + batch.numberOfErrors());
       } else {
-        System.out
-            .println("Imported & vectorized " + insertResponse.uuids().size()
-                + " objects into the Movie collection");
+        System.out.println("Imported & vectorized " + dataObjects.size()
+            + " objects into the Movie collection");
       }
     } finally {
       if (client != null) {

--- a/_includes/code/java-v6/src/test/java/quickstart/QuickstartCreateVectors.java
+++ b/_includes/code/java-v6/src/test/java/quickstart/QuickstartCreateVectors.java
@@ -7,7 +7,8 @@ import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
+import java.util.List;
 import java.util.Map;
 
 public class QuickstartCreateVectors {
@@ -63,20 +64,30 @@ public class QuickstartCreateVectors {
       float[] vector3 =
           new float[] {0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f};
 
-      // Insert the objects with vectors
+      // Insert the objects with vectors using server-side batching
       CollectionHandle<Map<String, Object>> movies =
           client.collections.use(collectionName);
-      InsertManyResponse insertResponse = movies.data.insertMany(
+      List<WeaviateObject<Map<String, Object>>> objectsToInsert = List.of(
           WeaviateObject.of(v -> v.properties(props1)
               .vectors(Vectors.of(vector1))),
           WeaviateObject.of(v -> v.properties(props2)
               .vectors(Vectors.of(vector2))),
           WeaviateObject.of(v -> v.properties(props3)
               .vectors(Vectors.of(vector3))));
-      if (!insertResponse.errors().isEmpty()) {
-        System.err.println("Errors during import: " + insertResponse.errors());
+
+      BatchContext<Map<String, Object>> batch = movies.batch.start();
+      // Closing the batch sends the remaining objects and waits for the results
+      try (batch) {
+        for (WeaviateObject<Map<String, Object>> object : objectsToInsert) {
+          batch.add(object);
+        }
+      }
+
+      if (batch.numberOfErrors() > 0) {
+        System.err
+            .println("Number of failed imports: " + batch.numberOfErrors());
       } else {
-        System.out.println("Imported " + insertResponse.uuids().size()
+        System.out.println("Imported " + objectsToInsert.size()
             + " objects with vectors into the Movie collection");
       }
     } finally {

--- a/_includes/code/java-v6/src/test/java/quickstart/QuickstartLocalCreate.java
+++ b/_includes/code/java-v6/src/test/java/quickstart/QuickstartLocalCreate.java
@@ -5,7 +5,8 @@ import io.weaviate.client6.v1.api.WeaviateClient;
 import io.weaviate.client6.v1.api.collections.CollectionHandle;
 import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.WeaviateObject;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
 
 import java.util.List;
 import java.util.Map;
@@ -53,18 +54,24 @@ public class QuickstartLocalCreate {
               "A meek Hobbit and his companions set out on a perilous journey to destroy a powerful ring and save Middle-earth.",
               "genre", "Fantasy"));
 
-      // Insert objects using insertMany
+      // Insert the objects using server-side batching
       CollectionHandle<Map<String, Object>> movies =
           client.collections.use(collectionName);
-      InsertManyResponse insertResponse =
-          movies.data.insertMany(dataObjects.toArray(new Map[0]));
+      BatchContext<Map<String, Object>> batch = movies.batch.start();
+      // Closing the batch sends the remaining objects and waits for the results
+      try (batch) {
+        for (Map<String, Object> properties : dataObjects) {
+          batch.add(
+              WeaviateObject.<Map<String, Object>>of(o -> o.properties(properties)));
+        }
+      }
 
-      if (!insertResponse.errors().isEmpty()) {
-        System.err.println("Errors during import: " + insertResponse.errors());
+      if (batch.numberOfErrors() > 0) {
+        System.err
+            .println("Number of failed imports: " + batch.numberOfErrors());
       } else {
-        System.out
-            .println("Imported & vectorized " + insertResponse.uuids().size()
-                + " objects into the Movie collection");
+        System.out.println("Imported & vectorized " + dataObjects.size()
+            + " objects into the Movie collection");
       }
     } finally {
       if (client != null) {

--- a/_includes/code/java-v6/src/test/java/quickstart/QuickstartLocalCreateVectors.java
+++ b/_includes/code/java-v6/src/test/java/quickstart/QuickstartLocalCreateVectors.java
@@ -7,7 +7,8 @@ import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
 import io.weaviate.client6.v1.api.collections.Vectors;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
-import io.weaviate.client6.v1.api.collections.data.InsertManyResponse;
+import io.weaviate.client6.v1.api.collections.batch.BatchContext;
+import java.util.List;
 import java.util.Map;
 
 public class QuickstartLocalCreateVectors {
@@ -59,10 +60,10 @@ public class QuickstartLocalCreateVectors {
       float[] vector3 =
           new float[] {0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f};
 
-      // Insert the objects with vectors
+      // Insert the objects with vectors using server-side batching
       CollectionHandle<Map<String, Object>> movies =
           client.collections.use(collectionName);
-      InsertManyResponse insertResponse = movies.data.insertMany(
+      List<WeaviateObject<Map<String, Object>>> objectsToInsert = List.of(
           WeaviateObject.of(v -> v.properties(props1)
               .vectors(Vectors.of(vector1))),
           WeaviateObject.of(v -> v.properties(props2)
@@ -70,10 +71,19 @@ public class QuickstartLocalCreateVectors {
           WeaviateObject.of(v -> v.properties(props3)
               .vectors(Vectors.of(vector3))));
 
-      if (!insertResponse.errors().isEmpty()) {
-        System.err.println("Errors during import: " + insertResponse.errors());
+      BatchContext<Map<String, Object>> batch = movies.batch.start();
+      // Closing the batch sends the remaining objects and waits for the results
+      try (batch) {
+        for (WeaviateObject<Map<String, Object>> object : objectsToInsert) {
+          batch.add(object);
+        }
+      }
+
+      if (batch.numberOfErrors() > 0) {
+        System.err
+            .println("Number of failed imports: " + batch.numberOfErrors());
       } else {
-        System.out.println("Imported " + insertResponse.uuids().size()
+        System.out.println("Imported " + objectsToInsert.size()
             + " objects with vectors into the Movie collection");
       }
     } finally {

--- a/_includes/code/llms-txt/python/quickstart.py
+++ b/_includes/code/llms-txt/python/quickstart.py
@@ -46,9 +46,7 @@ with weaviate.connect_to_weaviate_cloud(
     movies = client.collections.use("Movie__QuickstartPy")
 
     # Import objects
-    with movies.batch.fixed_size(batch_size=200) as batch:
-        for obj in data_objects:
-            batch.add_object(properties=obj)
+    movies.data.ingest(data_objects)
 
     print(f"Imported & vectorized {len(data_objects)} objects into the Movie collection")
 

--- a/_includes/code/llms-txt/typescript/quickstart.ts
+++ b/_includes/code/llms-txt/typescript/quickstart.ts
@@ -36,7 +36,7 @@ if (!(await client.collections.exists('Movie__QuickstartTs'))) {
 const movies = client.collections.use('Movie__QuickstartTs');
 
 // Import objects
-await movies.data.insertMany(dataObjects);
+await movies.data.ingest(dataObjects.map((properties) => ({ properties })));
 
 console.log(`Imported & vectorized ${dataObjects.length} objects into the Movie collection`);
 

--- a/_includes/code/python/local.quickstart.import_objects.py
+++ b/_includes/code/python/local.quickstart.import_objects.py
@@ -24,6 +24,7 @@ result = questions.data.ingest(
 )
 # highlight-end
 
+# Also check `errors` directly; it is populated for every failed object
 if result.has_errors or result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
     # `errors` is keyed by the position of the object in the input

--- a/_includes/code/python/local.quickstart.import_objects.py
+++ b/_includes/code/python/local.quickstart.import_objects.py
@@ -9,27 +9,26 @@ resp = requests.get(
 )
 data = json.loads(resp.text)
 
-# highlight-start
 questions = client.collections.use("Question")
 
-with questions.batch.fixed_size(batch_size=200) as batch:
-    for d in data:
-        batch.add_object(
-            {
-                "answer": d["Answer"],
-                "question": d["Question"],
-                "category": d["Category"],
-            }
-        )
-        # highlight-end
-        if batch.number_errors > 10:
-            print("Batch import stopped due to excessive errors.")
-            break
+# highlight-start
+result = questions.data.ingest(
+    [
+        {
+            "answer": d["Answer"],
+            "question": d["Question"],
+            "category": d["Category"],
+        }
+        for d in data
+    ]
+)
+# highlight-end
 
-failed_objects = questions.batch.failed_objects
-if failed_objects:
-    print(f"Number of failed imports: {len(failed_objects)}")
-    print(f"First failed object: {failed_objects[0]}")
+if result.has_errors or result.errors:
+    print(f"Number of failed imports: {len(result.errors)}")
+    # `errors` is keyed by the position of the object in the input
+    for index, error in result.errors.items():
+        print(f"Failed object at index {index}: {error.message}")
 
 client.close()  # Free up resources
 # END Import

--- a/_includes/code/python/local.quickstart.import_objects.py
+++ b/_includes/code/python/local.quickstart.import_objects.py
@@ -24,10 +24,9 @@ result = questions.data.ingest(
 )
 # highlight-end
 
-# `errors` is the reliable failure check for `ingest`
+# `errors` holds one entry per failed object, keyed by its position in the input
 if result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
-    # `errors` is keyed by the position of the object in the input
     for index, error in result.errors.items():
         print(f"Failed object at index {index}: {error.message}")
 

--- a/_includes/code/python/local.quickstart.import_objects.py
+++ b/_includes/code/python/local.quickstart.import_objects.py
@@ -24,8 +24,8 @@ result = questions.data.ingest(
 )
 # highlight-end
 
-# Also check `errors` directly; it is populated for every failed object
-if result.has_errors or result.errors:
+# `errors` is the reliable failure check for `ingest`
+if result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
     # `errors` is keyed by the position of the object in the input
     for index, error in result.errors.items():

--- a/_includes/code/python/quickstart.import_objects.py
+++ b/_includes/code/python/quickstart.import_objects.py
@@ -32,10 +32,9 @@ result = questions.data.ingest(
 )
 # highlight-end
 
-# `errors` is the reliable failure check for `ingest`
+# `errors` holds one entry per failed object, keyed by its position in the input
 if result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
-    # `errors` is keyed by the position of the object in the input
     for index, error in result.errors.items():
         print(f"Failed object at index {index}: {error.message}")
 

--- a/_includes/code/python/quickstart.import_objects.py
+++ b/_includes/code/python/quickstart.import_objects.py
@@ -17,27 +17,26 @@ resp = requests.get(
 )
 data = json.loads(resp.text)
 
-# highlight-start
 questions = client.collections.use("Question")
 
-with questions.batch.fixed_size(batch_size=200) as batch:
-    for d in data:
-        batch.add_object(
-            {
-                "answer": d["Answer"],
-                "question": d["Question"],
-                "category": d["Category"],
-            }
-        )
-        # highlight-end
-        if batch.number_errors > 10:
-            print("Batch import stopped due to excessive errors.")
-            break
+# highlight-start
+result = questions.data.ingest(
+    [
+        {
+            "answer": d["Answer"],
+            "question": d["Question"],
+            "category": d["Category"],
+        }
+        for d in data
+    ]
+)
+# highlight-end
 
-failed_objects = questions.batch.failed_objects
-if failed_objects:
-    print(f"Number of failed imports: {len(failed_objects)}")
-    print(f"First failed object: {failed_objects[0]}")
+if result.has_errors or result.errors:
+    print(f"Number of failed imports: {len(result.errors)}")
+    # `errors` is keyed by the position of the object in the input
+    for index, error in result.errors.items():
+        print(f"Failed object at index {index}: {error.message}")
 
 client.close()  # Free up resources
 # END Import

--- a/_includes/code/python/quickstart.import_objects.py
+++ b/_includes/code/python/quickstart.import_objects.py
@@ -32,6 +32,7 @@ result = questions.data.ingest(
 )
 # highlight-end
 
+# Also check `errors` directly; it is populated for every failed object
 if result.has_errors or result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
     # `errors` is keyed by the position of the object in the input

--- a/_includes/code/python/quickstart.import_objects.py
+++ b/_includes/code/python/quickstart.import_objects.py
@@ -32,8 +32,8 @@ result = questions.data.ingest(
 )
 # highlight-end
 
-# Also check `errors` directly; it is populated for every failed object
-if result.has_errors or result.errors:
+# `errors` is the reliable failure check for `ingest`
+if result.errors:
     print(f"Number of failed imports: {len(result.errors)}")
     # `errors` is keyed by the position of the object in the input
     for index, error in result.errors.items():

--- a/_includes/code/python/quickstart.short.create_collection.py
+++ b/_includes/code/python/quickstart.short.create_collection.py
@@ -42,9 +42,7 @@ with weaviate.connect_to_weaviate_cloud(
     # START CreateCollection
 
     movies = client.collections.use("Movie")
-    with movies.batch.fixed_size(batch_size=200) as batch:
-        for obj in data_objects:
-            batch.add_object(properties=obj)
+    movies.data.ingest(data_objects)
 
     print(f"Imported & vectorized {len(movies)} objects into the Movie collection")
 # END CreateCollection

--- a/_includes/code/python/quickstart.short.import_vectors.create_collection.py
+++ b/_includes/code/python/quickstart.short.import_vectors.create_collection.py
@@ -1,6 +1,7 @@
 # START CreateCollection
 import weaviate
 from weaviate.classes.config import Configure
+from weaviate.classes.data import DataObject
 import os
 
 # Best practice: store your credentials in environment variables
@@ -46,9 +47,10 @@ with weaviate.connect_to_weaviate_cloud(
 
     # Insert the objects with vectors
     movies = client.collections.get("Movie")
-    with movies.batch.fixed_size(batch_size=200) as batch:
-        for obj in data_objects:
-            batch.add_object(properties=obj["properties"], vector=obj["vector"])
+    movies.data.ingest(
+        DataObject(properties=obj["properties"], vector=obj["vector"])
+        for obj in data_objects
+    )
 
     print(
         f"Imported {len(data_objects)} objects with vectors into the Movie collection"

--- a/_includes/code/python/quickstart.short.local.create_collection.py
+++ b/_includes/code/python/quickstart.short.local.create_collection.py
@@ -36,9 +36,7 @@ with weaviate.connect_to_local() as client:
     # START CreateCollection
 
     movies = client.collections.use("Movie")
-    with movies.batch.fixed_size(batch_size=200) as batch:
-        for obj in data_objects:
-            batch.add_object(properties=obj)
+    movies.data.ingest(data_objects)
 
     print(f"Imported & vectorized {len(movies)} objects into the Movie collection")
     # END CreateCollection

--- a/_includes/code/python/quickstart.short.local.import_vectors.create_collection.py
+++ b/_includes/code/python/quickstart.short.local.import_vectors.create_collection.py
@@ -1,6 +1,7 @@
 # START CreateCollection
 import weaviate
 from weaviate.classes.config import Configure
+from weaviate.classes.data import DataObject
 
 # Step 1.1: Connect to your local Weaviate instance
 with weaviate.connect_to_local() as client:
@@ -38,9 +39,10 @@ with weaviate.connect_to_local() as client:
 
     # Insert the objects with vectors
     movies = client.collections.get("Movie")
-    with movies.batch.fixed_size(batch_size=200) as batch:
-        for obj in data_objects:
-            batch.add_object(properties=obj["properties"], vector=obj["vector"])
+    movies.data.ingest(
+        DataObject(properties=obj["properties"], vector=obj["vector"])
+        for obj in data_objects
+    )
 
     print(
         f"Imported {len(data_objects)} objects with vectors into the Movie collection"

--- a/_includes/code/quickstart/local.quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/local.quickstart.import_objects.mdx
@@ -8,6 +8,8 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartLocalTest.cs";
 
 
+Every import returns a result that reports which objects failed, if any. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
 
@@ -19,7 +21,7 @@ import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartLocalTest.
     title="quickstart_import.py"
   />
 
-The import returns a result object that reports whether anything failed, along with an entry for each failed object keyed by its position in the input. Check it after every import so that problems such as malformed data or a misconfigured model provider do not go unnoticed. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+`data.ingest()` returns a `BatchObjectReturn`. Read `result.has_errors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 
@@ -32,6 +34,8 @@ The import returns a result object that reports whether anything failed, along w
   language="ts"
   title="quickstart_import.ts"
 />
+
+`data.ingest()` returns a result object. Read `result.hasErrors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input.
 
 </TabItem>
 

--- a/_includes/code/quickstart/local.quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/local.quickstart.import_objects.mdx
@@ -19,7 +19,7 @@ import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartLocalTest.
     title="quickstart_import.py"
   />
 
-During a batch import, any failed objects can be obtained through `batch.failed_objects`. Additionally, a running count of failed objects is maintained and can be accessed through `batch.number_errors` within the context manager. This counter can be used to stop the import process in order to investigate the failed objects or references. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+The import returns a result object that reports whether anything failed, along with an entry for each failed object keyed by its position in the input. Check it after every import so that problems such as malformed data or a misconfigured model provider do not go unnoticed. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 

--- a/_includes/code/quickstart/local.quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/local.quickstart.import_objects.mdx
@@ -8,7 +8,7 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartLocalTest.cs";
 
 
-Every import returns a result that reports whether any objects failed. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+Every import reports whether any objects failed. Check for failures in your own code to catch problems such as malformed data or a misconfigured model provider.
 
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
@@ -57,7 +57,7 @@ Every import returns a result that reports whether any objects failed. Check it 
   language="java"
 />
 
-`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results, so read `batch.numberOfErrors()` afterwards for the number of objects that failed.
+`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results. Read `batch.numberOfErrors()` after the batch closes; before then, the tally is incomplete.
 
 </TabItem>
 
@@ -69,7 +69,7 @@ Every import returns a result that reports whether any objects failed. Check it 
       language="csharp"
     />
 
-`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, and `Objects` for one entry per object, each carrying the `Error` that failed it.
+`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, `Errors` for the failures alone, and `Objects` for one entry per object. Each entry's `Index` is its position in the input, and failed entries carry an `Error`.
 
   </TabItem>
 

--- a/_includes/code/quickstart/local.quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/local.quickstart.import_objects.mdx
@@ -8,7 +8,7 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartLocalTest.cs";
 
 
-Every import returns a result that reports which objects failed, if any. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+Every import returns a result that reports whether any objects failed. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
 
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
@@ -56,6 +56,9 @@ Every import returns a result that reports which objects failed, if any. Check i
   endMarker="// END Import"
   language="java"
 />
+
+`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results, so read `batch.numberOfErrors()` afterwards for the number of objects that failed.
+
 </TabItem>
 
   <TabItem value="csharp" label="C#">
@@ -65,6 +68,9 @@ Every import returns a result that reports which objects failed, if any. Check i
       endMarker="// END Import"
       language="csharp"
     />
+
+`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, and `Objects` for one entry per object, each carrying the `Error` that failed it.
+
   </TabItem>
 
 <TabItem value="curl" label="Curl">

--- a/_includes/code/quickstart/local.quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/local.quickstart.import_objects.mdx
@@ -21,7 +21,7 @@ Every import returns a result that reports which objects failed, if any. Check i
     title="quickstart_import.py"
   />
 
-`data.ingest()` returns a `BatchObjectReturn`. Read `result.has_errors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+`data.ingest()` returns a `BatchObjectReturn`. Read `result.errors` to check for failures. It holds one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 

--- a/_includes/code/quickstart/quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/quickstart.import_objects.mdx
@@ -8,7 +8,7 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartTest.cs";
 
 
-Every import returns a result that reports whether any objects failed. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+Every import reports whether any objects failed. Check for failures in your own code to catch problems such as malformed data or a misconfigured model provider.
 
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
@@ -20,7 +20,6 @@ Every import returns a result that reports whether any objects failed. Check it 
     language="py"
     title="quickstart_import.py"
   />
-
 
 `data.ingest()` returns a `BatchObjectReturn`. Read `result.errors` to check for failures. It holds one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
@@ -58,7 +57,7 @@ Every import returns a result that reports whether any objects failed. Check it 
   language="java"
 />
 
-`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results, so read `batch.numberOfErrors()` afterwards for the number of objects that failed.
+`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results. Read `batch.numberOfErrors()` after the batch closes; before then, the tally is incomplete.
 
 </TabItem>
 
@@ -70,7 +69,7 @@ Every import returns a result that reports whether any objects failed. Check it 
       language="csharp"
     />
 
-`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, and `Objects` for one entry per object, each carrying the `Error` that failed it.
+`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, `Errors` for the failures alone, and `Objects` for one entry per object. Each entry's `Index` is its position in the input, and failed entries carry an `Error`.
 
   </TabItem>
 

--- a/_includes/code/quickstart/quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/quickstart.import_objects.mdx
@@ -20,7 +20,7 @@ import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartTest.cs";
   />
 
 
-During a batch import, any failed objects can be obtained through `batch.failed_objects`. Additionally, a running count of failed objects is maintained and can be accessed through `batch.number_errors` within the context manager. This counter can be used to stop the import process in order to investigate the failed objects or references. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+The import returns a result object that reports whether anything failed, along with an entry for each failed object keyed by its position in the input. Check it after every import so that problems such as malformed data or a misconfigured model provider do not go unnoticed. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 

--- a/_includes/code/quickstart/quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/quickstart.import_objects.mdx
@@ -8,7 +8,7 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartTest.cs";
 
 
-Every import returns a result that reports which objects failed, if any. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+Every import returns a result that reports whether any objects failed. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
 
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
@@ -57,6 +57,9 @@ Every import returns a result that reports which objects failed, if any. Check i
   endMarker="// END Import"
   language="java"
 />
+
+`batch.start()` opens a server-side batch. Closing the batch sends any remaining objects and waits for the server to report the results, so read `batch.numberOfErrors()` afterwards for the number of objects that failed.
+
 </TabItem>
 
   <TabItem value="csharp" label="C#">
@@ -66,6 +69,9 @@ Every import returns a result that reports which objects failed, if any. Check i
       endMarker="// END Import"
       language="csharp"
     />
+
+`Batch.InsertMany()` returns a `BatchInsertResponse`. Read `HasErrors` for a quick check, and `Objects` for one entry per object, each carrying the `Error` that failed it.
+
   </TabItem>
 
 <TabItem value="curl" label="Curl">

--- a/_includes/code/quickstart/quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/quickstart.import_objects.mdx
@@ -8,6 +8,8 @@ import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/Quick
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartTest.cs";
 
 
+Every import returns a result that reports which objects failed, if any. Check it in your own code to catch problems such as malformed data or a misconfigured model provider.
+
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
 
@@ -20,7 +22,7 @@ import CSharpCode from "!!raw-loader!/_includes/code/csharp/QuickstartTest.cs";
   />
 
 
-The import returns a result object that reports whether anything failed, along with an entry for each failed object keyed by its position in the input. Check it after every import so that problems such as malformed data or a misconfigured model provider do not go unnoticed. Find out more about error handling on the Python client [reference page](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+`data.ingest()` returns a `BatchObjectReturn`. Read `result.has_errors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 
@@ -33,6 +35,8 @@ The import returns a result object that reports whether anything failed, along w
   language="ts"
   title="quickstart_import.ts"
 />
+
+`data.ingest()` returns a result object. Read `result.hasErrors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input.
 
 </TabItem>
 

--- a/_includes/code/quickstart/quickstart.import_objects.mdx
+++ b/_includes/code/quickstart/quickstart.import_objects.mdx
@@ -22,7 +22,7 @@ Every import returns a result that reports which objects failed, if any. Check i
   />
 
 
-`data.ingest()` returns a `BatchObjectReturn`. Read `result.has_errors` for a quick check, and `result.errors` for one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
+`data.ingest()` returns a `BatchObjectReturn`. Read `result.errors` to check for failures. It holds one entry per failed object, keyed by its position in the input. For more, see [error handling in the Python client reference](/weaviate/client-libraries/python/notes-best-practices#error-handling).
 
 </TabItem>
 

--- a/_includes/code/typescript/local.quickstart.import_objects.ts
+++ b/_includes/code/typescript/local.quickstart.import_objects.ts
@@ -16,6 +16,7 @@ async function importQuestions() {
   const data = await getJsonData();
 
   // highlight-start
+  // `ingest` imports the list using server-side batching
   const result = await questions.data.ingest(
     data.map((properties) => ({ properties }))
   );

--- a/_includes/code/typescript/local.quickstart.import_objects.ts
+++ b/_includes/code/typescript/local.quickstart.import_objects.ts
@@ -11,18 +11,26 @@ async function getJsonData() {
   return file.json();
 }
 
-// highlight-start
-// Note: The TS client does not have a `batch` method yet
-// We use `insertMany` instead, which sends all of the data in one request
 async function importQuestions() {
   const questions = client.collections.use('Question');
   const data = await getJsonData();
-  const result = await questions.data.insertMany(data);
-  console.log('Insertion response: ', result);
+
+  // highlight-start
+  const result = await questions.data.ingest(
+    data.map((properties) => ({ properties }))
+  );
+  // highlight-end
+
+  if (result.hasErrors) {
+    console.log(`Number of failed imports: ${Object.keys(result.errors).length}`);
+    // `errors` is keyed by the position of the object in the input
+    for (const [index, error] of Object.entries(result.errors)) {
+      console.log(`Failed object at index ${index}: ${error.message}`);
+    }
+  }
 }
 
 await importQuestions();
-// highlight-end
 
 client.close(); // Close the client connection
 // END Import

--- a/_includes/code/typescript/quickstart.import_objects.ts
+++ b/_includes/code/typescript/quickstart.import_objects.ts
@@ -25,6 +25,7 @@ async function importQuestions() {
   const data = await getJsonData();
 
   // highlight-start
+  // `ingest` imports the list using server-side batching
   const result = await questions.data.ingest(
     data.map((properties) => ({ properties }))
   );

--- a/_includes/code/typescript/quickstart.import_objects.ts
+++ b/_includes/code/typescript/quickstart.import_objects.ts
@@ -20,18 +20,26 @@ async function getJsonData() {
   return file.json();
 }
 
-// highlight-start
-// Note: The TS client does not have a `batch` method yet
-// We use `insertMany` instead, which sends all of the data in one request
 async function importQuestions() {
   const questions = client.collections.use('Question');
   const data = await getJsonData();
-  const result = await questions.data.insertMany(data);
-  console.log('Insertion response: ', result);
+
+  // highlight-start
+  const result = await questions.data.ingest(
+    data.map((properties) => ({ properties }))
+  );
+  // highlight-end
+
+  if (result.hasErrors) {
+    console.log(`Number of failed imports: ${Object.keys(result.errors).length}`);
+    // `errors` is keyed by the position of the object in the input
+    for (const [index, error] of Object.entries(result.errors)) {
+      console.log(`Failed object at index ${index}: ${error.message}`);
+    }
+  }
 }
 
 await importQuestions();
-// highlight-end
 
 client.close(); // Close the client connection
 // END Import

--- a/_includes/code/typescript/quickstart.short.create_collection.ts
+++ b/_includes/code/typescript/quickstart.short.create_collection.ts
@@ -41,7 +41,9 @@ const dataObjects = [
 
 // START CreateCollection
 const movieCollection = client.collections.get('Movie');
-const response = await movieCollection.data.insertMany(dataObjects);
+await movieCollection.data.ingest(
+  dataObjects.map((properties) => ({ properties }))
+);
 
 console.log(`Imported & vectorized ${dataObjects.length} objects into the Movie collection`);
 

--- a/_includes/code/typescript/quickstart.short.import_vectors.create_collection.ts
+++ b/_includes/code/typescript/quickstart.short.import_vectors.create_collection.ts
@@ -51,7 +51,7 @@ const dataObjects = [
 // START CreateCollection
 // Insert the objects with vectors
 const movieCollection = client.collections.get('Movie');
-const response = await movieCollection.data.insertMany(dataObjects);
+await movieCollection.data.ingest(dataObjects);
 
 console.log(`Imported ${dataObjects.length} objects with vectors into the Movie collection`);
 

--- a/_includes/code/typescript/quickstart.short.local.create_collection.ts
+++ b/_includes/code/typescript/quickstart.short.local.create_collection.ts
@@ -35,7 +35,9 @@ const dataObjects = [
 
 // START CreateCollection
 const movieCollection = client.collections.get('Movie');
-const response = await movieCollection.data.insertMany(dataObjects);
+await movieCollection.data.ingest(
+  dataObjects.map((properties) => ({ properties }))
+);
 
 console.log(`Imported & vectorized ${dataObjects.length} objects into the Movie collection`);
 

--- a/_includes/code/typescript/quickstart.short.local.import_vectors.create_collection.ts
+++ b/_includes/code/typescript/quickstart.short.local.import_vectors.create_collection.ts
@@ -36,7 +36,7 @@ const dataObjects = [
 
 // Insert the objects with vectors
 const movieCollection = client.collections.get('Movie');
-const response = await movieCollection.data.insertMany(dataObjects);
+await movieCollection.data.ingest(dataObjects);
 
 console.log(`Imported ${dataObjects.length} objects with vectors into the Movie collection`);
 

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -221,11 +221,11 @@ We can now add data to our collection.
 The following example:
 
 - Loads objects, and
-- Adds objects to the target collection (`Question`) using a batch process.
+- Adds objects to the target collection (`Question`) with a batch import.
 
 :::tip Batch imports
 
-([Batch imports](/weaviate/manage-objects/import.mdx)) are the most efficient way to add large amounts of data, as it sends multiple objects in a single request. See the [How-to: Batch import](/weaviate/manage-objects/import.mdx) guide for more information.
+Batch imports are the most efficient way to add large amounts of data, because they send objects in groups instead of one request per object. See the [How-to: Batch import](/weaviate/manage-objects/import.mdx) guide for the available methods, including [server-side batching](/weaviate/manage-objects/import.mdx#server-side-batching), where the server tells the client how much data to send next.
 
 :::
 

--- a/docs/weaviate/quickstart/local.md
+++ b/docs/weaviate/quickstart/local.md
@@ -152,10 +152,6 @@ import CreateCollectionCustomVectors from "/_includes/code/quickstart/quickstart
 </TabItem>
 </Tabs>
 
-:::note Requirement: Weaviate v1.36 or later
-The `docker-compose.yml` file on this page runs a current Weaviate release, so the examples in this step work as written. The Python and JavaScript/TypeScript examples [import a list of objects in a single call](../manage-objects/import.mdx#ingest-an-in-memory-list), which relies on [server-side batching](../manage-objects/import.mdx#server-side-batching) and needs Weaviate `v1.36` or later. Check the version first if you point the examples at an existing instance.
-:::
-
 ## Step 2: Semantic (vector) search {#semantic-search}
 
 <Tabs groupId="import" queryString="import" className="hidden-tabs">

--- a/docs/weaviate/quickstart/local.md
+++ b/docs/weaviate/quickstart/local.md
@@ -126,6 +126,10 @@ import CodeClientInstall from "/_includes/code/quickstart/clients.install.new.md
 
 ## Step 1: Create a collection & import data {#create-a-collection}
 
+:::info Minimum Weaviate version
+The Python and JavaScript/TypeScript examples below import data with [server-side batching](../manage-objects/import.mdx#server-side-batching), which requires Weaviate `v1.36` or later. The Docker Compose file above runs a current release, so this is only a concern if you point the examples at an older instance.
+:::
+
 There are two paths you can choose from when importing data:
 
 <CardsSection items={quickstartOptions} className={styles.smallCards} />

--- a/docs/weaviate/quickstart/local.md
+++ b/docs/weaviate/quickstart/local.md
@@ -126,10 +126,6 @@ import CodeClientInstall from "/_includes/code/quickstart/clients.install.new.md
 
 ## Step 1: Create a collection & import data {#create-a-collection}
 
-:::info Minimum Weaviate version
-The Python and JavaScript/TypeScript examples below import data with [server-side batching](../manage-objects/import.mdx#server-side-batching), which requires Weaviate `v1.36` or later. The Docker Compose file above runs a current release, so this is only a concern if you point the examples at an older instance.
-:::
-
 There are two paths you can choose from when importing data:
 
 <CardsSection items={quickstartOptions} className={styles.smallCards} />
@@ -155,6 +151,10 @@ import CreateCollectionCustomVectors from "/_includes/code/quickstart/quickstart
 
 </TabItem>
 </Tabs>
+
+:::note Requirement: Weaviate v1.36 or later
+The `docker-compose.yml` file on this page runs a current Weaviate release, so the examples in this step work as written. The Python and JavaScript/TypeScript examples [import a list of objects in a single call](../manage-objects/import.mdx#ingest-an-in-memory-list), which relies on [server-side batching](../manage-objects/import.mdx#server-side-batching) and needs Weaviate `v1.36` or later. Check the version first if you point the examples at an existing instance.
+:::
 
 ## Step 2: Semantic (vector) search {#semantic-search}
 

--- a/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
+++ b/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
@@ -212,11 +212,11 @@ We can now add data to our collection.
 The following example:
 
 - Loads objects, and
-- Adds objects to the target collection (`Question`) using a batch process.
+- Adds objects to the target collection (`Question`) with a batch import.
 
 :::tip Batch imports
 
-([Batch imports](../manage-objects/import.mdx)) are the most efficient way to add large amounts of data, as it sends multiple objects in a single request. See the [How-to: Batch import](../manage-objects/import.mdx) guide for more information.
+Batch imports are the most efficient way to add large amounts of data, because they send objects in groups instead of one request per object. See the [How-to: Batch import](../manage-objects/import.mdx) guide for the available methods, including [server-side batching](../manage-objects/import.mdx#server-side-batching), where the server tells the client how much data to send next.
 
 :::
 


### PR DESCRIPTION
Moves the quickstart import step to server-side batching. Go is unchanged — the Go client has no server-side batching API.

- Python and TypeScript — `data.ingest()`
- Java — `collection.batch.start()` / `BatchContext`
- C# — `collection.Batch.InsertMany()`
- Error-handling prose reworked per client; the shared line above the tabs no longer makes a client-specific claim

Two things that look removable but are not. The TypeScript `.map((properties) => ({ properties }))` wrappers are required, or properties are not persisted (weaviate/typescript-client#456). And `batch.numberOfErrors()` in Java must be read after the batch closes, not inside the try block, or it reports zero.

Merge after #486.
