### PR TITLE
docs(openai): add concrete DaoXE example for X-OpenAI-Baseurl

### DIFF
--- a/docs/weaviate/model-providers/openai/embeddings.md
+++ b/docs/weaviate/model-providers/openai/embeddings.md
@@ -274,7 +274,9 @@ Provide the headers as shown in the [API credentials examples](#api-credentials)
 
 :::note
 
-By passing the `X-OpenAI-Baseurl`, you can use an endpoint compatible with the OpenAI API. Weaviate appends `/v1/embeddings` to this base URL. If this doesn't match your endpoint, you can rewrite the path with a proxy (e.g., `your.domain.com/v1/embeddings` -> `api.deepinfra.com/v1/openai/embeddings`).
+By passing the `X-OpenAI-Baseurl`, you can use an endpoint compatible with the OpenAI API. Weaviate appends `/v1/embeddings` to this base URL. Example: `https://api.daoxe.com` (DaoXE's standard OpenAI-compatible base URL; it supports `/v1/embeddings`).
+
+If your endpoint uses a different path prefix, rewrite with a proxy (e.g., `your.domain.com/v1/embeddings` -> `api.deepinfra.com/v1/openai/embeddings` or `api.daoxe.com/v1/embeddings`).
 
 :::
 


### PR DESCRIPTION
## Summary

Document a concrete OpenAI-compatible base URL example for `X-OpenAI-Baseurl` on the OpenAI embeddings provider page.

Weaviate appends `/v1/embeddings` to the base URL. Example: `https://api.daoxe.com` (DaoXE). If a provider uses a different path prefix, rewrite with a proxy as already noted.

DaoXE is **one concrete example** among OpenAI-compatible gateways — no pricing/uptime claims.

Docs only.

## Test plan
- [ ] Embeddings provider page renders
- [ ] Note remains optional / non-breaking

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>