### PR TITLE
docs: document the gRPC-Web interface (GA in 1.39)

### DIFF
--- a/docs/cloud/manage-clusters/connect.mdx
+++ b/docs/cloud/manage-clusters/connect.mdx
@@ -81,7 +81,7 @@ If you don't have an existing API key, you'll need to create one. Follow these s
 :::note REST Endpoint vs gRPC Endpoint
 When using an official Weaviate [client library](/weaviate/client-libraries), you need to authenticate using the `REST Endpoint` and your API key. The client will infer the gRPC endpoint automatically and use the more performant gRPC protocol when available.
 
-The [gRPC-web interface](/weaviate/api/grpc.md#grpc-web) is reached through the `REST Endpoint` URL, not the `gRPC Endpoint` URL, because it is served on the REST port.
+To reach the [gRPC-Web interface](/weaviate/api/grpc.md#grpc-web), use the `REST Endpoint` URL, not the `gRPC Endpoint` URL, because gRPC-Web is served on the REST port.
 :::
 
 ### Environment variables

--- a/docs/cloud/manage-clusters/connect.mdx
+++ b/docs/cloud/manage-clusters/connect.mdx
@@ -80,6 +80,8 @@ If you don't have an existing API key, you'll need to create one. Follow these s
 
 :::note REST Endpoint vs gRPC Endpoint
 When using an official Weaviate [client library](/weaviate/client-libraries), you need to authenticate using the `REST Endpoint` and your API key. The client will infer the gRPC endpoint automatically and use the more performant gRPC protocol when available.
+
+The [gRPC-web interface](/weaviate/api/grpc.md#grpc-web) is reached through the `REST Endpoint` URL, not the `gRPC Endpoint` URL, because it is served on the REST port.
 :::
 
 ### Environment variables

--- a/docs/deploy/configuration/env-vars/runtime-config.md
+++ b/docs/deploy/configuration/env-vars/runtime-config.md
@@ -86,7 +86,7 @@ The following overrides are currently supported:
 | `tenant_activity_read_log_level`                 | `TENANT_ACTIVITY_READ_LOG_LEVEL`             |
 | `tenant_activity_write_log_level`                | `TENANT_ACTIVITY_WRITE_LOG_LEVEL`            |
 
-`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-Web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent, so it can only be set as a runtime override.
+`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-Web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent. In the static configuration file the same setting is spelled `grpc.grpcWebEnabled`, in camelCase.
 
 ### Raft settings
 

--- a/docs/deploy/configuration/env-vars/runtime-config.md
+++ b/docs/deploy/configuration/env-vars/runtime-config.md
@@ -11,7 +11,7 @@ import RuntimeConfig from '/_includes/feature-notes/runtime-config.mdx';
 
 Weaviate supports runtime configuration management, allowing some configurations to be changed without any further restarts.
 
-Most runtime configurations correspond to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable. A few runtime configurations are available only as overrides and have no environment variable equivalent.
+Most runtime configurations correspond to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable.
 
 ## How to set up runtime configuration
 
@@ -85,8 +85,6 @@ The following overrides are currently supported:
 | `revectorize_check_disabled`                     | `REVECTORIZE_CHECK_DISABLED`                 |
 | `tenant_activity_read_log_level`                 | `TENANT_ACTIVITY_READ_LOG_LEVEL`             |
 | `tenant_activity_write_log_level`                | `TENANT_ACTIVITY_WRITE_LOG_LEVEL`            |
-
-`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-Web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent. In the static configuration file the same setting is spelled `grpc.grpcWebEnabled`, in camelCase.
 
 ### Raft settings
 

--- a/docs/deploy/configuration/env-vars/runtime-config.md
+++ b/docs/deploy/configuration/env-vars/runtime-config.md
@@ -11,7 +11,7 @@ import RuntimeConfig from '/_includes/feature-notes/runtime-config.mdx';
 
 Weaviate supports runtime configuration management, allowing some configurations to be changed without any further restarts.
 
-Most runtime configurations correspond to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable. A few settings are available only as runtime overrides and have no environment variable equivalent.
+Most runtime configurations correspond to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable. A few runtime configurations are available only as overrides and have no environment variable equivalent.
 
 ## How to set up runtime configuration
 
@@ -86,7 +86,7 @@ The following overrides are currently supported:
 | `tenant_activity_read_log_level`                 | `TENANT_ACTIVITY_READ_LOG_LEVEL`             |
 | `tenant_activity_write_log_level`                | `TENANT_ACTIVITY_WRITE_LOG_LEVEL`            |
 
-`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent, so it can only be set as a runtime override.
+`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-Web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent, so it can only be set as a runtime override.
 
 ### Raft settings
 

--- a/docs/deploy/configuration/env-vars/runtime-config.md
+++ b/docs/deploy/configuration/env-vars/runtime-config.md
@@ -11,7 +11,7 @@ import RuntimeConfig from '/_includes/feature-notes/runtime-config.mdx';
 
 Weaviate supports runtime configuration management, allowing some configurations to be changed without any further restarts.
 
-Each runtime configuration corresponds to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable.
+Most runtime configurations correspond to an existing environment variable. When a runtime configuration is updated, it overrides the value set by the corresponding environment variable. A few settings are available only as runtime overrides and have no environment variable equivalent.
 
 ## How to set up runtime configuration
 
@@ -69,6 +69,7 @@ The following overrides are currently supported:
 | `export_default_path`                            | `EXPORT_DEFAULT_PATH`                        |
 | `export_enabled`                                 | `EXPORT_ENABLED`                             |
 | `export_parallelism`                             | `EXPORT_PARALLELISM`                         |
+| `grpc_web_enabled`                               | _(not applicable)_                           |
 | `inverted_sorter_disabled`                       | `INVERTED_SORTER_DISABLED`                   |
 | `maximum_allowed_collections_count`              | `MAXIMUM_ALLOWED_COLLECTIONS_COUNT`          |
 | `objects_ttl_batch_size`                          | `OBJECTS_TTL_BATCH_SIZE`                     |
@@ -84,6 +85,8 @@ The following overrides are currently supported:
 | `revectorize_check_disabled`                     | `REVECTORIZE_CHECK_DISABLED`                 |
 | `tenant_activity_read_log_level`                 | `TENANT_ACTIVITY_READ_LOG_LEVEL`             |
 | `tenant_activity_write_log_level`                | `TENANT_ACTIVITY_WRITE_LOG_LEVEL`            |
+
+`grpc_web_enabled` (added in `v1.38.3`) controls the [gRPC-web interface](/weaviate/api/grpc.md#grpc-web) and has no environment variable equivalent, so it can only be set as a runtime override.
 
 ### Raft settings
 

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -62,10 +62,7 @@ Alternatively, you can use other tools, such as the `grpcurl` command-line tool,
 
 Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-Web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
 
-The gRPC-Web interface is enabled by default. It can be turned off in two places, and the key is spelled differently in each:
-
-- **Static configuration file:** set `grpc.grpcWebEnabled` to `false`. Note the camelCase.
-- **[Runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override:** set `grpc_web_enabled` to `false`. Note the snake_case. This takes effect without a restart.
+The gRPC-Web interface is enabled by default. **[Runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override:** set `grpc_web_enabled` to `false`. Note the snake_case. This takes effect without a restart.
 
 This setting has no environment variable equivalent. When the interface is disabled, requests to `/v1/grpc-web/` fall through to the REST handler, so other REST endpoints keep working as usual.
 

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -53,7 +53,7 @@ services:
 
 Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
 
-The gRPC-web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override, which takes effect without a restart. While it is disabled, requests under `/v1/grpc-web/` fall through to the REST handler, so the rest of the REST API keeps working as usual.
+The gRPC-web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override, which takes effect without a restart. There is no environment variable equivalent. While it is disabled, requests under `/v1/grpc-web/` fall through to the REST handler, so the rest of the REST API keeps working as usual.
 
 No Weaviate client library uses this interface yet.
 

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -62,7 +62,12 @@ Alternatively, you can use other tools, such as the `grpcurl` command-line tool,
 
 Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-Web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
 
-The gRPC-Web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override to `false`, which takes effect without a restart. This setting has no environment variable equivalent. When the interface is disabled, requests to `/v1/grpc-web/` fall through to the REST handler, so other REST endpoints keep working as usual.
+The gRPC-Web interface is enabled by default. It can be turned off in two places, and the key is spelled differently in each:
+
+- **Static configuration file:** set `grpc.grpcWebEnabled` to `false`. Note the camelCase.
+- **[Runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override:** set `grpc_web_enabled` to `false`. Note the snake_case. This takes effect without a restart.
+
+This setting has no environment variable equivalent. When the interface is disabled, requests to `/v1/grpc-web/` fall through to the REST handler, so other REST endpoints keep working as usual.
 
 The Weaviate client libraries connect over plain gRPC, so they do not use the gRPC-Web interface yet.
 

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -46,17 +46,6 @@ services:
   # ... Other settings
 ````
 
-### gRPC-web
-
-:::info Added in `v1.38.3`
-:::
-
-Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
-
-The gRPC-web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override, which takes effect without a restart. There is no environment variable equivalent. While it is disabled, requests under `/v1/grpc-web/` fall through to the REST handler, so the rest of the REST API keeps working as usual.
-
-No Weaviate client library uses this interface yet.
-
 ### Client-side
 
 You can use the gRPC interface through the [Python (`v4` version)](../client-libraries/python/index.mdx) and [TypeScript (`v3` version)](../client-libraries/typescript/index.mdx) client libraries. Other client libraries will also introduce gRPC support in the near future.
@@ -65,6 +54,17 @@ Alternatively, you can use other tools, such as the `grpcurl` command-line tool,
 
 - `grpcurl` command-line tool ([GitHub repo](https://github.com/fullstorydev/grpcurl))
 - Postman ([How to send a gRPC request with Postman](https://learning.postman.com/docs/sending-requests/grpc/grpc-request-interface/))
+
+## gRPC-Web
+
+:::info Added in `v1.38.3`
+:::
+
+Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-Web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
+
+The gRPC-Web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override to `false`, which takes effect without a restart. This setting has no environment variable equivalent. When the interface is disabled, requests to `/v1/grpc-web/` fall through to the REST handler, so other REST endpoints keep working as usual.
+
+The Weaviate client libraries connect over plain gRPC, so they do not use the gRPC-Web interface yet.
 
 ## Questions and feedback
 

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -46,6 +46,17 @@ services:
   # ... Other settings
 ````
 
+### gRPC-web
+
+:::info Added in `v1.38.3`
+:::
+
+Browsers cannot speak plain gRPC. To reach the gRPC API from a browser, Weaviate also serves a gRPC-web interface over ordinary HTTP. It is served under the `/v1/grpc-web/` path prefix on the same port as the REST API (default `8080`), not on the gRPC port, so there is no second port to expose.
+
+The gRPC-web interface is enabled by default. To turn it off, set the `grpc_web_enabled` [runtime configuration](/deploy/configuration/env-vars/runtime-config.md) override, which takes effect without a restart. While it is disabled, requests under `/v1/grpc-web/` fall through to the REST handler, so the rest of the REST API keeps working as usual.
+
+No Weaviate client library uses this interface yet.
+
 ### Client-side
 
 You can use the gRPC interface through the [Python (`v4` version)](../client-libraries/python/index.mdx) and [TypeScript (`v3` version)](../client-libraries/typescript/index.mdx) client libraries. Other client libraries will also introduce gRPC support in the near future.


### PR DESCRIPTION
gRPC-Web had no coverage anywhere in the docs. It is being declared GA with 1.39, though the endpoint itself shipped in v1.38.3, so the version marker cites v1.38.3 and the GA declaration rides the release.

Scope is deliberately small: two mentions plus one factual correction. No new page.

## Changes

**`weaviate/api/grpc.md`** — new `## gRPC-Web` section covering: served on the REST port under `/v1/grpc-web/` rather than a dedicated listener, so there is no second port to expose; enabled by default; both ways to turn it off; and that no client library uses it yet.

**`cloud/manage-clusters/connect.mdx`** — one line in the existing "REST Endpoint vs gRPC Endpoint" admonition, noting gRPC-Web is reached through the REST endpoint URL.

**`deploy/configuration/env-vars/runtime-config.md`** — adds the `grpc_web_enabled` row, and corrects a claim that is now false. The page stated "Each runtime configuration corresponds to an existing environment variable"; gRPC-Web has no environment variable, so that is softened to "Most" with a note that some overrides have no env-var equivalent. The row's env-var column reads `_(not applicable)_`, matching the table's existing italic-parenthetical idiom.

## The casing split is deliberate

The off-switch is spelled differently in each place, which is the kind of thing an operator loses time to, so it is presented as a two-item list rather than buried in a sentence:

- Static configuration file: `grpc.grpcWebEnabled` (camelCase)
- Runtime override: `grpc_web_enabled` (snake_case)

## Verification

Facts checked against core at `v1.38.3`, `v1.38.8` and `v1.39.0-rc.1`:

- `Mount("/v1/grpc-web", ...)` in `adapters/handlers/rest/configure_api.go`
- `GrpcWebEnabledOrDefault()` returns true when unset, so enabled by default
- `GrpcWebEnabled` tagged `grpcWebEnabled` in `config_handler.go`; `grpc_web_enabled` in `runtimeconfig.go`; registered by pointer, so overrides apply without a restart
- No `GRPC_WEB*` token anywhere in `usecases/config` at any of the three tags, so there genuinely is no environment variable
- `v1.38.2` contains no gRPC-Web at all, so `Added in v1.38.3` is exact

Site builds; warning set is byte-identical to base. The new `#grpc-web` anchor was confirmed in rendered HTML (it slugifies to lowercase despite the capital W), and both inbound links resolve. No code snippets added.

## Known gaps, not addressed here

- **No released client speaks gRPC-Web.** `weaviate/typescript-client#307` is still open. The text says so plainly rather than implying a usage path, and that sentence will need removing when a client ships.
- **"Static configuration file" is currently unlinkable.** Weaviate's static configuration file is not documented on this site at all, so the phrase has nowhere to point. Worth its own task.
- **Cross-origin browser access on Weaviate Cloud is unverified.** `CORS_ALLOW_ORIGIN` defaults to the console origin, which may block browser apps served from elsewhere. Nothing here claims otherwise, but it is the obvious next question.