### PR TITLE
docs(model-providers): fix medium-severity review findings in provider and recipe pages

### DIFF
--- a/docs/weaviate/model-providers/_includes/provider.generative.py
+++ b/docs/weaviate/model-providers/_includes/provider.generative.py
@@ -824,6 +824,7 @@ client.collections.create(
         # model="mistral-large",
         # temperature=0.7,
         # max_tokens=500,
+        # base_url="<custom_mistral_url>",
     )
     # highlight-end
 )

--- a/docs/weaviate/model-providers/_includes/provider.generative.ts
+++ b/docs/weaviate/model-providers/_includes/provider.generative.ts
@@ -734,7 +734,8 @@ await client.collections.create({
     // These parameters are optional
     // model: 'mistral-large',
     // temperature: 0.7,
-    // maxTokens: 500
+    // maxTokens: 500,
+    // baseURL: '<custom_mistral_url>',
   }),
   // highlight-end
 });

--- a/docs/weaviate/model-providers/_includes/provider.vectorizer.py
+++ b/docs/weaviate/model-providers/_includes/provider.vectorizer.py
@@ -690,7 +690,7 @@ client.collections.create(
             name="title_vector",
             source_properties=["title"],
             model="mistral-embed",
-            # # Further options
+            # Further options
             # base_url="<custom_mistral_url>",
         )
     ],

--- a/docs/weaviate/model-providers/_includes/provider.vectorizer.py
+++ b/docs/weaviate/model-providers/_includes/provider.vectorizer.py
@@ -689,7 +689,9 @@ client.collections.create(
         Configure.Vectors.text2vec_mistral(
             name="title_vector",
             source_properties=["title"],
-            model="mistral-embed"
+            model="mistral-embed",
+            # # Further options
+            # base_url="<custom_mistral_url>",
         )
     ],
     # highlight-end
@@ -966,7 +968,7 @@ client.collections.create(
     # highlight-start
     vector_config=[
         Configure.Vectors.text2vec_digitalocean(
-            model="qwen3-embedding-0.6b",  # Required — choose from the DigitalOcean Serverless Inference catalogue
+            model="qwen3-embedding-0.6b",  # Required. Choose from the DigitalOcean Serverless Inference catalogue
             name="title_vector",
             source_properties=["title"],
         )

--- a/docs/weaviate/model-providers/_includes/provider.vectorizer.ts
+++ b/docs/weaviate/model-providers/_includes/provider.vectorizer.ts
@@ -327,7 +327,7 @@ await client.collections.create({
   // highlight-start
   vectorizers: [
     weaviate.configure.vectors.text2VecDigitalOcean({
-      model: 'qwen3-embedding-0.6b',  // Required — choose from the DigitalOcean Serverless Inference catalogue
+      model: 'qwen3-embedding-0.6b',  // Required. Choose from the DigitalOcean Serverless Inference catalogue
       name: 'title_vector',
       sourceProperties: ['title'],
     })
@@ -838,7 +838,9 @@ await client.collections.create({
     weaviate.configure.vectors.text2VecMistral({
       name: 'title_vector',
       sourceProperties: ['title'],
-      model: 'mistral-embed'
+      model: 'mistral-embed',
+      // Further options
+      // baseURL: '<custom_mistral_url>',
     },
     ),
   ],

--- a/docs/weaviate/model-providers/anthropic/generative.md
+++ b/docs/weaviate/model-providers/anthropic/generative.md
@@ -301,7 +301,7 @@ The default base URL is `https://api.anthropic.com`.
 
 ### Available models
 
-Any model available in the Anthropic API can be used with Weaviate. If you do not specify a model, Weaviate uses `claude-haiku-4-5` by default.
+Any model available in the Anthropic API can be used with Weaviate. If you do not specify a model, Weaviate uses `claude-haiku-4-5` by default. That default was set in `v1.34.0`, and backported to `v1.31.20`, `v1.32.17`, and `v1.33.5`. Earlier releases on each of those lines default to `claude-3-5-sonnet-20240620`.
 
 See the [Anthropic API documentation](https://docs.anthropic.com/en/docs/about-claude/models#model-names) for the most up-to-date list of available models.
 

--- a/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
@@ -294,6 +294,7 @@ The query below returns the `n` most similar objects to the input image from the
 
 ### Available models
 
+- `embed-v4.0`
 - `embed-multilingual-v3.0` (Default)
 - `embed-multilingual-light-v3.0`
 - `embed-english-v3.0`

--- a/docs/weaviate/model-providers/cohere/generative.md
+++ b/docs/weaviate/model-providers/cohere/generative.md
@@ -264,11 +264,15 @@ In other words, when you have `n` search results, the generative model generates
 
 ### Available models
 
-From Weaviate `v1.31.17`, `v1.32.10`, `v1.33.0` and later, Weaviate does not validate the model name, so you can set any model that your Cohere account can reach. The following models are commonly used:
+Weaviate does not validate the model name, so you can set any model that your Cohere account can reach. Name validation was removed in `v1.33.0`, and backported to `v1.31.17` and `v1.32.10`.
 
-- `command-a-03-2025` (server default in `v1.31.17`, `v1.32.10`, `v1.33.0` and later)
+The server default is `command-a-03-2025`. It changed in `v1.33.0`, and was backported to `v1.31.17` and `v1.32.10`. Earlier releases on each of those lines default to `command-r`.
+
+The following models are commonly used:
+
+- `command-a-03-2025` (server default)
 - `command-r-plus`
-- `command-r` (server default before `v1.31.17`, `v1.32.10` and `v1.33.0`)
+- `command-r` (previous server default)
 - `command-xlarge`
 - `command-xlarge-beta`
 - `command-xlarge-nightly`

--- a/docs/weaviate/model-providers/contextualai/generative.md
+++ b/docs/weaviate/model-providers/contextualai/generative.md
@@ -163,7 +163,7 @@ Configure the following generative parameters to customize the model behavior.
 
 For further details on model parameters, see the [Contextual AI API documentation](https://docs.contextual.ai/api-reference/generate/generate).
 
-If a parameter is not specified, Weaviate uses the server-side default for that parameter. They are:
+If a parameter is not specified, Weaviate uses the server default for that parameter. They are:
 
 - model           = `"v2"`
 - temperature     = `0.0`

--- a/docs/weaviate/model-providers/databricks/index.md
+++ b/docs/weaviate/model-providers/databricks/index.md
@@ -25,11 +25,11 @@ Databricks' embedding models transform text data into vector embeddings, capturi
 
 ### Generative AI models for RAG
 
-![Single prompt RAG integration generates individual outputs per search result](../_includes/integration_openai_rag_single.png)
+![Single prompt RAG integration generates individual outputs per search result](../_includes/integration_databricks_rag_single.png)
 
-Databrick' generative AI models can generate human-like text based on given prompts and contexts.
+Databricks' generative AI models can generate human-like text based on given prompts and contexts.
 
-[Weaviate's generative AI integration](./generative.md) enables users to perform retrieval augmented generation (RAG) directly from the Weaviate Database. This combines Weaviate' efficient storage and fast retrieval capabilities with Databrick' generative AI models to generate personalized and context-aware responses.
+[Weaviate's generative AI integration](./generative.md) enables users to perform retrieval augmented generation (RAG) directly from the Weaviate Database. This combines Weaviate's efficient storage and fast retrieval capabilities with Databricks' generative AI models to generate personalized and context-aware responses.
 
 [Databricks generative AI integration page](./generative.md)
 
@@ -43,7 +43,7 @@ In turn, they simplify the process of building AI-driven applications to speed u
 
 You must provide a valid Databricks personal access token to Weaviate for these integrations. Refer to the [Databricks documentation](https://docs.databricks.com/en/dev-tools/auth/pat.html) for instructions on generating your personal access token in your workspace.
 
-Then, go to the relevant integration page to learn how to configure Weaviate with the OpenAI models and start using them in your applications.
+Then, go to the relevant integration page to learn how to configure Weaviate with the Databricks models and start using them in your applications.
 
 - [Text Embeddings](./embeddings.md)
 - [Generative AI](./generative.md)

--- a/docs/weaviate/model-providers/digitalocean/embeddings.md
+++ b/docs/weaviate/model-providers/digitalocean/embeddings.md
@@ -164,7 +164,7 @@ When you perform a [hybrid search](../../search/hybrid.md), Weaviate fuses keywo
 
 ### Available models
 
-DigitalOcean's Serverless Inference catalogue includes several embedding-capable models. See the [DigitalOcean Serverless Inference docs](https://docs.digitalocean.com/products/inference/how-to/use-serverless-inference/) for the live list — model availability and dimensions can change.
+DigitalOcean's Serverless Inference catalogue includes several embedding-capable models. See the [DigitalOcean Serverless Inference docs](https://docs.digitalocean.com/products/inference/how-to/use-serverless-inference/) for the live list, as model availability and dimensions can change.
 
 :::note Dimensions parameter currently not supported
 
@@ -180,7 +180,7 @@ DigitalOcean's `/v1/embeddings` endpoint does not accept a `dimensions` request 
 
 ### Code examples
 
-Once the vectorizer is configured, Weaviate handles model inference transparently. The standard [client library how-tos](../../client-libraries/index.mdx) apply unchanged — no DigitalOcean-specific code is required at query or import time beyond the configuration shown above.
+Once the vectorizer is configured, Weaviate handles model inference transparently. The standard [client library how-tos](../../client-libraries/index.mdx) apply unchanged. No DigitalOcean-specific code is required at query or import time beyond the configuration shown above.
 
 ## Questions and feedback
 

--- a/docs/weaviate/model-providers/friendliai/_category_.json
+++ b/docs/weaviate/model-providers/friendliai/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "FriendliAI",
-    "position": 226
+    "position": 227
 }

--- a/docs/weaviate/model-providers/google/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/google/embeddings-multimodal.md
@@ -326,8 +326,8 @@ The query below returns the `n` most similar objects to the input image from the
 
 ### Available models
 
-- `gemini-embedding-2` (Vertex AI and Gemini API, added in 1.36.13) — Vertex AI and Gemini API; supports text, images, PDFs, and audio (Gemini API only, up to 180 seconds); `3072` dimensions
-- `multimodalembedding@001` (Vertex AI only) — supports text, images, and video; dimensions: `128`, `256`, `512`, `1408`
+- `gemini-embedding-2` (Vertex AI and Gemini API, added in 1.36.13). Supports text, images, PDFs, and audio (Gemini API only, up to 180 seconds); `3072` dimensions
+- `multimodalembedding@001` (Vertex AI only). Supports text, images, and video; dimensions: `128`, `256`, `512`, `1408`
 
 ## Further resources
 

--- a/docs/weaviate/model-providers/google/embeddings.md
+++ b/docs/weaviate/model-providers/google/embeddings.md
@@ -399,10 +399,13 @@ The query below returns the `n` best scoring objects from the database, set by `
 - `gemini-embedding-001` (default)
 
 **Vertex AI:**
+
+`gemini-embedding-001`, `text-embedding-005`, and `text-multilingual-embedding-002` were added in `v1.31.5`, and backported to `v1.30.11`.
+
 - `gemini-embedding-2`
-- `gemini-embedding-001` (default, added in 1.30.11, 1.31.5 and onwards)
-- `text-embedding-005` (added in 1.30.11, 1.31.5 and onwards)
-- `text-multilingual-embedding-002` (added in 1.30.11, 1.31.5 and onwards)
+- `gemini-embedding-001` (default)
+- `text-embedding-005`
+- `text-multilingual-embedding-002`
 
 <details>
   <summary>Deprecated models</summary>

--- a/docs/weaviate/model-providers/jinaai/embeddings.md
+++ b/docs/weaviate/model-providers/jinaai/embeddings.md
@@ -329,13 +329,13 @@ The query below returns the `n` best scoring objects from the database, set by `
 
 ### Available models
 
-The server default changed in `v1.31.6` and `v1.32.0`.
+The server default changed in `v1.32.0`, and was backported to `v1.31.6`. Earlier releases on each of those lines default to `jina-embeddings-v2-base-en`.
 
-- `jina-embeddings-v4` (server default in `v1.31.6`, `v1.32.0` and later)
+- `jina-embeddings-v4` (server default)
     - When using this model, Weaviate will automatically use the appropriate `task` type, applying `retrieval.passage` for embedding entries and `retrieval.query` for queries.
 - `jina-embeddings-v3`
     - When using this model, Weaviate will automatically use the appropriate `task` type, applying `retrieval.passage` for embedding entries and `retrieval.query` for queries.
-- `jina-embeddings-v2-base-en` (server default before `v1.31.6` and `v1.32.0`)
+- `jina-embeddings-v2-base-en` (previous server default)
 - `jina-embeddings-v2-small-en`
 - `jina-embeddings-v2-base-zh`
 - `jina-embeddings-v2-base-es`

--- a/docs/weaviate/model-providers/kubeai/_category_.json
+++ b/docs/weaviate/model-providers/kubeai/_category_.json
@@ -1,4 +1,4 @@
 {
-    "label": "KubeAI (Locally hosted)",
-    "position": 320
+    "label": "KubeAI (locally hosted)",
+    "position": 330
 }

--- a/docs/weaviate/model-providers/model2vec/_category_.json
+++ b/docs/weaviate/model-providers/model2vec/_category_.json
@@ -1,4 +1,4 @@
 {
-    "label": "GPT4All (locally hosted)",
-    "position": 320
+    "label": "Model2Vec (locally hosted)",
+    "position": 340
 }

--- a/docs/weaviate/model-providers/nvidia/index.md
+++ b/docs/weaviate/model-providers/nvidia/index.md
@@ -54,7 +54,7 @@ In turn, it simplifies the process of building AI-driven applications to speed u
 
 You must provide a valid NVIDIA API key to Weaviate for this integration. Go to [NVIDIA](https://build.nvidia.com/) to sign up and obtain an API key.
 
-Then, go to the relevant integration page to learn how to configure Weaviate with the Cohere models and start using them in your applications.
+Then, go to the relevant integration page to learn how to configure Weaviate with the NVIDIA models and start using them in your applications.
 
 - [Text Embeddings](./embeddings.md)
 - [Multimodal Embeddings](./embeddings-multimodal.md)

--- a/docs/weaviate/model-providers/nvidia/reranker.md
+++ b/docs/weaviate/model-providers/nvidia/reranker.md
@@ -170,7 +170,7 @@ Any search in Weaviate can be combined with a reranker to perform reranking oper
 
 You can use any reranker model [on NVIDIA NIM APIs](https://build.nvidia.com/models) with Weaviate.
 
-The default model is `nnvidia/rerank-qa-mistral-4b`.
+The default model is `nvidia/rerank-qa-mistral-4b`.
 
 ## Further resources
 

--- a/docs/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
+++ b/docs/weaviate/model-providers/octoai/_includes/octoai_deprecation.md
@@ -7,6 +7,9 @@
 OctoAI announced that they are winding down the commercial availability of its services by **31 October 2024**. Accordingly, the Weaviate OctoAI integrations are deprecated. Do not use these integrations for new projects.
 <br/>
 
+From Weaviate `v1.25.22`, `v1.26.8`, and `v1.27.1`, the `text2vec-octoai` and `generative-octoai` modules are inactive. Every vectorization and generation request they receive fails server-side with the error `OctoAI is permanently shut down`. The configuration, import, search, and RAG examples on these pages therefore no longer run against OctoAI, and are kept only as a record of how the integrations used to be configured. Of the options below, only "bring your own vectors" (Option 1) keeps an existing OctoAI collection usable.
+<br/>
+
 If you have a collection that is using an OctoAI integration, consider your options depending on whether you are using OctoAI's embedding models ([your options](#for-collections-with-octoai-embedding-integrations)) or generative models ([your options](#for-collections-with-octoai-generative-ai-integrations)).
 
 #### For collections with OctoAI embedding integrations

--- a/docs/weaviate/model-providers/openai/generative.md
+++ b/docs/weaviate/model-providers/openai/generative.md
@@ -163,7 +163,7 @@ Configure the following generative parameters to customize the model behavior.
 
 </Tabs>
 
-From Weaviate `v1.31.15`, `v1.32.9`, `v1.33.0` and later, two additional parameters are available for reasoning models such as the `gpt-5` family:
+Two additional parameters are available for reasoning models such as the `gpt-5` family. They were added in `v1.33.0`, and backported to `v1.31.15` and `v1.32.9`:
 
 - `reasoningEffort`: How much reasoning the model does before it answers. One of `minimal`, `low`, `medium`, or `high`. If not set, the model provider default applies.
 - `verbosity`: How detailed the generated answer is. One of `low`, `medium`, or `high`. If not set, the model provider default applies.
@@ -301,12 +301,16 @@ You can also supply images as a part of the input when performing retrieval augm
 
 ### Available models
 
-From Weaviate `v1.31.17`, `v1.32.10`, `v1.33.0` and later, Weaviate does not validate the model name, so you can set any model that your OpenAI account can reach. The following models are recognized by Weaviate's token limit table:
+Weaviate does not validate the model name, so you can set any model that your OpenAI account can reach. Name validation was removed in `v1.33.0`, and backported to `v1.31.17` and `v1.32.10`.
+
+The server default is `gpt-5-mini`. It changed in `v1.32.3`, and was backported to `v1.30.16` and `v1.31.10`. Earlier releases on each of those lines default to `gpt-3.5-turbo`.
+
+The following models are recognized by Weaviate's token limit table:
 
 * [gpt-5](https://platform.openai.com/docs/models/gpt-5)
-* [gpt-5-mini](https://platform.openai.com/docs/models/gpt-5-mini) (server default in `v1.30.16`, `v1.31.10`, `v1.32.3` and later)
+* [gpt-5-mini](https://platform.openai.com/docs/models/gpt-5-mini) (server default)
 * [gpt-5-nano](https://platform.openai.com/docs/models/gpt-5-nano)
-* [gpt-3.5-turbo](https://platform.openai.com/docs/models/gpt-3-5) (server default before `v1.30.16`, `v1.31.10` and `v1.32.3`)
+* [gpt-3.5-turbo](https://platform.openai.com/docs/models/gpt-3-5) (previous server default)
 * [gpt-3.5-turbo-16k](https://platform.openai.com/docs/models/gpt-3-5)
 * [gpt-3.5-turbo-1106](https://platform.openai.com/docs/models/gpt-3-5)
 * [gpt-4](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo)

--- a/docs/weaviate/model-providers/transformers/embeddings.md
+++ b/docs/weaviate/model-providers/transformers/embeddings.md
@@ -188,7 +188,7 @@ Specify `passageInferenceUrl` and `queryInferenceUrl` if using a [DPR](https://h
 
 #### Additional parameters
 
-- `poolingStrategy` – the pooling strategy to use when the input exceeds the model's context window.
+- `poolingStrategy`: the pooling strategy to use when the input exceeds the model's context window.
   - Default: `masked_mean`. Allowed values: `masked_mean` or `cls`. ([Read more on this topic.](https://arxiv.org/abs/1908.10084))
 
 <Tabs className="code" groupId="languages">

--- a/docs/weaviate/model-providers/voyageai/embeddings.md
+++ b/docs/weaviate/model-providers/voyageai/embeddings.md
@@ -388,7 +388,7 @@ The `voyage-context-3` model uses Voyage AI's [contextual embeddings API](https:
 ### Other integrations
 
 - [Voyage AI multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
-- [Voyage AI reranker models + Weaviate](./embeddings.md).
+- [Voyage AI reranker models + Weaviate](./reranker.md).
 
 ### Code examples
 

--- a/docs/weaviate/recipes/multi-vector-colipali-rag.md
+++ b/docs/weaviate/recipes/multi-vector-colipali-rag.md
@@ -444,7 +444,7 @@ Python output:
 True
 ```
 
-For this tutorial, you will need the Weaviate `v1.29.0` or higher.
+This tutorial requires Weaviate `v1.29.0` and later.
 Let's make sure we have the required version:
 
 ```python
@@ -576,16 +576,6 @@ As an example of what we are going to build, consider the following actual demo 
 
 ```python
 query = "How does DeepSeek-V2 compare against the LLaMA family of LLMs?"
-```
-
-Python output:
-
-```text
-Running cells with 'Python 3.13.5' requires the ipykernel package.
-
-Install 'ipykernel' into the Python environment.
-
-Command: '/opt/homebrew/bin/python3 -m pip install ipykernel -U --user --force-reinstall'
 ```
 
 By inspecting the first page of the [DeepSeek-V2 paper](https://arxiv.org/abs/2405.04434), we see that it does indeed contain a figure that is relevant for answering our query:

--- a/docs/weaviate/recipes/rag_titan-text-express-v1_bedrock.md
+++ b/docs/weaviate/recipes/rag_titan-text-express-v1_bedrock.md
@@ -7,7 +7,7 @@ integration: False
 agent: False
 tags: ['Generative Search', 'RAG', 'AWS']
 ---
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/weaviate-features/model-providers/aws/rag_titan-text-express-v1_bedrock.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/weaviate-features/model-providers/aws/rag_titan-text-express-v1_bedrock.ipynb)
 
 ## Dependencies
 
@@ -57,7 +57,7 @@ if (client.collections.exists("JeopardyQuestion")):
 client.collections.create(
     name="JeopardyQuestion",
 
-    vectorizer_config=wc.Configure.Vectorizer.text2vec_aws(
+    vector_config=wc.Configure.Vectors.text2vec_aws(
         service="bedrock",   #this is crucial
         model="cohere.embed-english-v3", # select the model, make sure it is enabled for your account
         # model="amazon.titan-embed-text-v1", # select the model, make sure it is enabled for your account

--- a/docs/weaviate/recipes/weaviate_embeddings_service.md
+++ b/docs/weaviate/recipes/weaviate_embeddings_service.md
@@ -8,7 +8,7 @@ agent: False
 tags: ["Weaviate Embeddings", "Weaviate Cloud"]
 ---
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/weaviate-services/embedding-service/weaviate_embeddings_service.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/weaviate/recipes/blob/main/weaviate-services/embedding-service/weaviate_embeddings_service.ipynb)
 
 # Weaviate Embedding Service
 


### PR DESCRIPTION
Medium tier of the docs deep review, group 1 of 4. 13 findings, 25 files.

**Stacked on #493** (the high-severity pass) because 16 medium findings live in files that PR rewrote. Base retargets to `main` automatically when #493 merges.

**Copy-paste-and-it-fails:** the NVIDIA reranker default model was written `nnvidia/...`, an invalid model id.

**Template leaks from cloned pages.** The NVIDIA overview told readers to configure "the Cohere models"; the Databricks overview said OpenAI, shipped the OpenAI RAG illustration, and had two broken possessives. All 25 provider overview pages were checked, and those were the only two affected.

**OctoAI.** The pages carried a deprecation banner but still read as working walkthroughs. Every module method has returned a shutdown error server-side since v1.25.22, v1.26.8 and v1.27.1, so the examples are now marked as a historical record and readers are pointed at the one option that still works.

**Model information.** Added `embed-v4.0` to the Cohere multimodal list, which the page's own example already used, and documented `base_url` on the Mistral full-parameter samples to match the OpenAI ones.

**Version wording** is normalized to two house forms: a capability that was introduced and backported reads "Added in vX, and backported to vA, vB"; a changed default additionally states what earlier releases on those lines used. Every version was verified by reading the value at the boundary tags rather than by `git tag --contains`, which under-reports cherry-picked backports.

Also: a self-referencing link in the Voyage AI further-reading list, two Colab badges missing the `blob/main` segment, a Jupyter kernel error published as a snippet's expected output, a deprecated `vectorizer_config` call, duplicate sidebar positions with a mislabeled category, and the remaining em dashes.

Verified: `yarn build-dev` exit 0; broken links and anchors identical to the base; shared provider includes syntax-checked; every FilteredTextBlock marker still unique and byte-exact.