### PR TITLE
docs(search,api): fix snippets that do not parse, a mis-targeted anchor, and stale gRPC support

### DIFF
--- a/_includes/feature-notes/boost.mdx
+++ b/_includes/feature-notes/boost.mdx
@@ -1,3 +1,3 @@
-:::caution Preview — added in `v1.38`
+:::caution Preview: added in `v1.38`
 This is a preview feature. The API may change in future releases.
 :::

--- a/docs/weaviate/api/graphql/filters.md
+++ b/docs/weaviate/api/graphql/filters.md
@@ -243,7 +243,7 @@ The `ContainsAny`, `ContainsAll` and `ContainsNone` operators filter objects usi
 
 These operators expect an array of values and return objects that match based on the input values.
 
-They are not limited to text. They work on `text`/`string`, `int`, `number`, `boolean`, `date`, and `uuid` properties — and on the array variants of each (`int[]`, `number[]`, etc.). A scalar property is treated as a single-element set: the object matches if its value satisfies the operator against the candidate list.
+They are not limited to text. They work on `text`/`string`, `int`, `number`, `boolean`, `date`, and `uuid` properties, and on the array variants of each (`int[]`, `number[]`, etc.). A scalar property is treated as a single-element set: the object matches if its value satisfies the operator against the candidate list.
 
 Pass the candidate values using the argument that matches the property's data type: `valueText` for `text`/`string`, `valueInt` for `int`, `valueNumber` for `number`, `valueBoolean` for `boolean`, and `valueDate` for `date`. For `uuid`/`uuid[]` properties, pass the UUIDs as strings using `valueText` (there is no `valueUuid` argument). For example, a `ContainsAny` query on an `int` property with a value of `[10, 20, 30]` returns objects whose property holds at least one of those integers.
 
@@ -588,8 +588,11 @@ Using the `IsNull` operator allows you to do filter for objects where given prop
   Get {
     <Class>(where: {
         operator: IsNull,
-        valueBoolean: <true/false>
+        valueBoolean: <true/false>,
         path: [<property>]
+      }) {
+      <property>
+    }
   }
 }
 ```

--- a/docs/weaviate/api/grpc.md
+++ b/docs/weaviate/api/grpc.md
@@ -7,7 +7,7 @@ image: og/docs/api.jpg
 
 Starting with Weaviate `v1.19.0`, a gRPC interface has been progressively added to Weaviate. gRPC is a high-performance, open-source universal RPC framework that is contract-based and can be used in any environment. It is based on HTTP/2 and Protocol Buffers, and is therefore very fast and efficient.
 
-As of Weaviate `v1.23.7`, the gRPC interface is considered stable. The [Python (`v4` version)](../client-libraries/python/index.mdx) and [TypeScript (`v3` version)](../client-libraries/typescript/index.mdx) client libraries support gRPC, and the other client libraries will follow.
+As of Weaviate `v1.23.7`, the gRPC interface is considered stable. The [Python](../client-libraries/python/index.mdx), [TypeScript](../client-libraries/typescript/index.mdx), [Java](../client-libraries/java/index.mdx), and [C#](../client-libraries/csharp.mdx) client libraries use gRPC. The [Go](../client-libraries/go.md) client uses gRPC for batch imports, and offers gRPC search through its experimental API.
 
 ## Protocol Buffer (Protobuf) definitions
 
@@ -33,8 +33,6 @@ We suggest using the default port `50051` for gRPC calls. It can be modified thr
 Note that [Weaviate Cloud](/go/console?utm_content=api) uses port `443` for gRPC.
 :::
 
-````yaml:
-
 ```yaml
 ---
 services:
@@ -44,11 +42,11 @@ services:
      - "8080:8080"  # REST calls
      - "50051:50051"  # gRPC calls
   # ... Other settings
-````
+```
 
 ### Client-side
 
-You can use the gRPC interface through the [Python (`v4` version)](../client-libraries/python/index.mdx) and [TypeScript (`v3` version)](../client-libraries/typescript/index.mdx) client libraries. Other client libraries will also introduce gRPC support in the near future.
+You can use the gRPC interface through the [Python](../client-libraries/python/index.mdx), [TypeScript](../client-libraries/typescript/index.mdx), [Java](../client-libraries/java/index.mdx), and [C#](../client-libraries/csharp.mdx) client libraries. The [Go](../client-libraries/go.md) client sends batch imports over gRPC. Its gRPC search API is still experimental, and is reached through `Experimental().Search()` rather than the regular query builder.
 
 Alternatively, you can use other tools, such as the `grpcurl` command-line tool, to interact with the gRPC API. Some options include:
 

--- a/docs/weaviate/search/bm25.md
+++ b/docs/weaviate/search/bm25.md
@@ -454,8 +454,8 @@ See [Inverted index: Accent folding](../concepts/indexing/inverted-index.md#acce
 
 By default, Weaviate filters out common English stopwords (like "a", "the", "is") from BM25 scoring. You can customize this behavior:
 
-- **Custom presets**: Define named stopword lists per collection via `invertedIndexConfig.stopwordPresets` — useful for non-English languages or domain-specific terms.
-- **Per-property overrides**: Assign different stopword presets to individual properties via `textAnalyzer.stopwordPreset` — useful for multilingual collections where each property contains text in a different language.
+- **Custom presets**: Define named stopword lists per collection via `invertedIndexConfig.stopwordPresets`, useful for non-English languages or domain-specific terms.
+- **Per-property overrides**: Assign different stopword presets to individual properties via `textAnalyzer.stopwordPreset`, useful for multilingual collections where each property contains text in a different language.
 
 Stopwords are still indexed and only filtered at query time, so changing the configuration does not require reindexing.
 
@@ -769,7 +769,7 @@ Set the tokenization method to `trigram` at the property level when creating you
 
 <BoostPreview/>
 
-Keyword (BM25) queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
+Keyword (BM25) queries accept an optional `boost` argument that promotes or demotes matching documents without removing them. This is useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
 
 See [Boost](./boost.md) for the supported condition types (filter, property value, time decay, numeric decay), curve choices, blending semantics, and depth tuning.
 

--- a/docs/weaviate/search/boost.md
+++ b/docs/weaviate/search/boost.md
@@ -2,7 +2,7 @@
 title: Boost
 sidebar_position: 76
 image: og/docs/howto.jpg
-description: Soft-rank vector, hybrid, and BM25 results — promote or demote matching documents without filtering them out. Worked Python examples for filter, property, time-decay, numeric-decay, and blended boosts.
+description: Soft-rank vector, hybrid, and BM25 results by promoting or demoting matching documents without filtering them out. Worked Python examples for filter, property, time-decay, numeric-decay, and blended boosts.
 # tags: ['boost', 'search', 'ranking']
 ---
 
@@ -14,7 +14,7 @@ import BoostPreview from '/_includes/feature-notes/boost.mdx';
 
 <BoostPreview/>
 
-**Boost** soft-ranks search results — promote or demote matching documents without removing them from the result set. Matching documents move up. Non-matching documents stay in the results but rank lower.
+**Boost** soft-ranks search results: it promotes or demotes matching documents without removing them from the result set. Matching documents move up. Non-matching documents stay in the results but rank lower.
 
 Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, near-image, and near-media queries.
 
@@ -23,7 +23,7 @@ Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, near-i
 A boost is a **post-retrieval rescorer**:
 
 1. The primary search (vector, hybrid, BM25, ...) fetches `depth` candidate results. Set `depth` higher than `offset + limit` if you want boost to consider candidates beyond the first page.
-2. The boost scorer rescores those candidates in memory by evaluating each condition per candidate, normalizing per result set, and blending with the primary score. There are no new index queries — the cost is per-candidate in-memory scoring, not extra shard fan-out. Both primary and boost scores are min-max normalized into `[0, 1]` before blending, and the final score is renormalized to `[0, 1]`.
+2. The boost scorer rescores those candidates in memory by evaluating each condition per candidate, normalizing per result set, and blending with the primary score. There are no new index queries. The cost is per-candidate in-memory scoring, not extra shard fan-out. Both primary and boost scores are min-max normalized into `[0, 1]` before blending, and the final score is renormalized to `[0, 1]`.
 3. The user's original `offset` and `limit` are applied **after** the re-sort.
 
 ## Condition types
@@ -96,9 +96,9 @@ Continuous `[0, 1]` score that **decays with distance from an origin time**. The
 
 ### Numeric decay {#numeric-decay}
 
-Like time decay but for numeric (`int`, `number`) properties. Use this when "closer to X is better" — prices near a target, distances near a coordinate, ages near a band. Same `scale` / `offset` / `decay` / `curve` semantics as time decay, with all values expressed as numbers.
+Like time decay but for numeric (`int`, `number`) properties. Use this when "closer to X is better": prices near a target, distances near a coordinate, ages near a band. Same `scale` / `offset` / `decay` / `curve` semantics as time decay, with all values expressed as numbers.
 
-`scale` must be `> 0` and `decay` (if set) must be in `(0, 1]` — same as time decay.
+`scale` must be `> 0` and `decay` (if set) must be in `(0, 1]`, same as time decay.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -117,11 +117,11 @@ The three decay curves shape how score falls off with distance. At `distance == 
 
 | Curve | Shape | When to use |
 |---|---|---|
-| `EXPONENTIAL` (default) | Heavy tail — score halves geometrically every `scale` past the origin. | "Recency matters, but don't aggressively flatten older items to zero." |
-| `GAUSSIAN` | Bell curve — sharp falloff past `scale`. | "Items close to the origin are great, items far away are nearly worthless." |
-| `LINEAR` | Straight line — score reaches zero at a finite distance past `scale`. | "Predictable falloff with a clear cutoff." |
+| `EXPONENTIAL` (default) | Heavy tail: score halves geometrically every `scale` past the origin. | "Recency matters, but don't aggressively flatten older items to zero." |
+| `GAUSSIAN` | Bell curve: sharp falloff past `scale`. | "Items close to the origin are great, items far away are nearly worthless." |
+| `LINEAR` | Straight line: score reaches zero at a finite distance past `scale`. | "Predictable falloff with a clear cutoff." |
 
-Only these three values are accepted — anything else is rejected at request time.
+Only these three values are accepted. Anything else is rejected at request time.
 
 ## Blending and weights
 
@@ -131,10 +131,10 @@ A boost must carry **at least one** and **at most 20** conditions. Use `Boost.bl
 final_score = (1 − weight) · primary_norm + weight · boost_norm
 ```
 
-- **`weight`** — the outer blending weight, in `[0, 1]`. Defaults to `0.5`.
+- **`weight`**: the outer blending weight, in `[0, 1]`. Defaults to `0.5`.
 - **`weight: 0`** is a no-op: the boost short-circuits and primary results are returned unchanged.
-- **Per-condition `weight`** — a `float` defaulting to `1.0`. Use it to balance multiple boosts ("recency twice as important as popularity").
-- **Negative per-condition `weight`** — *demotes* matching documents. They stay in the result set but rank lower than non-matching ones.
+- **Per-condition `weight`**: a `float` defaulting to `1.0`. Use it to balance multiple boosts ("recency twice as important as popularity").
+- **Negative per-condition `weight`**: *demotes* matching documents. They stay in the result set but rank lower than non-matching ones.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -149,7 +149,7 @@ final_score = (1 − weight) · primary_norm + weight · boost_norm
 
 ### Negative weights demote
 
-A condition with `weight: -1.0` (or `-2.0`, etc.) reverses the effect: documents that match the condition rank below non-matching ones instead of above them. They are not removed. This is useful for deprioritizing — for example, surfacing drafts last without filtering them out.
+A condition with `weight: -1.0` (or `-2.0`, etc.) reverses the effect: documents that match the condition rank below non-matching ones instead of above them. They are not removed. This is useful for deprioritizing (for example, surfacing drafts last without filtering them out).
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -171,12 +171,12 @@ A condition with `weight: -1.0` (or `-2.0`, etc.) reverses the effect: documents
 | Default | `100` |
 | Operator override | [`QUERY_BOOST_DEFAULT_DEPTH`](/deploy/configuration/env-vars#QUERY_BOOST_DEFAULT_DEPTH) env var |
 | Hard cap | `QUERY_MAXIMUM_RESULTS` (cluster-wide limit) |
-| Lower bound | At least `offset + limit` — boost always sees enough to fill the page |
-| Accepted range | `≥ 0` — `0` means "use the default" |
+| Lower bound | At least `offset + limit`, so boost always sees enough to fill the page |
+| Accepted range | `≥ 0`, where `0` means "use the default" |
 
 :::tip Raise `depth` to reorder beyond the top page
 
-Boost can only reorder what the primary search already retrieved. If your boost should reorder past the default top-100 — for example, to pull a popular older article back to page 1 — pass a higher `depth` on the query.
+Boost can only reorder what the primary search already retrieved. If your boost should reorder past the default top-100 (for example, to pull a popular older article back to page 1), pass a higher `depth` on the query.
 
 Higher `depth` increases the primary search cost (BM25 / vector index work) and per-candidate scoring cost. Set it as tight as your use case allows.
 
@@ -184,10 +184,10 @@ Higher `depth` increases the primary search cost (BM25 / vector index work) and 
 
 ## Further resources
 
-- [Rerank](./rerank.md) — second-stage reranking with an external model.
-- [Hybrid search](./hybrid.md) — the BM25 / vector `alpha` blend.
-- [Filters](./filters.md) — hard filters (remove non-matching docs).
-- [BM25](./bm25.md) — keyword search.
+- [Rerank](./rerank.md): second-stage reranking with an external model.
+- [Hybrid search](./hybrid.md): the BM25 / vector `alpha` blend.
+- [Filters](./filters.md): hard filters (remove non-matching docs).
+- [BM25](./bm25.md): keyword search.
 
 ## Questions and feedback
 

--- a/docs/weaviate/search/filters.md
+++ b/docs/weaviate/search/filters.md
@@ -1069,7 +1069,7 @@ This filter requires the [property null state](../config-refs/indexing/inverted-
 
 :::caution Preview feature
 
-Available from Weaviate `v1.38` as a preview, gated by the `WEAVIATE_PREVIEW_NESTED_FILTERING=on` environment variable on the server. The path syntax and operator semantics are stable, but the on-disk encoding may change before GA — don't rely on persistent state from preview clusters carrying over to the GA release. The env var is removed at GA and the feature is enabled unconditionally.
+Available from Weaviate `v1.38` as a preview, gated by the `WEAVIATE_PREVIEW_NESTED_FILTERING=on` environment variable on the server. The path syntax and operator semantics are stable, but the on-disk encoding may change before GA. Don't rely on persistent state from preview clusters carrying over to the GA release. The env var is removed at GA and the feature is enabled unconditionally.
 
 :::
 
@@ -1094,7 +1094,7 @@ The filter property is a single dotted path. The dot is the only separator. An o
 | `cars.tires.width` | Any tire on any car (recursive across two `object[]` levels) |
 | `cars[1].tires[2].brand` | The second car's third tire's `brand` (positional through nesting) |
 
-`[N]` on a segment requires that segment to be an `object[]` (array). Every intermediate segment must be `object` or `object[]` — you cannot pivot through a scalar. The leaf may be any supported scalar type.
+`[N]` on a segment requires that segment to be an `object[]` (array). Every intermediate segment must be `object` or `object[]`. You cannot pivot through a scalar. The leaf may be any supported scalar type.
 
 ### Match any element (default)
 
@@ -1128,7 +1128,7 @@ Use `[N]` to pin a path segment to a specific array index. Indices are 0-based.
 
 ### Same-element correlation across leaves
 
-Combining two leaf filters with `And` matches when **the same element** in the parent array satisfies both. A document with one car `(Toyota, blue)` and another `(Honda, red)` would not match `cars.make = "Toyota" AND cars.color = "red"` — both conditions must hold on the **same** car.
+Combining two leaf filters with `And` matches when **the same element** in the parent array satisfies both. A document with one car `(Toyota, blue)` and another `(Honda, red)` would not match `cars.make = "Toyota" AND cars.color = "red"`. Both conditions must hold on the **same** car.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -1176,7 +1176,7 @@ Pointing a path at an `object` or `object[]` segment (rather than a scalar leaf)
 :::note
 
 - **Allowed leaf data types**: `text`, `int`, `number`, `boolean`, `date`, `uuid`, and their array variants. `blob`, `blobHash`, `geoCoordinates`, `phoneNumber`, and cross-references (`cref`) are not allowed inside nested objects for nested filtering.
-- **`IndexFilterable` is required**: nested filtering uses the filterable inverted index on each leaf. `IndexRangeFilters` and `IndexSearchable` flags exist on nested-property definitions but are not yet exercised by the nested searcher — range filters on nested numeric leaves currently use the filterable bucket.
+- **`IndexFilterable` is required**: nested filtering uses the filterable inverted index on each leaf. `IndexRangeFilters` and `IndexSearchable` flags exist on nested-property definitions but are not yet exercised by the nested searcher. Range filters on nested numeric leaves currently use the filterable bucket.
 - **Tokenization matters**: nested `text` leaves use the same tokenization options as flat properties. For exact-match filters on names, codes, or identifiers, set `tokenization: field` on the leaf so the value is stored as a single token.
 - **Reference-path vs nested-path**: a reference-path filter is a multi-element `Path` (`["inCity", "City", "name"]`) traversing cross-references; a nested-path filter is a **single-element** path with dots inside it (`["cars.make"]`).
 

--- a/docs/weaviate/search/hybrid.md
+++ b/docs/weaviate/search/hybrid.md
@@ -376,7 +376,7 @@ The output is like this:
     Additional information
   </summary>
 
-For a discussion of fusion methods, see [this blog post](https://weaviate.io/blog/hybrid-search-fusion-algorithms) and [this reference page](../api/graphql/search-operators.md#variables-2)
+For a discussion of fusion methods, see [this blog post](https://weaviate.io/blog/hybrid-search-fusion-algorithms) and [this reference page](../api/graphql/search-operators.md#fusion-algorithms).
 
 </details>
 
@@ -1045,7 +1045,7 @@ import TokenizationNote from '/\_includes/tokenization.mdx'
 
 <BoostPreview/>
 
-Hybrid queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property.
+Hybrid queries accept an optional `boost` argument that promotes or demotes matching documents without removing them. This is useful for biasing results by recency, popularity, a soft filter, or another property.
 
 The boost runs once over the **fused** hybrid result. The BM25 and vector sub-search legs do not see the boost themselves. Hybrid's own `alpha` blend runs first, and the boost rescores the fused candidate pool on top.
 

--- a/docs/weaviate/search/query-profile.md
+++ b/docs/weaviate/search/query-profile.md
@@ -16,7 +16,7 @@ import QueryProfileNote from '/_includes/feature-notes/query-profile.mdx';
 
 <QueryProfileNote/>
 
-Query profiling provides per-shard timing breakdowns for search queries. Enable it on any search request to see how long each phase takes — vector search, keyword scoring, filter evaluation, object retrieval — broken down by shard and cluster node.
+Query profiling provides per-shard timing breakdowns for search queries. Enable it on any search request to see how long each phase takes (vector search, keyword scoring, filter evaluation, object retrieval), broken down by shard and cluster node.
 
 Profiling uses the same instrumentation as [slow query logging](/deploy/configuration/logging.md#slow-query-logging). It adds minimal overhead when enabled and zero overhead when disabled.
 

--- a/docs/weaviate/search/rerank.md
+++ b/docs/weaviate/search/rerank.md
@@ -201,7 +201,7 @@ The response should look like this:
 
 <BoostPreview/>
 
-For lightweight result reordering based on filters, property values, or time / numeric decay — without calling an external rerank model — use [Boost](./boost.md). Rerank and Boost can be used independently. Pick rerank when you need a smarter model to re-rank the top-N, and Boost when you want to bias by simple signals already on the objects.
+For lightweight result reordering based on filters, property values, or time / numeric decay (without calling an external rerank model), use [Boost](./boost.md). Rerank and Boost can be used independently. Pick rerank when you need a smarter model to re-rank the top-N, and Boost when you want to bias by simple signals already on the objects.
 
 ## Related pages
 

--- a/docs/weaviate/search/similarity.md
+++ b/docs/weaviate/search/similarity.md
@@ -673,7 +673,7 @@ import V137Preview from '/\_includes/feature-notes/v137-preview.mdx';
 
 <V137Preview/>
 
-Standard vector search returns the closest matches to the query, which often means a cluster of near-duplicate results. **Maximum Marginal Relevance (MMR)** reranks results to balance relevance with diversity — each selected result must add something new to the result set.
+Standard vector search returns the closest matches to the query, which often means a cluster of near-duplicate results. **Maximum Marginal Relevance (MMR)** reranks results to balance relevance with diversity: each selected result must add something new to the result set.
 
 Add the `diversity_selection` parameter to any vector search query:
 
@@ -721,7 +721,7 @@ A larger candidate set (higher top-level `limit`) gives MMR more results to choo
 
 <BoostPreview/>
 
-Vector search queries accept an optional `boost` argument that promotes or demotes matching documents without removing them — useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
+Vector search queries accept an optional `boost` argument that promotes or demotes matching documents without removing them. This is useful for biasing results by recency, popularity, a soft filter, or another property. Matching documents move up. Everything else stays in the results but ranks lower.
 
 See [Boost](./boost.md) for the supported condition types (filter, property value, time decay, numeric decay), curve choices, blending semantics, and depth tuning.
 

--- a/docs/weaviate/tutorials/cross-references.mdx
+++ b/docs/weaviate/tutorials/cross-references.mdx
@@ -18,7 +18,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import FilteredTextBlock from '@site/src/components/Documentation/FilteredTextBlock';
 import XRefCrudPythonCode from '!!raw-loader!/_includes/code/howto/manage-data.cross-refs.py';
-import XRefCrudTSCode from '!!raw-loader!/_includes/code/howto/manage-data.cross-refs';
+import XRefCrudTSCode from '!!raw-loader!/_includes/code/howto/manage-data.cross-refs.ts';
 import XRefCrudGoCode from '!!raw-loader!/_includes/code/howto/go/docs/manage-data.cross-refs_test.go';
 
 import SearchBasicsPythonCode from '!!raw-loader!/_includes/code/howto/search.basics.py';
@@ -37,7 +37,7 @@ We will refer to the originating object as the **source** object, and the object
 
 ### Prerequisites
 
-This tutorial assumes that you have completed the [QuickStart tutorial](docs/weaviate/quickstart/index.md) and have access to a Weaviate instance with write access.
+This tutorial assumes that you have completed the [QuickStart tutorial](../quickstart/index.md) and have access to a Weaviate instance with write access.
 
 ## When to use cross-references
 
@@ -112,6 +112,14 @@ An example syntax is shown below:
 
   </TabItem>
 
+  <TabItem value="ts" label="JavaScript/TypeScript">
+    <FilteredTextBlock
+      text={XRefCrudTSCode}
+      startMarker="// START OneWay"
+      endMarker="// END OneWay"
+      language="ts"
+    />
+  </TabItem>
 
   <TabItem value="go" label="Go">
     <FilteredTextBlock

--- a/docs/weaviate/tutorials/spark-connector.md
+++ b/docs/weaviate/tutorials/spark-connector.md
@@ -17,7 +17,7 @@ By the end of this tutorial, you'll be able to see how to you can import your da
 
 ## Installation
 
-We recommend reading the [Quickstart tutorial](docs/weaviate/quickstart/index.md) first before tackling this tutorial.
+We recommend reading the [Quickstart tutorial](../quickstart/index.md) first before tackling this tutorial.
 
 We will install the python `weaviate-client` and also run Spark locally for which we need to install the python `pyspark` package. Use the following command in your terminal to get both:
 ```bash
@@ -32,7 +32,7 @@ We will also need the Weaviate Spark connector. You can download this by running
 curl https://github.com/weaviate/spark-connector/releases/download/v||site.spark_connector_version||/spark-connector-assembly-||site.spark_connector_version||.jar --output spark-connector-assembly-||site.spark_connector_version||.jar
 ```
 
-For this tutorial, you will also need a Weaviate instance running at `http://localhost:8080`. This instance does not need to have any modules and can be setup by following the [Quickstart tutorial](docs/weaviate/quickstart/index.md).
+For this tutorial, you will also need a Weaviate instance running at `http://localhost:8080`. This instance does not need to have any modules and can be setup by following the [Quickstart tutorial](../quickstart/index.md).
 
 You will also need Java 8+ and Scala 2.12 installed. You can get these separately setup or a more convenient way to get both of these set up is to install [IntelliJ](https://www.jetbrains.com/idea/).
 
@@ -102,7 +102,7 @@ To verify this is done correctly we can have a look at the first few records:
 ## Writing to Weaviate
 
 :::tip
-Prior to this step, make sure your Weaviate instance is running at `http://localhost:8080`. You can refer to the [Quickstart tutorial](docs/weaviate/quickstart/index.md) for instructions on how to set that up.
+Prior to this step, make sure your Weaviate instance is running at `http://localhost:8080`. You can refer to the [Quickstart tutorial](../quickstart/index.md) for instructions on how to set that up.
 :::
 
 To quickly get a Weaviate instance running you can save the following `docker-compose.yml` file to your local machine:
@@ -199,7 +199,15 @@ Let's examine the code above to understand exactly what's happening and all the 
 By now we've written our data to Weaviate, and we understand the capabilities of the Spark connector and its settings. As a last step, we can query the data via the Python client to confirm that the data has been loaded.
 
 ```python
-client.query.get("Sphere", "title").do()
+spheres = client.collections.use("Sphere")
+
+response = spheres.query.fetch_objects(
+    limit=3,
+    return_properties=["title"],
+)
+
+for obj in response.objects:
+    print(obj.properties["title"])
 ```
 
 ## Additional options


### PR DESCRIPTION
Medium tier of the docs deep review, group 2 of 4. 8 findings, 12 files.

**Stacked on #493.** Base retargets to `main` when that merges.

**Two snippets could not be copy-pasted.** The `IsNull` example in the GraphQL filter reference was missing a closing paren and two braces, so it would not parse; all 14 code blocks on that page were checked and it was the only unbalanced one. The gRPC page's docker-compose block opened with a four-backtick fence and an invalid info string, so the page rendered a literal ` ```yaml ` line as content.

**gRPC client support** was documented as Python and TypeScript only, with others "in the near future". Java and C# have first-class gRPC. The Go client uses it for batch imports but reaches gRPC search only through its experimental API, so Go is described separately rather than claimed at parity.

**A link that pointed at the wrong section.** The hybrid page linked to `search-operators#variables-2`, which lands on nearText's Variables section, not hybrid's. That page has six identically titled "Variables" headings, so Docusaurus numbers the anchors positionally and any heading move silently re-points every inbound link. Rather than switch to a more accurate ordinal, this targets the uniquely named `#fusion-algorithms` section, which is what the sentence is actually about. The underlying fragility is tracked separately.

**A tab that was never rendered.** The cross-references tutorial imported a TypeScript source and never used it, so the tab was simply absent; the import path was also extensionless. The Spark connector tutorial ended on a removed v3 client call.

Em dashes removed across the search partition. Dashes inside sample output are deliberately left, since they are quoted dataset text.

Verified: `yarn build-dev` exit 0; broken links and anchors identical to the base; the Go package still compiles; every marker unique and byte-exact.