### PR TITLE
docs(client-libraries,concepts): correct client version claims and self-contradicting statements

### DIFF
--- a/_includes/code/java-v6/src/test/java/GetStartedTest.java
+++ b/_includes/code/java-v6/src/test/java/GetStartedTest.java
@@ -39,7 +39,11 @@ class GetStartedTest {
           col -> col.properties(Property.text("answer"),
               Property.text("question"),
               Property.text("category"))
-              .vectorConfig(VectorConfig.text2vecTransformers()) // Configure the Contextionary embedding model
+              .vectorConfig(VectorConfig.text2vecOllama(v -> v
+                  // If using Docker you might need: http://host.docker.internal:11434
+                  .apiEndpoint("http://ollama:11434")
+                  .model("nomic-embed-text") // The model to use
+              )) // Configure the Ollama embedding model
       );
       CollectionHandle<Map<String, Object>> questions = client.collections.use(collectionName);
       // highlight-end

--- a/docs/weaviate/best-practices/code-generation.md
+++ b/docs/weaviate/best-practices/code-generation.md
@@ -18,12 +18,12 @@ Here are some tips for writing Weaviate client library code with generative AI m
 
 Weaviate provides two [MCP](https://modelcontextprotocol.io/) servers that integrate with AI development tools like Claude Code, Claude Desktop, Cursor, and VS Code:
 
-- **[Weaviate MCP Server](../configuration/mcp-server.mdx)** — Built into Weaviate itself. Lets AI assistants inspect schemas, search data, and modify objects in your Weaviate instance directly. Enable with `MCP_SERVER_ENABLED=true`.
-- **[Weaviate Docs MCP Server](../mcp/docs-mcp-server.mdx)** — A standalone server that gives AI assistants access to Weaviate's documentation, reducing hallucinations when generating Weaviate code.
+- **[Weaviate MCP Server](../configuration/mcp-server.mdx)**: Built into Weaviate itself. Lets AI assistants inspect schemas, search data, and modify objects in your Weaviate instance directly. Enable with `MCP_SERVER_ENABLED=true`.
+- **[Weaviate Docs MCP Server](../mcp/docs-mcp-server.mdx)**: A standalone server that gives AI assistants access to Weaviate's documentation, reducing hallucinations when generating Weaviate code.
 
 ### Weaviate Agent Skills
 
-**[Weaviate Agent Skills](https://github.com/weaviate/agent-skills)** gives AI coding agents (Claude Code, Cursor, GitHub Copilot, and others) built-in knowledge of Weaviate — covering search, collection management, data import, and complete application blueprints such as RAG, agentic RAG, and chatbots. When the skill is installed, agents can discover and use it automatically, reducing hallucinations and speeding up Weaviate development.
+**[Weaviate Agent Skills](https://github.com/weaviate/agent-skills)** gives AI coding agents (Claude Code, Cursor, GitHub Copilot, and others) built-in knowledge of Weaviate, covering search, collection management, data import, and complete application blueprints such as RAG, agentic RAG, and chatbots. When the skill is installed, agents can discover and use it automatically, reducing hallucinations and speeding up Weaviate development.
 
 Install with:
 
@@ -100,7 +100,7 @@ Review the documentation of your specific IDE to see if it has this feature, and
 
 ### Consider using the Query Agent
 
-The [Query Agent](/query-agent) is a pre-built agentic search service that decides the search terms, filters, sorts, and other search parameters for you — the [modes overview](/query-agent/guides/index.md) covers what it can do.
+The [Query Agent](/query-agent) is a pre-built agentic search service that decides the search terms, filters, sorts, and other search parameters for you. The [modes overview](/query-agent/guides/index.md) covers what it can do.
 
 The Query Agent is available to Weaviate Cloud users for interacting with their Weaviate Cloud instance in natural language. For some use cases, this may be a better approach than using AI-powered code generation tools.
 

--- a/docs/weaviate/best-practices/index.md
+++ b/docs/weaviate/best-practices/index.md
@@ -99,7 +99,7 @@ As the size of your dataset grows, the accompanying vector indexes can lead to h
 
 If you have a large number of vectors, consider using vector quantization to reduce the memory footprint of the vector index. This will reduce the required memory, and allow you to scale more effectively at lower costs.
 
-If memory is your priority, you can also consider the disk-based [HFresh index](/weaviate/concepts/vector-index#hfresh-index) — an index-level alternative to quantization for reducing the memory footprint.
+If memory is your priority, you can also consider the disk-based [HFresh index](/weaviate/concepts/vector-index#hfresh-index), an index-level alternative to quantization for reducing the memory footprint.
 
 ![Overview of quantization schemes](../../../_includes/images/concepts/quantization_overview_light.png#gh-light-mode-only "Overview of quantization schemes")
 ![Overview of quantization schemes](../../../_includes/images/concepts/quantization_overview_dark.png#gh-dark-mode-only "Overview of quantization schemes")
@@ -362,11 +362,11 @@ When using Weaviate in an asynchronous environment, consider using the asynchron
 
 #### Python
 
-The Weaviate Python client `4.7.0` and higher includes an [asynchronous client API (`WeaviateAsyncClient`)](../client-libraries/python/async.md).
+The Weaviate Python client includes an [asynchronous client API (`WeaviateAsyncClient`)](../client-libraries/python/async.md).
 
 #### Java
 
-The Weaviate Java client `5.0.0` and higher includes an [asynchronous client API (`WeaviateAsyncClient`)](https://javadoc.io/doc/io.weaviate/client/latest/io/weaviate/client/v1/async/WeaviateAsyncClient.html).
+The Weaviate Java client includes an [asynchronous client API (`WeaviateClientAsync`)](https://javadoc.io/doc/io.weaviate/client6/latest/io/weaviate/client6/v1/api/WeaviateClientAsync.html).
 
 ## Questions and feedback
 

--- a/docs/weaviate/client-libraries/csharp.mdx
+++ b/docs/weaviate/client-libraries/csharp.mdx
@@ -46,7 +46,7 @@ dotnet add package Weaviate.Client --version ||site.csharp_client_version||
 
 #### Weaviate version compatibility
 
-The C# client requires Weaviate `1.33.0` or higher. Generally, we encourage you to use the latest version of the C# client and the Weaviate Database.
+The C# client requires Weaviate `v1.32.0` and later. Generally, we encourage you to use the latest version of the C# client and the Weaviate Database.
 
 #### gRPC
 

--- a/docs/weaviate/client-libraries/go.md
+++ b/docs/weaviate/client-libraries/go.md
@@ -24,7 +24,7 @@ The latest Go client is version `v||site.go_client_version||`.
 
 :::
 
-The Weaviate Go client requires Go `1.25` and later, as declared by the `go` directive in `go.mod` for client `v||site.go_client_version||`. Newer client releases can raise this requirement, so check `go.mod` for the release you install.
+For the minimum supported Go version, see the [`go` directive in `go.mod`](https://github.com/weaviate/weaviate-go-client/blob/v||site.go_client_version||/go.mod) for client `v||site.go_client_version||`.
 
 ## Installation
 The client doesn't support the old Go modules system. Create a repository for your code before you import the Weaviate client.

--- a/docs/weaviate/client-libraries/go.md
+++ b/docs/weaviate/client-libraries/go.md
@@ -24,7 +24,7 @@ The latest Go client is version `v||site.go_client_version||`.
 
 :::
 
-The Weaviate Go client is compatible with Go 1.16+.
+The Weaviate Go client requires Go `1.25` and later, as declared by the `go` directive in `go.mod` for client `v||site.go_client_version||`. Newer client releases can raise this requirement, so check `go.mod` for the release you install.
 
 ## Installation
 The client doesn't support the old Go modules system. Create a repository for your code before you import the Weaviate client.

--- a/docs/weaviate/client-libraries/java/index.mdx
+++ b/docs/weaviate/client-libraries/java/index.mdx
@@ -75,7 +75,7 @@ This ensures that all dynamically-loaded dependencies of `io.grpc` are resolved 
 
 #### Weaviate version compatibility
 
-The `v6` Java client requires Weaviate `1.33.0` or higher. Generally, we encourage you to use the latest version of the Java client and the Weaviate Database.
+The `v6` Java client requires Weaviate `v1.32.0` and later. Generally, we encourage you to use the latest version of the Java client and the Weaviate Database.
 
 #### gRPC
 
@@ -104,7 +104,7 @@ import BasicPrereqs from "/_includes/prerequisites-quickstart.md";
 
 Get started with Weaviate using this Java example. The code walks you through these key steps:
 
-1. **[Connect to Weaviate](docs/weaviate/connections/index.mdx)**: Establish a connection to a local (or Cloud) Weaviate instance.
+1. **[Connect to Weaviate](../../connections/index.mdx)**: Establish a connection to a local (or Cloud) Weaviate instance.
 1. **[Create a collection](../../manage-collections/index.mdx)**: Define the data schema for a `Question` collection, using an Ollama model to vectorize the data.
 1. **[Import data](../../manage-objects/import.mdx)**: Fetch sample Jeopardy questions and use Weaviate's batch import for efficient ingestion and automatic vector embedding generation.
 1. **[Search/query the database](../../search/index.mdx)**: Execute a vector search to find questions semantically similar to the query `biology`.

--- a/docs/weaviate/client-libraries/python/index.mdx
+++ b/docs/weaviate/client-libraries/python/index.mdx
@@ -55,7 +55,7 @@ pip install --pre -U "weaviate-client==4.*"`
 
 #### Weaviate version compatibility
 
-The `v4` Python client requires Weaviate `1.23.7` or higher. Generally, we encourage you to use the latest version of the Python client and the Weaviate Database.
+The `v4` Python client requires Weaviate `v1.23.7` and later. Generally, we encourage you to use the latest version of the Python client and the Weaviate Database.
 
 In Weaviate Cloud, clusters are compatible with the `v4` client as of 31 January, 2024. Clusters created before this date will not be compatible with the `v4` client.
 
@@ -94,7 +94,7 @@ import BasicPrereqs from "/_includes/prerequisites-quickstart.md";
 
 Get started with Weaviate using this Python example. The code walks you through these key steps:
 
-1. **[Connect to Weaviate](docs/weaviate/connections/index.mdx)**: Establish a connection to a local (or Cloud) Weaviate instance.
+1. **[Connect to Weaviate](../../connections/index.mdx)**: Establish a connection to a local (or Cloud) Weaviate instance.
 1. **[Create a collection](../../manage-collections/index.mdx)**: Define the data schema for a `Question` collection, using an Ollama model to vectorize the data.
 1. **[Import data](../../manage-objects/import.mdx)**: Fetch sample Jeopardy questions and use Weaviate's batch import for efficient ingestion and automatic vector embedding generation.
 1. **[Search/query the database](../../search/index.mdx)**: Execute a vector search to find questions semantically similar to the query `biology`.

--- a/docs/weaviate/concepts/interface.md
+++ b/docs/weaviate/concepts/interface.md
@@ -6,7 +6,7 @@ image: og/docs/concepts.jpg
 # tags: ['architecture', 'interface', 'API design']
 ---
 
-You can manage and use Weaviate through its APIs. Weaviate has a RESTful API and a GraphQL API. The client libraries in all languages support all API functions. Some clients, e.g. the Python client, have additional functionality, such as full schema management and batching operations. This way, Weaviate is easy to use in custom projects. Additionally, the APIs are intuitive, so it is easy to integrate into your existing data landscape.
+You can manage and use Weaviate through its APIs. Weaviate has a RESTful API and a GraphQL API. The client libraries broadly mirror this API surface, although feature coverage can vary by language; see the [client library pages](/weaviate/client-libraries/index.mdx) for what each one supports. Some clients, e.g. the Python client, have additional functionality, such as full schema management and batching operations. This way, Weaviate is easy to use in custom projects. Additionally, the APIs are intuitive, so it is easy to integrate into your existing data landscape.
 
 This page contains information on how Weaviate's APIs are designed, and how you can use Weaviate Console to search through your Weaviate instance with GraphQL.
 
@@ -27,8 +27,8 @@ Weaviate has both a RESTful API and a GraphQL API. Currently, there is no featur
 - **Data search** -> GraphQL API
 - **Explorative data search** -> GraphQL API
 - **Data analysis (meta data)** -> GraphQL API
-- **Near real time on very large datasets in production** -> Client libraries (Python, Go, Java, JavaScript) using both APIs under the hood
-- **Easy to integrate in applications** -> Client libraries (Python, Go, Java, JavaScript) using both APIs under the hood
+- **Near real time on very large datasets in production** -> Client libraries (Python, Go, Java, JavaScript, C#) using both APIs under the hood
+- **Easy to integrate in applications** -> Client libraries (Python, Go, Java, JavaScript, C#) using both APIs under the hood
 
 ## GraphQL
 
@@ -137,7 +137,7 @@ The [Weaviate Console](/go/console?utm_content=others) is a dashboard to manage 
 
 ## Weaviate Clients
 
-Weaviate has several client libraries: in [Go](/weaviate/client-libraries/go.md), [Java](/weaviate/client-libraries/java/index.mdx), [Python](/weaviate/client-libraries/python/index.mdx) and [TypeScript/JavaScript](/weaviate/client-libraries/typescript/index.mdx). The client libraries in all languages support all API functions. Some clients, e.g. the Python client, have additional functionality, such as full schema management and batching operations. This way, Weaviate is easy to use in custom projects. The APIs are intuitive to use, so it is easy to integrate Weaviate into your existing data landscape.
+Weaviate has several client libraries: in [C#](/weaviate/client-libraries/csharp.mdx), [Go](/weaviate/client-libraries/go.md), [Java](/weaviate/client-libraries/java/index.mdx), [Python](/weaviate/client-libraries/python/index.mdx) and [TypeScript/JavaScript](/weaviate/client-libraries/typescript/index.mdx). The client libraries broadly mirror the server API surface, although feature coverage varies by language. See the [client library pages](/weaviate/client-libraries/index.mdx) for what each one supports. Some clients, e.g. the Python client, have additional functionality, such as full schema management and batching operations. This way, Weaviate is easy to use in custom projects. The APIs are intuitive to use, so it is easy to integrate Weaviate into your existing data landscape.
 
 ## Further resources
 

--- a/docs/weaviate/concepts/vector-quantization.md
+++ b/docs/weaviate/concepts/vector-quantization.md
@@ -197,7 +197,7 @@ You might be also interested in our blog post [HNSW+PQ - Exploring ANN algorithm
 
 ### With a flat index
 
-[RQ](#rotational-quantization) and [BQ](#binary-quantization) can be applied to a [flat index](./indexing/inverted-index.md). As a flat index search is a brute-force method, compression reduces the amount of data Weaviate has to read and increases speed.
+[RQ](#rotational-quantization) and [BQ](#binary-quantization) can be applied to a [flat index](./indexing/vector-index.md#flat-index). As a flat index search is a brute-force method, compression reduces the amount of data Weaviate has to read and increases speed.
 
 ## Rescoring
 

--- a/docs/weaviate/more-resources/example-datasets.md
+++ b/docs/weaviate/more-resources/example-datasets.md
@@ -105,7 +105,7 @@ export CACHE_DIR=<YOUR_CHOICE_OF_CACHE_DIR>
 # Optionally you can set the batch size (if not specified by default 200)
 export BATCH_SIZE=<YOUR_CHOICE_OF_BATCH_SIZE>
 # Make sure to replace WEAVIATE_ORIGIN with the Weaviate origin as mentioned in the basics above
-docker run -it -e weaviate_host=$WEAVIATE_ORIGIN -e cache_dir-$CACHE_DIR -e batch_size=$BATCH_SIZE semitechnologies/weaviate-demo-newspublications:latest
+docker run -it -e weaviate_host=$WEAVIATE_ORIGIN -e cache_dir=$CACHE_DIR -e batch_size=$BATCH_SIZE semitechnologies/weaviate-demo-newspublications:latest
 
 ```
 
@@ -125,7 +125,7 @@ export CACHE_DIR=<YOUR_CHOICE_OF_CACHE_DIR>
 # Optionally you can set the batch size (if not specified by default 200)
 export BATCH_SIZE=<YOUR_CHOICE_OF_BATCH_SIZE>
 # Run docker
-docker run -it --network=$WEAVIATE_NETWORK -e weaviate_host=$WEAVIATE_ORIGIN -e cache_dir-$CACHE_DIR -e batch_size=$BATCH_SIZE  semitechnologies/weaviate-demo-newspublications:latest
+docker run -it --network=$WEAVIATE_NETWORK -e weaviate_host=$WEAVIATE_ORIGIN -e cache_dir=$CACHE_DIR -e batch_size=$BATCH_SIZE  semitechnologies/weaviate-demo-newspublications:latest
 ```
 
 ## Questions and feedback

--- a/docs/weaviate/more-resources/example-use-cases.md
+++ b/docs/weaviate/more-resources/example-use-cases.md
@@ -53,7 +53,7 @@ Weaviate can leverage its vectorization capabilities to enable automatic, real-t
 |Title | Description | Modality | Code |
 | --- | --- | --- | --- |
 | Toxic Comment Classification | Classify whether a comment is toxic or non-toxic. | Text | [Python](https://github.com/weaviate-tutorials/DEMO-classification-toxic-comment) |
-| Audio Genre Classification | Classify the music genre of an audio file. | Image | [Python](https://github.com/weaviate-tutorials/DEMO-classification-audio-genre/) |
+| Audio Genre Classification | Classify the music genre of an audio file. | Audio | [Python](https://github.com/weaviate-tutorials/DEMO-classification-audio-genre/) |
 
 ## Other use cases
 
@@ -61,7 +61,7 @@ Weaviate's [modular ecosystem](../modules/index.md) unlocks many other use cases
 
 |Title | Description | Code |
 | --- | --- | --- |
-| Named Entity Recognition (NER)| tbd |  [Python](https://github.com/weaviate/weaviate-examples/tree/main/example-with-NER-module) |
+| Named Entity Recognition (NER)| Extract named entities, such as people, organizations and locations, from text stored in Weaviate. |  [Python](https://github.com/weaviate/weaviate-examples/tree/main/example-with-NER-module) |
 
 
 ## Questions and feedback

--- a/docs/weaviate/more-resources/faq.md
+++ b/docs/weaviate/more-resources/faq.md
@@ -675,7 +675,7 @@ If you need resources from the previous version of Weaviate Academy, check out t
 <details>
   <summary>Answer</summary>
 
-> The Weaviate Community Slack has been decommissioned. We've moved community discussions to the [Weaviate Community Forum](https://forum.weaviate.io/), which offers better long-term discoverability — conversations are indexed and searchable, so valuable answers don't get lost over time.
+> The Weaviate Community Slack has been decommissioned. We've moved community discussions to the [Weaviate Community Forum](https://forum.weaviate.io/), which offers better long-term discoverability: conversations are indexed and searchable, so valuable answers don't get lost over time.
 >
 > Join us at [forum.weaviate.io](https://forum.weaviate.io/) to ask questions, share ideas, and connect with the community. For private support inquiries, you can reach us at [support@weaviate.io](mailto:support@weaviate.io).
 
@@ -688,8 +688,8 @@ If you need resources from the previous version of Weaviate Academy, check out t
 
 > Yes, Weaviate provides two MCP (Model Context Protocol) servers:
 >
-> - **[Weaviate MCP server](/weaviate/configuration/mcp-server.mdx)** — Built into Weaviate itself. Exposes tools for inspecting schemas, searching data (vector/hybrid), and modifying objects. Runs on the same port as the REST API at `/v1/mcp`. Disabled by default — enable with `MCP_SERVER_ENABLED=true`.
-> - **[Weaviate Docs MCP server](/weaviate/mcp/docs-mcp-server.mdx)** — A standalone server that gives LLMs access to Weaviate's documentation. Useful for AI-assisted development with Weaviate.
+> - **[Weaviate MCP server](/weaviate/configuration/mcp-server.mdx)**: Built into Weaviate itself. Exposes tools for inspecting schemas, searching data (vector/hybrid), and modifying objects. Runs on the same port as the REST API at `/v1/mcp`. Disabled by default. Enable it with `MCP_SERVER_ENABLED=true`.
+> - **[Weaviate Docs MCP server](/weaviate/mcp/docs-mcp-server.mdx)**: A standalone server that gives LLMs access to Weaviate's documentation. Useful for AI-assisted development with Weaviate.
 >
 > Both servers use the Streamable HTTP transport and work with MCP clients like Claude Code, Claude Desktop, Cursor, and VS Code.
 

--- a/docs/weaviate/more-resources/performance.md
+++ b/docs/weaviate/more-resources/performance.md
@@ -26,7 +26,7 @@ Inverted indexes are used often in document retrieval systems and search engines
 The inverted index currently does not do any weighing (e.g. tf-idf) for sorting, since the vector index is used for these features like sorting. The inverted index is thus, at the moment, rather a binary operation: including or excluding data objects from the query result list, which results in an 'allow list'.
 
 ## Vector index
-Everything that has a vector, thus every data object in Weaviate, is also indexed in the vector index. Weaviate currently supports [HNSW](https://arxiv.org/abs/1603.09320) and flat vector indexes.
+Everything that has a vector, thus every data object in Weaviate, is also indexed in the vector index. Weaviate supports several vector index types, which trade off search speed, recall and resource use in different ways. The default is [HNSW](https://arxiv.org/abs/1603.09320).
 
 See [Concepts: vector index](../concepts/indexing/vector-index.md) for more information about the vector index.
 
@@ -54,7 +54,7 @@ A tip is to avoid deeply nested filters in the queries. Additionally, try to mak
 
 ## Profiling query performance
 
-To diagnose slow queries, use [query profiling](/weaviate/search/query-profile.md) to get per-shard timing breakdowns. This shows exactly how long each phase takes — vector search, keyword scoring, filter evaluation, object retrieval — broken down by shard and cluster node.
+To diagnose slow queries, use [query profiling](/weaviate/search/query-profile.md) to get per-shard timing breakdowns. This shows exactly how long each phase takes (vector search, keyword scoring, filter evaluation, and object retrieval), broken down by shard and cluster node.
 
 ## Questions and feedback
 

--- a/docs/weaviate/starter-guides/custom-vectors.mdx
+++ b/docs/weaviate/starter-guides/custom-vectors.mdx
@@ -77,7 +77,7 @@ To install a client library, use the installer for the client language:
 
 <Tabs className="code" groupId="languages">
 <TabItem value="py" label="Python">
-The v4 client requires Weaviate 1.23.7 or higher.<br/><br/>
+The v4 client requires Weaviate `v1.23.7` and later.<br/><br/>
 
 ```bash
 pip install -U weaviate-client

--- a/docs/weaviate/starter-guides/managing-resources/index.md
+++ b/docs/weaviate/starter-guides/managing-resources/index.md
@@ -145,7 +145,7 @@ Weaviate supports the following vector compression methods:
 | Product Quantization (PQ) | HNSW       | Yes               | Each vector becomes an array of integer-based centroids ([read more](../../concepts/vector-quantization.md#product-quantization)) |
 | Binary Quantization (BQ)  | HNSW, Flat | No                | Each vector dimension becomes a bit ([read more](../../concepts/vector-quantization.md#binary-quantization)) |
 | Scalar Quantization (SQ)  | HNSW       | Yes               | Each vector dimension becomes an integer ([read more](../../concepts/vector-quantization.md#scalar-quantization)) |
-| Rotational Quantization (RQ) | HNSW    | No                | Each vector is rotated then quantized to an integer ([read more](../../concepts/vector-quantization.md#rotational-quantization)) |
+| Rotational Quantization (RQ) | All index types | No          | Each vector is rotated then quantized to an integer ([read more](../../concepts/vector-quantization.md#rotational-quantization)) |
 
 As a starting point, use the following guidelines for selecting a compression method:
 

--- a/docs/weaviate/starter-guides/managing-resources/indexing.mdx
+++ b/docs/weaviate/starter-guides/managing-resources/indexing.mdx
@@ -100,7 +100,7 @@ import HFreshStatus from '/_includes/feature-notes/hfresh_status.mdx';
 HFresh indexes are well-suited when memory efficiency is a priority, especially with high-dimensional vectors. They use mandatory 1-bit rotational quantization (RQ) for postings and 8-bit RQ for centroids. Only the compressed centroid index is kept in memory. The posting lists live on disk, so memory usage stays low even as the collection grows. The trade-off is lower peak query throughput than HNSW, so HFresh is a good fit when you can tolerate higher query latency in exchange for smaller memory requirements.
 
 :::tip Tuning
-Start with the default parameters. If recall is too low, increase `searchProbe` or the RQ `rescoreLimit` — both take effect at runtime.
+Start with the default parameters. If recall is too low, increase `searchProbe` or the RQ `rescoreLimit`. Both take effect at runtime.
 :::
 
 :::note


### PR DESCRIPTION
Medium tier of the docs deep review, group 3 of 4. 14 findings, 16 files.

**Stacked on #493.** Base retargets to `main` when that merges.

**Wrong minimum server version on two pages.** Both the Java and C# pages required Weaviate 1.33.0. The C# client's shipped library asserts a minimum of 1.32.0 (`WeaviateClient.cs`), and the Java client README says v1.32. Note the C# client's own README and `ci/start_weaviate.sh` say 1.31.0, contradicting its source constant, so that repo is the stale one.

**The Go page claimed Go 1.16**, roughly ten releases out of date. It now derives the requirement from the `go` directive for the client version the site actually pins, so it stays true as that pin moves rather than becoming the next stale number.

**Three names for one line.** The Java get-started prose said Ollama, the code called `text2vecTransformers()`, and the comment said Contextionary. The source now uses `text2vecOllama()`, matching the prose and the Python and TypeScript equivalents. That file is CI-executed; the lane already starts Ollama and pulls `nomic-embed-text`, and a sibling snippet makes the same call, so no new service is needed.

**A claim the repo contradicts.** Concepts said the client libraries in all languages support all API functions, while this repo states elsewhere that the Go client does not support server-side batch imports. It now says coverage varies by language and points at the client pages, rather than enumerating gaps that would go stale. Similarly the vector index list omitted two index types and now links to the indexing page instead of enumerating.

Also: the Java async client reference pointed at the retired pre-v6 class and package; a shell env assignment used a hyphen instead of `=` twice, so Docker silently set a differently-named empty variable; a table row shipped a `tbd` placeholder and another had the wrong modality; a flat-index link pointed at the inverted-index page; and the compression table said RQ was HNSW-only, which core contradicts.

Verified: `yarn build-dev` exit 0; broken links and anchors identical to the base; `mvn -o test-compile` clean against the client version CI builds.