### PR TITLE
docs(model-providers): fix structure, model lists, and a wrong published token limit

### DIFF
--- a/_includes/wcs/restart-warning.mdx
+++ b/_includes/wcs/restart-warning.mdx
@@ -1,1 +1,0 @@
-This action restarts the cluster. If you have a stand-alone cluster, there is a short downtime while the cluster restarts. There is no downtime if you have a high availability cluster.

--- a/_includes/weaviate-embeddings-multimodal-models.mdx
+++ b/_includes/weaviate-embeddings-multimodal-models.mdx
@@ -4,7 +4,7 @@
 - Generates multi-vector embeddings (ColBERT-style late-interaction) from document images and text queries.
 - Ideal for getting documents directly into Weaviate without heavy preprocessing - no OCR or text extraction required.
 - State-of-the-art performance in its size class, matching models up to 10x larger.
-- Query token limit: 8,092 tokens
+- Query token limit: 8,192 tokens
 - Read more at the [Hugging Face model card](https://huggingface.co/ModernVBERT/colmodernvbert)
 - For integration details, see [Weaviate Embeddings: Multimodal](/weaviate/model-providers/weaviate/embeddings-multimodal)
 

--- a/docs/cloud/manage-clusters/authentication.mdx
+++ b/docs/cloud/manage-clusters/authentication.mdx
@@ -5,11 +5,6 @@ description: "Configure authentication options for Weaviate Cloud clusters by ad
 image: og/wcd/user_guides.jpg
 ---
 
-import WCDAPIKeys from "/docs/cloud/img/wcs-api-keys.jpg";
-import WCDAddAPIKeys from "/docs/cloud/img/wcs-add-key-details.jpg";
-import WCDDelAPIKeys from "/docs/cloud/img/wcs-delete-api-key.jpg";
-import RestartTheCluster from "/_includes/wcs/restart-warning.mdx";
-
 [Weaviate Cloud (WCD)](/go/console?utm_content=cloud) uses [RBAC (Role-Based Access Control)](/weaviate/configuration/rbac/index.mdx) to manage authentication. Below, you can find guides on how to create, edit, rotate and delete API keys for accessing Weaviate Cloud.
 
 ### Create an API key

--- a/docs/weaviate/client-libraries/_includes/feedback.mdx
+++ b/docs/weaviate/client-libraries/_includes/feedback.mdx
@@ -1,7 +1,0 @@
-:::note Questions
-Please answer in relation to this section of the API.
-
-- Any specific features that you liked or disliked?
-- Did you encounter any errors or difficulties? If yes, what were they?
-- Any other notes or suggestions for improvement?
-:::

--- a/docs/weaviate/model-providers/aws/generative.md
+++ b/docs/weaviate/model-providers/aws/generative.md
@@ -147,7 +147,7 @@ For SageMaker, you must provide the endpoint address in the generative AI config
 
 </Tabs>
 
-You can [specify](#generative-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+You can [specify](#generative-parameters) which [model](#available-models) Weaviate uses.
 
 ### Generative parameters
 
@@ -272,31 +272,11 @@ You can also supply images as a part of the input when performing retrieval augm
 
 #### Bedrock
 
-- `ai21.j2-ultra-v1`
-- `ai21.j2-mid-v1`
-- `amazon.titan-text-lite-v1`
-- `amazon.titan-text-express-v1`
-- `amazon.titan-text-premier-v1:0`
-- `anthropic.claude-v2`
-- `anthropic.claude-v2:1`
-- `anthropic.claude-instant-v1`
-- `anthropic.claude-3-sonnet-20240229-v1:0`
-- `anthropic.claude-3-haiku-20240307-v1:0`
-- `cohere.command-text-v14`
-- `cohere.command-light-text-v14`
-- `cohere.command-r-v1:0`
-- `cohere.command-r-plus-v1:0`
-- `meta.llama3-8b-instruct-v1:0`
-- `meta.llama3-70b-instruct-v1:0`
-- `meta.llama2-13b-chat-v1`
-- `meta.llama2-70b-chat-v1`
-- `mistral.mistral-7b-instruct-v0:2`
-- `mistral.mixtral-8x7b-instruct-v0:1`
-- `mistral.mistral-large-2402-v1:0`
+Weaviate passes the `model` value through to Amazon Bedrock, so any Bedrock text generation model that your AWS account and region has access to can be used. Weaviate recognizes the model families offered by AI21 Labs, Amazon (Titan and Nova), Anthropic, Cohere, Meta, and Mistral AI, including their cross-region inference profile IDs.
 
-Refer to the [this document](https://docs.aws.amazon.com/bedrock/latest/userguide/model-usage.html) to find out how request access to a model.
+For the current model IDs, see the [Amazon Bedrock supported foundation models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html) documentation. Refer to [this document](https://docs.aws.amazon.com/bedrock/latest/userguide/model-usage.html) to find out how to request access to a model.
 
-### SageMaker
+#### SageMaker
 
 Any custom SageMaker URL can be used as an endpoint.
 

--- a/docs/weaviate/model-providers/google/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/google/embeddings-multimodal.md
@@ -144,9 +144,7 @@ import ApiKeyNote from '../_includes/google-api-key-note.md';
 
 </Tabs>
 
-You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for the vectorizer to use.
-
-<!-- The default model (`textembedding-gecko@001` for Vertex AI, `embedding-001` for Gemini API) is used if no model is specified. -->
+You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for the vectorizer to use. The [default model](#available-models) is used if no model is specified.
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
@@ -327,7 +325,7 @@ The query below returns the `n` most similar objects to the input image from the
 ### Available models
 
 - `gemini-embedding-2` (Vertex AI and Gemini API, added in 1.36.13). Supports text, images, PDFs, and audio (Gemini API only, up to 180 seconds); `3072` dimensions
-- `multimodalembedding@001` (Vertex AI only). Supports text, images, and video; dimensions: `128`, `256`, `512`, `1408`
+- `multimodalembedding@001` (default, Vertex AI only). Supports text, images, and video; dimensions: `128`, `256`, `512`, `1408`
 
 ## Further resources
 

--- a/docs/weaviate/model-providers/index.md
+++ b/docs/weaviate/model-providers/index.md
@@ -40,7 +40,11 @@ This enables an enhanced developed experience, such as the ability to:
 
 #### Enable all API-based modules
 
-All API-based model integrations are available by default starting with Weaviate `v1.33`. For older versions, you can enable them all by setting the [`ENABLE_API_BASED_MODULES` environment variable](/deploy/configuration/env-vars#ENABLE_API_BASED_MODULES) to `true`.
+All API-based model integrations are available by default starting with Weaviate `v1.33`.
+
+To opt out, for example in an air-gapped or otherwise restricted deployment, set the [`API_BASED_MODULES_DISABLED` environment variable](/deploy/configuration/env-vars#API_BASED_MODULES_DISABLED) to `true`. Weaviate then loads only the modules that you list in [`ENABLE_MODULES`](/deploy/configuration/env-vars#ENABLE_MODULES). This variable was added in `v1.33`.
+
+For releases before `v1.33`, enable all API-based modules by setting the [`ENABLE_API_BASED_MODULES` environment variable](/deploy/configuration/env-vars#ENABLE_API_BASED_MODULES) to `true`. Weaviate stopped reading that variable in `v1.33`.
 
 ### Locally hosted
 

--- a/docs/weaviate/model-providers/jinaai/embeddings-colbert.md
+++ b/docs/weaviate/model-providers/jinaai/embeddings-colbert.md
@@ -328,7 +328,7 @@ The query below returns the `n` best scoring objects from the database, set by `
 
 ### Available models
 
-- `jina-colbert-v2`
+- `jina-colbert-v2` (server default)
     - By default, Weaviate uses `128` dimensions
 - `jina-colbert-v1`
 

--- a/docs/weaviate/model-providers/jinaai/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/jinaai/embeddings-multimodal.md
@@ -125,7 +125,7 @@ You can specify one of the [available models](#available-models) for the vectori
 
 </Tabs>
 
-You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+The [default model](#available-models) is used if you do not specify one.
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
@@ -139,6 +139,10 @@ import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 ### Vectorizer parameters
 
 The following examples show how to configure Jina AI-specific options.
+
+- `model`: The model name.
+- `dimensions`: The number of dimensions for the model.
+  - Note that [not all models](#available-models) support this parameter.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -160,12 +164,6 @@ The following examples show how to configure Jina AI-specific options.
   </TabItem>
 
 </Tabs>
-
-### Vectorizer parameters
-
-- `model`: The model name.
-- `dimensions`: The number of dimensions for the model.
-  - Note that [not all models](#available-models) support this parameter.
 
 ## Data import
 
@@ -297,7 +295,7 @@ The query below returns the `n` most similar objects to the input image from the
 
 ### Available models
 
-- `jina-clip-v2`
+- `jina-clip-v2` (server default)
     - This model is a multilingual, multimodal model using [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147).
     - It will accept a `dimensions` parameter, which can be any integer between (and including) 64 and 1024. The default value is 1024.
 - `jina-clip-v1`

--- a/docs/weaviate/model-providers/jinaai/index.md
+++ b/docs/weaviate/model-providers/jinaai/index.md
@@ -25,6 +25,16 @@ Jina AI's embedding models transform text data into vector embeddings, capturing
 [Jina AI ColBERT embedding integration page](./embeddings-colbert.md)
 [Jina AI multimodal embedding integration page](./embeddings-multimodal.md)
 
+### Reranker models
+
+![Reranker integration illustration](../_includes/integration_jinaai_reranker.png)
+
+Jina AI's reranker models are designed to improve the relevance and ranking of search results.
+
+[The Weaviate reranker integration](./reranker.md) allows users to easily refine their search results by leveraging Jina AI's reranker models.
+
+[Jina AI reranker integration page](./reranker.md)
+
 ## Summary
 
 These integrations enable developers to leverage Jina AI's powerful models directly within Weaviate.
@@ -40,7 +50,7 @@ Then, go to the relevant integration page to learn how to configure Weaviate wit
 - [Text Embeddings](./embeddings.md)
 - [ColBERT embeddings](./embeddings-colbert.md)
 - [Multimodal embeddings](./embeddings-multimodal.md)
-- [Rerankers](./reranker.md)
+- [Reranker](./reranker.md)
 
 ## Questions and feedback
 

--- a/docs/weaviate/model-providers/jinaai/reranker.md
+++ b/docs/weaviate/model-providers/jinaai/reranker.md
@@ -167,7 +167,7 @@ Any search in Weaviate can be combined with a reranker to perform reranking oper
 
 ### Available models
 
-- `jina-reranker-v2-base-multilingual` (default)
+- `jina-reranker-v2-base-multilingual` (server default)
 - `jina-reranker-v1-base-en`
 - `jina-reranker-v1-turbo-en`
 - `jina-reranker-v1-tiny-en`

--- a/docs/weaviate/model-providers/transformers/index.md
+++ b/docs/weaviate/model-providers/transformers/index.md
@@ -25,6 +25,16 @@ Transformers-compatible embedding models transform text data into vector embeddi
 
 [Hugging Face Transformers embedding integration page](./embeddings.md)
 
+### Reranker models
+
+![Reranker integration illustration](../_includes/integration_transformers_reranker.png)
+
+Transformers-compatible reranker models are designed to improve the relevance and ranking of search results.
+
+[The Weaviate reranker integration](./reranker.md) allows users to easily refine their search results with a locally hosted Hugging Face Transformers reranker model.
+
+[Hugging Face Transformers reranker integration page](./reranker.md)
+
 ## Summary
 
 These integrations enable developers to leverage powerful Hugging Face Transformers models from directly within Weaviate.
@@ -41,6 +51,7 @@ Go to the relevant integration page to learn how to configure Weaviate with the 
 - [Text Embeddings (custom image)](./embeddings-custom-image.md)
 - [Multimodal Embeddings](./embeddings-multimodal.md)
 - [Multimodal Embeddings (custom image)](./embeddings-multimodal-custom-image.md)
+- [Reranker](./reranker.md)
 
 ## Questions and feedback
 


### PR DESCRIPTION
Low tier of the docs deep review, 1 of 7. 7 findings, 11 files.

**Stacked on the review integration branch**, which carries #493 and #494-#497. Retargets to `main` as that stack merges.

A **wrong published spec**: the ColModernVBERT query token limit read 8,092. The model's own `tokenizer_config.json` gives `model_max_length: 8192`. It renders on two pages through a shared include.

The **AWS Bedrock list** had 21 stale model IDs. Core detects families by substring, so newer models already work; the list is replaced by that explanation plus a pointer to AWS's live list, so it cannot rot again. A follow-on sentence that promised "one of the available models" and a default was corrected too, since the section no longer provides either.

Also: a duplicated `Vectorizer parameters` heading merged, default markers added to three lists that had none, a Reranker section added to two provider index pages whose reranker page existed but was unreachable, and the v1.33+ opt-out for API-based modules documented beside the older opt-in.

Verified: `yarn build-dev` exit 0; links and anchors at or better than baseline.