### PR TITLE
docs(model-providers): copy-editing across provider pages

### DIFF
--- a/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
@@ -295,7 +295,7 @@ The query below returns the `n` most similar objects to the input image from the
 ### Available models
 
 - `embed-v4.0`
-- `embed-multilingual-v3.0` (Default)
+- `embed-multilingual-v3.0` (server default)
 - `embed-multilingual-light-v3.0`
 - `embed-english-v3.0`
 - `embed-english-light-v3.0`

--- a/docs/weaviate/model-providers/cohere/embeddings.md
+++ b/docs/weaviate/model-providers/cohere/embeddings.md
@@ -356,7 +356,7 @@ The query below returns the `n` best scoring objects from the database, set by `
 ### Available models
 
 - `embed-v4.0`
-- `embed-multilingual-v3.0` (Default)
+- `embed-multilingual-v3.0` (server default)
 - `embed-multilingual-light-v3.0`
 - `embed-multilingual-v2.0` (previously `embed-multilingual-22-12`)
 - `embed-english-v3.0`
@@ -379,7 +379,7 @@ The following models are available, but deprecated:
 
 ### Other integrations
 
-- [Cohere multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [Cohere multimodal embedding models + Weaviate](./embeddings-multimodal.md)
 - [Cohere generative models + Weaviate](./generative.md)
 - [Cohere reranker models + Weaviate](./reranker.md)
 

--- a/docs/weaviate/model-providers/cohere/generative.md
+++ b/docs/weaviate/model-providers/cohere/generative.md
@@ -288,7 +288,7 @@ The following models are commonly used:
 ### Other integrations
 
 - [Cohere text embedding models + Weaviate](./embeddings.md).
-- [Cohere multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [Cohere multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 - [Cohere reranker models + Weaviate](./reranker.md).
 
 ### Code examples

--- a/docs/weaviate/model-providers/cohere/reranker.md
+++ b/docs/weaviate/model-providers/cohere/reranker.md
@@ -180,7 +180,7 @@ Any search in Weaviate can be combined with a reranker to perform reranking oper
 
 ### Available models
 
-- `rerank-v3.5` (default)
+- `rerank-v3.5` (server default)
 - `rerank-english-v3.0`
 - `rerank-multilingual-v3.0`
 - `rerank-english-v2.0`
@@ -199,7 +199,7 @@ For further details on model parameters, see the [Cohere API documentation](http
 ### Other integrations
 
 - [Cohere text embedding models + Weaviate](./embeddings.md).
-- [Cohere multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [Cohere multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 - [Cohere generative models + Weaviate](./generative.md).
 
 ### Code examples

--- a/docs/weaviate/model-providers/databricks/embeddings.md
+++ b/docs/weaviate/model-providers/databricks/embeddings.md
@@ -50,7 +50,7 @@ This integration is enabled by default on Weaviate Cloud (WCD) instances.
 
 You must provide a valid Databricks Personal Access Token (PAT) to Weaviate for this integration. Refer to the [Databricks documentation](https://docs.databricks.com/en/dev-tools/auth/pat.html) for instructions on generating your PAT in your workspace.
 
-Provide the Dataricks token to Weaviate using one of the following methods:
+Provide the Databricks token to Weaviate using one of the following methods:
 
 - Set the `DATABRICKS_TOKEN` environment variable that is available to Weaviate.
 - Provide the token at runtime, as shown in the examples below.
@@ -125,13 +125,13 @@ This will configure Weaviate to use the vectorizer served through the endpoint y
 ### Vectorizer parameters
 
 - `endpoint`: The URL of the embedding model hosted on Databricks.
-- `instruction`:An optional instruction to pass to the embedding model.
+- `instruction`: An optional instruction to pass to the embedding model.
 
 For further details on model parameters, see the [Databricks documentation](https://docs.databricks.com/en/machine-learning/foundation-models/api-reference.html#embedding-request).
 
 ## Header parameters
 
-You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+You can provide the token as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 
 - `X-Databricks-Token`: The Databricks API token.
 - `X-Databricks-Endpoint`: The endpoint to use for the Databricks model.

--- a/docs/weaviate/model-providers/databricks/generative.md
+++ b/docs/weaviate/model-providers/databricks/generative.md
@@ -48,10 +48,10 @@ This integration is enabled by default on Weaviate Cloud (WCD) instances.
 
 You must provide a valid Databricks Personal Access Token (PAT) to Weaviate for this integration. Refer to the [Databricks documentation](https://docs.databricks.com/en/dev-tools/auth/pat.html) for instructions on generating your PAT in your workspace.
 
-Provide the Dataricks token to Weaviate using one of the following methods:
+Provide the Databricks token to Weaviate using one of the following methods:
 
 - Set the `DATABRICKS_TOKEN` environment variable that is available to Weaviate.
-- Provide the API key at runtime, as shown in the examples below.
+- Provide the token at runtime, as shown in the examples below.
 
 <Tabs className="code" groupId="languages">
 
@@ -156,7 +156,7 @@ Aside from setting the default model provider when creating the collection, you 
 
 ## Header parameters
 
-You can provide the API key as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
+You can provide the token as well as some optional parameters at runtime through additional headers in the request. The following headers are available:
 
 - `X-Databricks-Token`: The Databricks API token.
 - `X-Databricks-Endpoint`: The endpoint to use for the Databricks model.

--- a/docs/weaviate/model-providers/google/index.md
+++ b/docs/weaviate/model-providers/google/index.md
@@ -22,6 +22,7 @@ Google's embedding models transform text data into vector embeddings, capturing 
 [Weaviate integrates with Google's embedding models](./embeddings.md) to enable seamless vectorization of data. This integration allows users to perform semantic and hybrid search operations without the need for additional preprocessing or data transformation steps.
 
 [Google embedding integration page](./embeddings.md)
+
 [Google multimodal embedding integration page](./embeddings-multimodal.md)
 
 ### Generative AI models for RAG
@@ -42,11 +43,11 @@ In turn, they simplify the process of building AI-driven applications to speed u
 
 ## Credentials
 
-You must provide a valid Googles API credentials to Weaviate for these integrations.
+You must provide valid Google API credentials to Weaviate for these integrations.
 
 ### Vertex AI
 
-##### Automatic token generation
+#### Automatic token generation
 
 import UseGoogleAuthInstructions from './_includes/use_google_auth_instructions.mdx';
 
@@ -54,7 +55,7 @@ import UseGoogleAuthInstructions from './_includes/use_google_auth_instructions.
 
 ## Get started
 
-Weaviate integrates with both [Google Gemini API](https://aistudio.google.com/app/apikey/?utm_source=weaviate&utm_medium=referral&utm_campaign=partnerships&utm_content=) or [Google Vertex AI](https://cloud.google.com/vertex-ai).
+Weaviate integrates with both the [Google Gemini API](https://aistudio.google.com/app/apikey/?utm_source=weaviate&utm_medium=referral&utm_campaign=partnerships&utm_content=) and [Google Vertex AI](https://cloud.google.com/vertex-ai).
 
 Go to the relevant integration page to learn how to configure Weaviate with the Google models and start using them in your applications.
 

--- a/docs/weaviate/model-providers/kubeai/index.md
+++ b/docs/weaviate/model-providers/kubeai/index.md
@@ -7,7 +7,7 @@ image: og/docs/integrations/provider_integrations_kubeai.jpg
 
 <!-- Note: for images, use https://docs.google.com/presentation/d/15opIcJuaIjEEcs_1Zm8B6pccox2p7_MHSjCnRv4dPfU/edit?usp=sharing -->
 
-[KubeAI](https://github.com/substratusai/kubeai) provides offers a wide range of models for natural language processing and generation through OpenAI-style API endpoints. Weaviate seamlessly integrates with KubeAI's APIs, allowing users to leverage any KubeAI models directly from the Weaviate Database.
+[KubeAI](https://github.com/substratusai/kubeai) offers a wide range of models for natural language processing and generation through OpenAI-style API endpoints. Weaviate seamlessly integrates with KubeAI's APIs, allowing users to leverage any KubeAI models directly from the Weaviate Database.
 
 These integrations empower developers to build sophisticated AI-driven applications with ease.
 

--- a/docs/weaviate/model-providers/nvidia/embeddings.md
+++ b/docs/weaviate/model-providers/nvidia/embeddings.md
@@ -342,7 +342,7 @@ The default model is `nvidia/nv-embed-v1`.
 
 ### Other integrations
 
-- [NVIDIA multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [NVIDIA multimodal embedding models + Weaviate](./embeddings-multimodal.md)
 - [NVIDIA generative models + Weaviate](./generative.md)
 - [NVIDIA reranker models + Weaviate](./reranker.md)
 

--- a/docs/weaviate/model-providers/nvidia/generative.md
+++ b/docs/weaviate/model-providers/nvidia/generative.md
@@ -260,7 +260,7 @@ The default model is `nvidia/llama-3.1-nemotron-51b-instruct`.
 ### Other integrations
 
 - [NVIDIA text embedding models + Weaviate](./embeddings.md).
-- [NVIDIA multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [NVIDIA multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 - [NVIDIA reranker models + Weaviate](./reranker.md).
 
 ### Code examples

--- a/docs/weaviate/model-providers/nvidia/reranker.md
+++ b/docs/weaviate/model-providers/nvidia/reranker.md
@@ -177,7 +177,7 @@ The default model is `nvidia/rerank-qa-mistral-4b`.
 ### Other integrations
 
 - [NVIDIA text embedding models + Weaviate](./embeddings.md).
-- [NVIDIA multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [NVIDIA multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 - [NVIDIA generative models + Weaviate](./generative.md).
 
 ### Code examples

--- a/docs/weaviate/model-providers/transformers/embeddings-custom-image.md
+++ b/docs/weaviate/model-providers/transformers/embeddings-custom-image.md
@@ -70,7 +70,7 @@ To build an image with a local, custom model, create a new `Dockerfile` similar 
 Save the `Dockerfile` as `my-inference-image.Dockerfile`. (You can name it anything you like.)
 <br/>
 
-This will creates a custom image for a model stored in a local folder `my-model` on your machine.
+This will create a custom image for a model stored in a local folder `my-model` on your machine.
 <br/>
 
 ```yaml

--- a/docs/weaviate/model-providers/transformers/embeddings-multimodal-custom-image.md
+++ b/docs/weaviate/model-providers/transformers/embeddings-multimodal-custom-image.md
@@ -61,7 +61,7 @@ RUN CLIP_MODEL_NAME=clip-ViT-B-32 TEXT_MODEL_NAME=clip-ViT-B-32 ./download.py
 </TabItem>
 <TabItem value="private" label="Private/local model">
 
-You can also build a custom image with any model that is compatible with the Transformer library's `SentenceTransformers` and `CLIPModel` classes. To ensure that text embeddings will output compatible vectors to image embeddings, you must only use models that have been specifically trained for use with CLIP models. (Note that a CLIP model is in reality two models: one for text and one for images.)
+You can also build a custom image with models compatible with the `SentenceTransformer` class from the Sentence Transformers library and the `CLIPModel` class from the Transformers library. To ensure that text embeddings will output compatible vectors to image embeddings, you must only use models that have been specifically trained for use with CLIP models. (Note that a CLIP model is in reality two models: one for text and one for images.)
 <br/>
 
 To build an image with a local, custom model, create a new `Dockerfile` similar to the following, replacing `./my-text-model` and `./my-clip-model` with the paths to your model folders.

--- a/docs/weaviate/model-providers/transformers/embeddings-multimodal-custom-image.md
+++ b/docs/weaviate/model-providers/transformers/embeddings-multimodal-custom-image.md
@@ -61,16 +61,16 @@ RUN CLIP_MODEL_NAME=clip-ViT-B-32 TEXT_MODEL_NAME=clip-ViT-B-32 ./download.py
 </TabItem>
 <TabItem value="private" label="Private/local model">
 
-You can also build a custom image with any model that is compatible with the Transformer library's `SentenceTransformers` and `ClIPModel` classes. To ensure that text embeddings will output compatible vectors to image embeddings, you must only use models that have been specifically trained for use with CLIP models. (Note that a CLIP model is in reality two models: one for text and one for images.)
+You can also build a custom image with any model that is compatible with the Transformer library's `SentenceTransformers` and `CLIPModel` classes. To ensure that text embeddings will output compatible vectors to image embeddings, you must only use models that have been specifically trained for use with CLIP models. (Note that a CLIP model is in reality two models: one for text and one for images.)
 <br/>
 
-To build an image with a local, custom model, create a new `Dockerfile` similar to the following, replacing `./my-test-model` and `./my-clip-model` with the path to your model folder.
+To build an image with a local, custom model, create a new `Dockerfile` similar to the following, replacing `./my-text-model` and `./my-clip-model` with the paths to your model folders.
 <br/>
 
 Save the `Dockerfile` as `my-inference-image.Dockerfile`. (You can name it anything you like.)
 <br/>
 
-This will creates a custom image for a model stored in a local folder `my-model` on your machine.
+This will create a custom image for the models stored in the local folders `my-text-model` and `my-clip-model` on your machine.
 <br/>
 
 ```yaml

--- a/docs/weaviate/model-providers/transformers/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/transformers/embeddings-multimodal.md
@@ -156,8 +156,8 @@ As this integration runs a local container with the CLIP model, no additional cr
 
 </Tabs>
 
-:::note Chose a container image to select a model
-To chose a model, select the [container image](#configure-the-integration) that hosts it.
+:::note Choose a container image to select a model
+To choose a model, select the [container image](#configure-the-integration) that hosts it.
 :::
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';

--- a/docs/weaviate/model-providers/transformers/embeddings.md
+++ b/docs/weaviate/model-providers/transformers/embeddings.md
@@ -159,8 +159,8 @@ As this integration runs a local container with the Transformers model, no addit
 
 </Tabs>
 
-:::note Chose a container image to select a model
-To chose a model, select the [container image](#configure-the-integration) that hosts it.
+:::note Choose a container image to select a model
+To choose a model, select the [container image](#configure-the-integration) that hosts it.
 :::
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';

--- a/docs/weaviate/model-providers/transformers/reranker.md
+++ b/docs/weaviate/model-providers/transformers/reranker.md
@@ -160,8 +160,8 @@ Configure a Weaviate collection to use a Transformer reranker model as follows:
 
 </Tabs>
 
-:::note Chose a container image to select a model
-To chose a model, select the [container image](#configure-the-integration) that hosts it.
+:::note Choose a container image to select a model
+To choose a model, select the [container image](#configure-the-integration) that hosts it.
 :::
 
 ## Reranking query

--- a/docs/weaviate/model-providers/voyageai/embeddings.md
+++ b/docs/weaviate/model-providers/voyageai/embeddings.md
@@ -387,7 +387,7 @@ The `voyage-context-3` model uses Voyage AI's [contextual embeddings API](https:
 
 ### Other integrations
 
-- [Voyage AI multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [Voyage AI multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 - [Voyage AI reranker models + Weaviate](./reranker.md).
 
 ### Code examples

--- a/docs/weaviate/model-providers/voyageai/reranker.md
+++ b/docs/weaviate/model-providers/voyageai/reranker.md
@@ -184,7 +184,7 @@ Any search in Weaviate can be combined with a reranker to perform reranking oper
 ### Other integrations
 
 - [Voyage AI embedding models + Weaviate](./embeddings.md).
-- [Voyage AI multimodal embedding embeddings models + Weaviate](./embeddings-multimodal.md)
+- [Voyage AI multimodal embedding models + Weaviate](./embeddings-multimodal.md).
 
 ### Code examples
 


### PR DESCRIPTION
Low tier, 2 of 7. 4 findings, 18 files.

A duplicated-word footer ("multimodal embedding embeddings models") appears in **eight** provider pages, not the two filed. Plus a duplicated verb, a repeated `Dataricks` typo, and `Chose` for `Choose` across three Transformers pages.

Beyond the brief: the **Databricks pages told readers to provide an API key** in several places. Databricks uses a personal access token, which those pages' own header tables already say. The multimodal custom-image page also told readers to replace a folder name the Dockerfile beside it does not use.

Verified: build exit 0.