### PR TITLE
docs: house-style sweep across reference and concepts pages

### DIFF
--- a/docs/deploy/configuration/backups.md
+++ b/docs/deploy/configuration/backups.md
@@ -29,7 +29,7 @@ Weaviate's Backup feature is designed to work natively with cloud technology. Mo
 :::caution Important backup considerations
 
 - **Version Requirements**: If you are running Weaviate `v1.23.12` or older, you must [update](/deploy/migration/index.md) to `v1.23.13` or higher before restoring a backup to prevent data corruption.
-- **[Multi-tenancy](/weaviate/concepts/data.md#multi-tenancy) limitations**: Starting in `v1.37`, backups include both `active` (HOT) and `inactive` (COLD) tenants — inactive tenants are backed up directly from disk without activation. `Offloaded` (FROZEN) tenants are still skipped since they have no local data. In versions prior to `v1.37`, only active tenants are included, so be sure to [activate](/weaviate/manage-collections/multi-tenancy.mdx#manage-tenant-states) any required tenants before creating a backup.
+- **[Multi-tenancy](/weaviate/concepts/data.md#multi-tenancy) limitations**: Starting in `v1.37`, backups include both `active` (HOT) and `inactive` (COLD) tenants. Inactive tenants are backed up directly from disk without activation. `Offloaded` (FROZEN) tenants are still skipped since they have no local data. In versions prior to `v1.37`, only active tenants are included, so be sure to [activate](/weaviate/manage-collections/multi-tenancy.mdx#manage-tenant-states) any required tenants before creating a backup.
 :::
 
 ## Backup Quickstart

--- a/docs/deploy/configuration/replication.md
+++ b/docs/deploy/configuration/replication.md
@@ -48,7 +48,7 @@ When Weaviate detects inconsistent data across nodes, it attempts to repair the 
 
 Weaviate offers [async replication](/weaviate/concepts/replication-architecture/consistency.md#async-replication) to proactively detect inconsistencies. In earlier versions, Weaviate uses a [repair-on-read](/weaviate/concepts/replication-architecture/consistency.md#repair-on-read) strategy to repair inconsistencies at read time.
 
-Repair-on-read is automatic. As of Weaviate `v1.38`, async replication is also **enabled by default** for any collection with a replication factor greater than `1` — there is no longer a per-collection flag to switch it on. To turn it off cluster-wide, set the [`ASYNC_REPLICATION_DISABLED`](/deploy/configuration/env-vars/index.md#async-replication) environment variable to `true`. The `replicationConfig` section is used to set the replication factor and to fine-tune async replication via `asyncConfig`:
+Repair-on-read is automatic. As of Weaviate `v1.38`, async replication is also **enabled by default** for any collection with a replication factor greater than `1`. There is no longer a per-collection flag to switch it on. To turn it off cluster-wide, set the [`ASYNC_REPLICATION_DISABLED`](/deploy/configuration/env-vars/index.md#async-replication) environment variable to `true`. The `replicationConfig` section is used to set the replication factor and to fine-tune async replication via `asyncConfig`:
 
 import ReplicationConfigWithAsyncRepair from '/\_includes/code/configuration/replication-consistency.mdx';
 

--- a/docs/weaviate/api/index.mdx
+++ b/docs/weaviate/api/index.mdx
@@ -32,7 +32,7 @@ Weaviate offers official client libraries for these programming languages:
 
 The client libraries abstract away the complexities of making direct REST, GraphQL, or gRPC calls. You interact with Weaviate using idiomatic methods and objects in your preferred language.
 
-Modern versions of the client libraries (e.g., Python v4+, TypeScript v3+) are designed to **automatically utilize the more performant gRPC interface** for search and query operations whenever possible and supported by the Weaviate instance you are connected to. They handle the negotiation and use the optimal protocol under the hood, typically requiring only the standard connection details (like the REST endpoint URL and authentication keys) for setup.
+Modern versions of the client libraries are designed to **automatically utilize the more performant gRPC interface** for search and query operations whenever possible and supported by the Weaviate instance you are connected to. They handle the negotiation and use the optimal protocol under the hood, typically requiring only the standard connection details (like the REST endpoint URL and authentication keys) for setup.
 
 :::
 

--- a/docs/weaviate/client-libraries/index.mdx
+++ b/docs/weaviate/client-libraries/index.mdx
@@ -15,13 +15,13 @@ export const clientLibrariesData = [
   {
     title: "Python Client",
     description:
-      "Install and use the official Python client (v4) to interact with Weaviate.",
+      "Install and use the official Python client to interact with Weaviate.",
     link: "/weaviate/client-libraries/python/",
     icon: "fab fa-python",
   },
   {
     title: "TypeScript / JavaScript Client",
-    description: "Use the official client (v3) with Node.js.",
+    description: "Use the official client with Node.js.",
     link: "/weaviate/client-libraries/typescript/",
     icon: "fab fa-js",
   },

--- a/docs/weaviate/concepts/indexing/inverted-index.md
+++ b/docs/weaviate/concepts/indexing/inverted-index.md
@@ -312,7 +312,7 @@ Beyond the built-in `en` and `none` presets, you can declare custom stopword pre
 
 #### Per-property stopword overrides
 
-Each text property can override the collection-level stopword behavior via `textAnalyzer.stopwordPreset`. This is useful for multilingual collections where different properties contain text in different languages. The override is only supported on properties with `tokenization: "word"` — schema validation rejects it on other tokenizers.
+Each text property can override the collection-level stopword behavior via `textAnalyzer.stopwordPreset`. This is useful for multilingual collections where different properties contain text in different languages. The override is only supported on properties with `tokenization: "word"`. Schema validation rejects it on other tokenizers.
 
 ```json
 "properties": [
@@ -331,7 +331,7 @@ Each text property can override the collection-level stopword behavior via `text
 ]
 ```
 
-Stopwords are still **indexed** — they are only filtered at query time. Changing the stopword configuration does **not** require reindexing your data.
+Stopwords are still **indexed**: they are only filtered at query time. Changing the stopword configuration does **not** require reindexing your data.
 
 See the [custom stopwords tutorial](../../tutorials/tokenization.md#example-5-custom-and-per-property-stopword-presets) for a worked example and the [stopwordPresets configuration reference](../../config-refs/indexing/inverted-index.mdx#stopwordpresets) for all options.
 

--- a/docs/weaviate/concepts/search/keyword-search.md
+++ b/docs/weaviate/concepts/search/keyword-search.md
@@ -47,7 +47,7 @@ Tokenization for keyword searches refers to how each source text is split up int
 
 The default tokenization method is `word`.
 
-Other tokenization methods such as `whitespace`, `lowercase`, and `field` are available, as well as specialized ones such as `GSE` or `kagome_kr` for other languages ([more details](../../config-refs/collections.mdx#tokenization)).
+Other tokenization methods such as `whitespace`, `lowercase`, and `field` are available, as well as specialized ones such as `gse` or `kagome_kr` for other languages ([more details](../../config-refs/collections.mdx#tokenization)).
 
 Set the tokenization option [in the inverted index configuration](../../search/bm25.md#set-tokenization) for a collection.
 
@@ -67,7 +67,7 @@ Weaviate uses configurable stopwords in calculating the BM25 score. Any tokens t
 
 See the [reference page](../../config-refs/indexing/inverted-index.mdx#stopwords) for more details.
 
-Stopword lists are also configurable per collection **and** per property. You can define custom presets on `invertedIndexConfig.stopwordPresets` and assign them to individual text properties via `textAnalyzer.stopwordPreset`. This is useful for multilingual collections — for example, English and French properties using different stopword lists. Stopwords are still indexed and only filtered at query time, so changing your stopword configuration does not require reindexing. See [Inverted index: Custom stopword presets](../indexing/inverted-index.md#custom-stopword-presets) for details.
+Stopword lists are also configurable per collection **and** per property. You can define custom presets on `invertedIndexConfig.stopwordPresets` and assign them to individual text properties via `textAnalyzer.stopwordPreset`. This is useful for multilingual collections. For example, English and French properties can use different stopword lists. Stopwords are still indexed and only filtered at query time, so changing your stopword configuration does not require reindexing. See [Inverted index: Custom stopword presets](../indexing/inverted-index.md#custom-stopword-presets) for details.
 
 ### BM25 parameters
 
@@ -142,7 +142,7 @@ Conceptually, it works as though a filter is applied to the results of the BM25 
 - `and`: All tokens must be present within a single searched property
 - `or`: At least one token must be present within a single searched property, with the minimum number of tokens being configurable (`minimumOrTokensMatch`)
 
-As an example, a BM25 query of `computer networking guide` with the `and` operator would only return objects where all of the tokens `computer`, `networking`, and `guide` appear together within a single searched property. If the tokens are spread across different properties — for example, `computer` in `title` and `networking` in `description` — the object does not match under `and`. In contrast, the same query with the `or` operator would return objects where at least one of those tokens appears in a searched property. If the `or` operator is used with a `minimumOrTokensMatch` of `2`, then at least two of the tokens must be present within a single searched property.
+As an example, a BM25 query of `computer networking guide` with the `and` operator would only return objects where all of the tokens `computer`, `networking`, and `guide` appear together within a single searched property. If the tokens are spread across different properties (for example, `computer` in `title` and `networking` in `description`), the object does not match under `and`. In contrast, the same query with the `or` operator would return objects where at least one of those tokens appears in a searched property. If the `or` operator is used with a `minimumOrTokensMatch` of `2`, then at least two of the tokens must be present within a single searched property.
 
 If not specified, the default operator is `or`, with a `minimumOrTokensMatch` of `1`. This means that at least one token must be present in a searched property for the object to be returned.
 
@@ -194,7 +194,7 @@ Here are some key considerations when using keyword search:
 
 1. **Tokenization Choice**
    - Choose based on your data and search requirements. For example, use `word` tokenization for natural language text, but consider `field` for URLs or email addresses that need exact matching as a whole.
-   - For multilingual content, consider specialized tokenizers like `GSE` for Chinese/Japanese or `kagome_kr` for Korean
+   - For multilingual content, consider specialized tokenizers like `gse` for Chinese/Japanese or `kagome_kr` for Korean
    - Consider special characters and case sensitivity needs
    - Test your tokenization choice with subsets of your data and queries to ensure it handles special characters and case sensitivity as expected. You could perform these experiments with vectorization disabled to save resources/costs, as the two processes are independent.
 

--- a/docs/weaviate/concepts/search/vector-search.md
+++ b/docs/weaviate/concepts/search/vector-search.md
@@ -262,9 +262,9 @@ Standard vector search returns the closest matches to a query, which often means
 - **Diversity**: how different is the item from the results already selected?
 
 The algorithm works iteratively. It selects the most relevant item first, then for each subsequent pick it scores candidates by weighing their query similarity against their maximum similarity to any already-selected result. The `balance` parameter (λ) controls the trade-off:
-- **λ = 0.0**: Pure diversity — maximizes difference from already-selected items
-- **λ = 0.5**: Balanced — each result must be both relevant and distinct
-- **λ = 1.0**: Pure relevance — equivalent to standard vector search
+- **λ = 0.0**: Pure diversity (maximizes difference from already-selected items)
+- **λ = 0.5**: Balanced (each result must be both relevant and distinct)
+- **λ = 1.0**: Pure relevance (equivalent to standard vector search)
 
 MMR is applied at query time as a reranking step on top of standard search. No reindexing is needed. The typical pattern is to retrieve a larger candidate set via regular vector search, then rerank a subset using MMR.
 

--- a/docs/weaviate/concepts/storage.md
+++ b/docs/weaviate/concepts/storage.md
@@ -79,9 +79,9 @@ This change improves reliability during rolling restarts and upgrades. Eager loa
 
 #### Vector cache prefill behavior
 
-The [`HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE`](/deploy/configuration/env-vars#hnsw_startup_wait_for_vector_cache) environment variable controls whether vector cache prefill is synchronous (blocking) or asynchronous (background) at startup. Its default changed to `true` in v1.36.6.
+The [`HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE`](/deploy/configuration/env-vars#HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE) environment variable controls whether vector cache prefill is synchronous (blocking) or asynchronous (background) at startup. Its default changed to `true` in v1.36.6.
 
-For collections where lazy shard loading is active, vector cache prefill is always **asynchronous** — the `HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE` value is overridden to `false` regardless of the configured value. For eagerly-loaded collections, the configured value applies (default: `true`, meaning synchronous prefill).
+For collections where lazy shard loading is active, vector cache prefill is always **asynchronous**: the `HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE` value is overridden to `false` regardless of the configured value. For eagerly-loaded collections, the configured value applies (default: `true`, meaning synchronous prefill).
 
 :::note Behavior change from v1.36.6
 Prior to v1.36.6, lazy shard loading was enabled by default for all collections. From v1.36.6 onward, shards are **eagerly loaded by default** until a multi-tenant collection crosses the count or size threshold. This may increase startup time for smaller deployments but provides better reliability during rollouts.

--- a/docs/weaviate/config-refs/datatypes.md
+++ b/docs/weaviate/config-refs/datatypes.md
@@ -536,7 +536,7 @@ For example, a `Person` collection could have an `address` property as an object
 
 :::note Indexing and filtering
 
-`object` and `object[]` properties are not vectorized: only their leaf scalars are stored in the inverted index. From Weaviate `v1.38` (preview), you can filter on nested-object leaves using a dotted path syntax. See [Filter on nested object properties](../search/filters.md#filter-on-nested-object-properties).
+`object` and `object[]` properties are not vectorized by default, and only their leaf scalars are stored in the inverted index. If you list an object property in the vector configuration's [`properties` field](indexing/vector-index.mdx#specify-which-properties-to-vectorize), it is converted to a string (its JSON representation) and concatenated into the vectorizer's input text. From Weaviate `v1.38` (preview), you can filter on nested-object leaves using a dotted path syntax. See [Filter on nested object properties](../search/filters.md#filter-on-nested-object-properties).
 
 :::
 

--- a/docs/weaviate/config-refs/datatypes.md
+++ b/docs/weaviate/config-refs/datatypes.md
@@ -526,7 +526,7 @@ The `blobHash` data type accepts base64-encoded data (same as [`blob`](#blob)) b
 }
 ```
 
-Use `blobHash` when you need a vectorizer to see the raw media at import time but don't need to retrieve the original bytes afterwards — only the hash is stored.
+Use `blobHash` when you need a vectorizer to see the raw media at import time but don't need to retrieve the original bytes afterwards: only the hash is stored.
 
 ## `object`
 
@@ -536,7 +536,7 @@ For example, a `Person` collection could have an `address` property as an object
 
 :::note Indexing and filtering
 
-`object` and `object[]` properties are not vectorized — only their leaf scalars are stored in the inverted index. From Weaviate `v1.38` (preview), you can filter on nested-object leaves using a dotted path syntax. See [Filter on nested object properties](../search/filters.md#filter-on-nested-object-properties).
+`object` and `object[]` properties are not vectorized: only their leaf scalars are stored in the inverted index. From Weaviate `v1.38` (preview), you can filter on nested-object leaves using a dotted path syntax. See [Filter on nested object properties](../search/filters.md#filter-on-nested-object-properties).
 
 :::
 

--- a/docs/weaviate/config-refs/indexing/inverted-index.mdx
+++ b/docs/weaviate/config-refs/indexing/inverted-index.mdx
@@ -191,19 +191,19 @@ A preset name that matches a built-in (`"en"`, `"none"`) fully replaces the buil
 
 </details>
 
-The existing [`stopwords`](#stopwords) configuration remains as the default for properties that do not specify a `textAnalyzer.stopwordPreset` override. For extending a built-in preset with `additions`/`removals`, use [`stopwords`](#stopwords) instead — it is the only stopword config that accepts that object form.
+The existing [`stopwords`](#stopwords) configuration remains as the default for properties that do not specify a `textAnalyzer.stopwordPreset` override. For extending a built-in preset with `additions`/`removals`, use [`stopwords`](#stopwords) instead. It is the only stopword config that accepts that object form.
 
 #### `textAnalyzer` {#textanalyzer}
 
 <TokenizerPreview />
 
-Part of a **property definition** (not `invertedIndexConfig`). Configures text analysis behavior for individual `text` properties. The accent-folding options (`asciiFold`, `asciiFoldIgnore`) are supported on properties with tokenization `word`, `lowercase`, `whitespace`, `field`, or `trigram` — not on the language-specific tokenizers (`gse`, `gse_ch`, `kagome_ja`, `kagome_kr`). The `stopwordPreset` option is only supported on properties with `tokenization: "word"`.
+Part of a **property definition** (not `invertedIndexConfig`). Configures text analysis behavior for individual `text` properties. The accent-folding options (`asciiFold`, `asciiFoldIgnore`) are supported on properties with tokenization `word`, `lowercase`, `whitespace`, `field`, or `trigram`. They are not supported on the language-specific tokenizers (`gse`, `gse_ch`, `kagome_ja`, and `kagome_kr`). The `stopwordPreset` option is only supported on properties with `tokenization: "word"`.
 
 | Parameter         | Type       | Default | Details                                                                                                                                                                                                                                  |
 | :---------------- | :--------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `asciiFold`       | `boolean`  | `false` | Normalizes accented Latin characters to ASCII equivalents during indexing and querying. Uses Unicode NFD decomposition. **Immutable** after the property is created.                                                                     |
 | `asciiFoldIgnore` | `string[]` | `[]`    | Characters exempt from ASCII folding. Each entry must be a single character. **Immutable** after the property is created.                                                                                                               |
-| `stopwordPreset`  | `string`   | (none)  | Name of a built-in (`en`, `none`) or collection-level stopword preset to use for this property, overriding the default `stopwords` config. **Only supported on properties with `tokenization: "word"`** — schema validation rejects it on other tokenizers. |
+| `stopwordPreset`  | `string`   | (none)  | Name of a built-in (`en`, `none`) or collection-level stopword preset to use for this property, overriding the default `stopwords` config. **Only supported on properties with `tokenization: "word"`**. Schema validation rejects it on other tokenizers. |
 
 <details>
   <summary>Example <code>textAnalyzer</code> configuration - JSON object</summary>
@@ -225,7 +225,7 @@ Part of a **property definition** (not `invertedIndexConfig`). Configures text a
 
 :::note
 
-`asciiFoldIgnore` changes which tokens are written to disk. It cannot be modified after the property is created — schema updates that change the ignore list are rejected. To change it, create a new property and reindex.
+`asciiFoldIgnore` changes which tokens are written to disk. It cannot be modified after the property is created. Schema updates that change the ignore list are rejected. To change it, create a new property and reindex.
 
 :::
 
@@ -253,7 +253,7 @@ Using these features requires more resources, as the additional inverted indexes
 
 ## Drop an inverted index
 
-You can drop (delete) an inverted index from a property. This is a destructive operation — the index data is removed from disk. To use the index again, it must be regenerated.
+You can drop (delete) an inverted index from a property. This is a destructive operation: the index data is removed from disk. To use the index again, it must be regenerated.
 
 The following index types can be dropped: `searchable`, `filterable`, `rangeFilters`.
 
@@ -306,7 +306,7 @@ Two REST endpoints let you test tokenization without modifying your schema.
 
 :::note
 
-`stopwords` and `stopwordPresets` are mutually exclusive — pass one or the other, not both. Use `stopwords` for a single preset optionally tweaked with additions/removals; use `stopwordPresets` to define named presets and select one via `analyzerConfig.stopwordPreset`.
+`stopwords` and `stopwordPresets` are mutually exclusive. Pass one or the other, not both. Use `stopwords` for a single preset optionally tweaked with additions/removals; use `stopwordPresets` to define named presets and select one via `analyzerConfig.stopwordPreset`.
 
 :::
 
@@ -386,7 +386,7 @@ curl -X POST http://localhost:8080/v1/tokenize -d '{
 
 ### Property-based tokenization
 
-`POST /v1/schema/{className}/properties/{propertyName}/tokenize` resolves the full analyzer config from an existing property. The property's tokenization method, `textAnalyzer` settings, and the collection's stopword configuration are applied automatically — nothing else needs to be passed.
+`POST /v1/schema/{className}/properties/{propertyName}/tokenize` resolves the full analyzer config from an existing property. The property's tokenization method, `textAnalyzer` settings, and the collection's stopword configuration are applied automatically. Nothing else needs to be passed.
 
 **Request body:**
 

--- a/docs/weaviate/config-refs/indexing/vector-index.mdx
+++ b/docs/weaviate/config-refs/indexing/vector-index.mdx
@@ -156,7 +156,7 @@ Using the `dynamic` index will initially create a flat index and once the number
 
 This is only a one-way switch that converts a flat index to a HNSW, the index does not support changing back to a flat index even if the object count goes below the threshold due to deletion.
 
-The goal of `dynamic` indexing is to shorten latencies during query time at the cost of a larger memory footprint. If your priority is the opposite — keeping memory low — consider the [HFresh index](#hfresh-index) instead.
+The goal of `dynamic` indexing is to shorten latencies during query time at the cost of a larger memory footprint. If your priority is the opposite (keeping memory low), consider the [HFresh index](#hfresh-index) instead.
 
 ### Dynamic index parameters
 
@@ -184,10 +184,10 @@ HFresh only supports `cosine` and `l2-squared` distance metrics. Dot product is 
 | Parameter          | Type    | Default  | Mutable | Details                                                                                                                                                                         |
 | :----------------- | :------ | :------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `distance`         | string  | `cosine` | No      | Distance metric. Only `cosine` and `l2-squared` are supported.                                                                                                                  |
-| `maxPostingSizeKB` | integer | `48`     | Yes     | Maximum size in KB for a posting list. Weaviate uses this value along with the vector dimensions to calculate the maximum number of vectors per posting. Min: `8`, Max: `1024`. Best set when you create the collection: an update is accepted but only affects newly-indexed data — data that is already indexed is not re-partitioned. |
+| `maxPostingSizeKB` | integer | `48`     | Yes     | Maximum size in KB for a posting list. Weaviate uses this value along with the vector dimensions to calculate the maximum number of vectors per posting. Min: `8`, Max: `1024`. Best set when you create the collection: an update is accepted but only affects newly-indexed data. Data that is already indexed is not re-partitioned. |
 | `replicas`         | integer | `4`      | No      | Number of posting lists in which a vector is added. Min: `1`, Max: `10`.                                                                                                        |
 | `searchProbe`      | integer | `256`    | Yes     | Number of posting lists to search during a query. The default is `256` in `v1.36.20`, `v1.37.10`, `v1.38.2` and later. Earlier releases on each of those lines default to `64`.                        |
-| `rq`               | object  | --       | Partial | Rotational quantization (RQ) compression configuration. RQ is mandatory for HFresh and cannot be turned off. Its `rescoreLimit` (default `350`) — the number of candidates rescored against uncompressed vectors — is mutable at runtime.                                                                                 |
+| `rq`               | object  | --       | Partial | Rotational quantization (RQ) compression configuration. RQ is mandatory for HFresh and cannot be turned off. Its `rescoreLimit` (default `350`), the number of candidates rescored against uncompressed vectors, is mutable at runtime.                                                                                 |
 
 :::tip Tuning HFresh recall
 Start with the defaults. If recall is too low, increase `searchProbe` (search more posting lists per query) or the RQ `rescoreLimit` (rescore more candidates with full-precision vectors). Both are mutable at runtime and take effect **without reindexing**.
@@ -245,7 +245,7 @@ For instance, text embedding integrations (e.g. `text2vec-cohere` for Cohere, or
 
 Unless specified otherwise in the collection definition, the default behavior is to:
 
-- Only vectorize properties with a string value — `text`, `text[]`, and `blob` (a base64-encoded string) — unless [skipped](../../manage-collections/vector-config.mdx#property-level-settings). Other data types (such as `number`, `int`, `boolean`, `date`, and `object`) are not vectorized unless they are listed in `source_properties` (see [below](#specify-which-properties-to-vectorize)).
+- Only vectorize properties with a string value (`text`, `text[]`, and `blob`, which is a base64-encoded string) unless [skipped](../../manage-collections/vector-config.mdx#property-level-settings). Other data types (such as `number`, `int`, `boolean`, `date`, and `object`) are not vectorized unless they are listed in `source_properties` (see [below](#specify-which-properties-to-vectorize)).
 - Sort properties in alphabetical (a-z) order before concatenating values
 - If `vectorizePropertyName` is `true` (`false` by default) prepend the property name to each property value
 - Join the (prepended) property values with spaces
@@ -277,10 +277,10 @@ To configure vectorization on a per-property basis, use `skip` and `vectorizePro
 
 To vectorize only a specific set of properties, set `source_properties` (the `properties` field of the vector configuration). Only the listed properties are then vectorized, in the order given.
 
-When `source_properties` is set, listed properties that are **not** text are also vectorized: `number`, `int`, `boolean`, `date`, `object`, and their array variants are converted to a string and concatenated into the input text. (Without `source_properties`, only string-valued properties — `text`, `text[]`, and `blob` — are vectorized; `uuid`, geo-coordinates, and phone-number properties are never vectorized.)
+When `source_properties` is set, listed properties that are **not** text are also vectorized: `number`, `int`, `boolean`, `date`, `object`, and their array variants are converted to a string and concatenated into the input text. (Without `source_properties`, only `text`, `text[]`, and `blob` properties are vectorized. `uuid`, geo-coordinates, and phone-number properties are never vectorized.)
 
 :::caution `blob` properties are vectorized as text
-A `blob` value is a base64-encoded string, so an indexed `blob` property is vectorized like text — even without `source_properties`. To avoid sending a blob's base64 data to a text vectorizer, exclude it with `source_properties` or [`skip`](../../manage-collections/vector-config.mdx#property-level-settings).
+A `blob` value is a base64-encoded string, so an indexed `blob` property is vectorized like text, even without `source_properties`. To avoid sending a blob's base64 data to a text vectorizer, exclude it with `source_properties` or [`skip`](../../manage-collections/vector-config.mdx#property-level-settings).
 :::
 
 ## Asynchronous indexing

--- a/docs/weaviate/connections/connect-custom.mdx
+++ b/docs/weaviate/connections/connect-custom.mdx
@@ -15,7 +15,7 @@ import TsCodeV3 from "!!raw-loader!/_includes/code/connections/connect-ts-v3.ts"
 import JavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/ConnectionTest.java";
 import CSharpCode from "!!raw-loader!/_includes/code/csharp/ConnectionTest.cs";
 
-The [Python Client v4](/weaviate/client-libraries/python) and the [TypeScript Client v3](../client-libraries/typescript/index.mdx) provide helper methods for common connection types. They also provide custom methods for when you need additional connection configuration.
+The [Python client](/weaviate/client-libraries/python) and the [TypeScript client](../client-libraries/typescript/index.mdx) provide helper methods for common connection types. They also provide custom methods for when you need additional connection configuration.
 
 If you are using one of the other clients, the standard connection methods are configurable for all connections.
 
@@ -121,11 +121,11 @@ import WCDOIDCWarning from "/_includes/wcd-oidc.mdx";
 
 The examples below assume you already have a bearer access token. Set the following environment variables before running them:
 
-- `WEAVIATE_HTTP_HOST` — host:port of the Weaviate REST endpoint (e.g., `localhost:8080`)
-- `WEAVIATE_GRPC_HOST` — host:port of the Weaviate gRPC endpoint (e.g., `localhost:50051`)
-- `WEAVIATE_OIDC_ACCESS_TOKEN` — the access token from your IdP
-- `WEAVIATE_OIDC_REFRESH_TOKEN` — *(optional)* refresh token for automatic renewal
-- `WEAVIATE_OIDC_EXPIRES_IN` — *(optional)* token lifetime in seconds
+- `WEAVIATE_HTTP_HOST`: host:port of the Weaviate REST endpoint (e.g., `localhost:8080`)
+- `WEAVIATE_GRPC_HOST`: host:port of the Weaviate gRPC endpoint (e.g., `localhost:50051`)
+- `WEAVIATE_OIDC_ACCESS_TOKEN`: the access token from your IdP
+- `WEAVIATE_OIDC_REFRESH_TOKEN`: *(optional)* refresh token for automatic renewal
+- `WEAVIATE_OIDC_EXPIRES_IN`: *(optional)* token lifetime in seconds
 
 import OIDCExamples from "/_includes/code/connections/oidc-connect.mdx";
 

--- a/docs/weaviate/connections/connect-query.mdx
+++ b/docs/weaviate/connections/connect-query.mdx
@@ -9,7 +9,7 @@ import WCDQueryConsoleLocation from "/docs/cloud/img/wcs-query-console-location.
 
 <CloudOnlyBadge />
 
-The fastest way to query data in [Weaviate Cloud (WCD)](/cloud) without writing code is the [Query Agent](/docs/cloud/tools/query-agent.mdx) — a natural-language interface that translates a prompt into a multi-step search against your collections and returns a grounded answer.
+The fastest way to query data in [Weaviate Cloud (WCD)](/cloud) without writing code is the [Query Agent](/docs/cloud/tools/query-agent.mdx), a natural-language interface that translates a prompt into a multi-step search against your collections and returns a grounded answer.
 
 If you'd rather write GraphQL by hand, the [Query tool](#query-tool) is still available further down on this page.
 
@@ -53,7 +53,7 @@ Beyond picking collections, you can also provide API keys for external model pro
 
 ### Generate client code
 
-After running a query in the console, you can copy a Python or TypeScript snippet that reproduces the same call through the [`weaviate-agents`](/query-agent/index.md) client libraries — useful for moving from exploration into application code.
+After running a query in the console, you can copy a Python or TypeScript snippet that reproduces the same call through the [`weaviate-agents`](/query-agent/index.md) client libraries. This makes it easy to move from exploration into application code.
 
 ### Limitations
 

--- a/docs/weaviate/manage-objects/create.mdx
+++ b/docs/weaviate/manage-objects/create.mdx
@@ -288,7 +288,7 @@ import CrossReferencePerformanceNote from "/_includes/cross-reference-performanc
 <CrossReferencePerformanceNote />
 
 import XrefPyCode from "!!raw-loader!/_includes/code/howto/manage-data.cross-refs.py";
-import XrefTSCode from "!!raw-loader!/_includes/code/howto/manage-data.cross-refs";
+import XrefTSCode from "!!raw-loader!/_includes/code/howto/manage-data.cross-refs.ts";
 import XrefJavaV6Code from "!!raw-loader!/_includes/code/java-v6/src/test/java/ManageCollectionsCrossReferencesTest.java";
 
 You can create an object with cross-references to other objects.

--- a/docs/weaviate/manage-objects/import.mdx
+++ b/docs/weaviate/manage-objects/import.mdx
@@ -15,7 +15,7 @@ import CSharpCode from '!!raw-loader!/_includes/code/csharp/ManageObjectsImportT
 import GoCode from '!!raw-loader!/_includes/code/howto/go/docs/manage-data.import_test.go';
 import SkipLink from '/src/components/SkipValidationLink'
 
-[Batch imports](../tutorials/import.mdx) are an efficient way to add multiple data objects and cross-references. For most use cases, we recommend **server-side batching** as the starting point: the server tells the client how much data to send next, so you don't have to tune batch parameters yourself. When you need manual control over the batch size and concurrency — or you are using a client that does not yet support server-side batching — use [manual batching](#manual-batching) instead.
+[Batch imports](../tutorials/import.mdx) are an efficient way to add multiple data objects and cross-references. For most use cases, we recommend **server-side batching** as the starting point: the server tells the client how much data to send next, so you don't have to tune batch parameters yourself. When you need manual control over the batch size and concurrency, or you are using a client that does not yet support server-side batching, use [manual batching](#manual-batching) instead.
 
 ## Server-side batching
 

--- a/docs/weaviate/manage-objects/read-all-objects.mdx
+++ b/docs/weaviate/manage-objects/read-all-objects.mdx
@@ -20,7 +20,7 @@ Weaviate provides the necessary APIs to iterate through all your data. This is u
 This is done with the help of the `after` operator, also called the [cursor API](../api/graphql/additional-operators.md#cursor-with-after).
 
 :::info Iterator
-The new API clients (currently supported by the Python Client v4), encapsulate this functionality as an `Iterator`.
+Some clients, such as the Python client, encapsulate this functionality as an `Iterator`.
 :::
 
 ## Read object properties and ids


### PR DESCRIPTION
Low tier, 3 of 7. 9 findings, 16 files.

**33 em dashes** replaced, each with the punctuation the sentence actually wants rather than a mechanical hyphen. Eight of these were never filed by the review, which is why a CI lint is tracked separately.

**Client library version numbers removed from prose** in five places. Where a version carried meaning the sentence was rewritten to say the same thing without a number that rots.

Two correctness items: the keyword-search page wrote the tokenizer as `GSE`, but the config value is lowercase `gse` and the uppercase form is a schema validation error; and an env-var anchor was miscased, which **fixes one of only two broken anchors in the whole build**.

Verified: build exit 0; broken anchors 2 to 1.