### PR TITLE
docs(tutorials): fix invalid JSON, a duplicate card icon, and em dashes

### DIFF
--- a/docs/weaviate/tutorials/index.mdx
+++ b/docs/weaviate/tutorials/index.mdx
@@ -21,7 +21,7 @@ export const advancedFeaturesData = [
     title: "Quick tour of Weaviate",
     description: (
       <>
-        End-to-end guide that cover important topics like configuring
+        End-to-end guide that covers important topics like configuring
         collections, compression, etc.
       </>
     ),
@@ -38,9 +38,9 @@ export const advancedFeaturesData = [
   {
     title: "Zero-downtime collection migration with aliases",
     description:
-      "Learn how to migrate Weaviate collections without service interruption using collections aliases.",
+      "Learn how to migrate Weaviate collections without service interruption using collection aliases.",
     link: "/weaviate/tutorials/collection-aliases",
-    icon: "fas fa-share	",
+    icon: "fas fa-share",
   },
   {
     title: "Import data in bulk",
@@ -82,7 +82,7 @@ export const advancedFeaturesData = [
     description:
       "Learn how to update the embedding model in order to improve performance.",
     link: "/weaviate/tutorials/vectorizer-migration",
-    icon: "fas fa-lock",
+    icon: "fas fa-right-left",
   },
 ];
 

--- a/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
+++ b/docs/weaviate/tutorials/quick-tour-of-weaviate.mdx
@@ -245,20 +245,18 @@ import QueryNearText from "/_includes/code/quickstart/quickstart.query.neartext.
 Run this code to perform the query. Our query found entries for `DNA` and `species`.
 
 <details>
-  <summary>Example full response in JSON format</summary>
+  <summary>Example response</summary>
 
 ```json
 {
-  {
-    "answer": "DNA",
-    "question": "In 1953 Watson & Crick built a model of the molecular structure of this, the gene-carrying substance",
-    "category": "SCIENCE"
-  },
-  {
-    "answer": "species",
-    "question": "2000 news: the Gunnison sage grouse isn't just another northern sage grouse, but a new one of this classification",
-    "category": "SCIENCE"
-  }
+  "answer": "DNA",
+  "question": "In 1953 Watson & Crick built a model of the molecular structure of this, the gene-carrying substance",
+  "category": "SCIENCE"
+}
+{
+  "answer": "species",
+  "question": "2000 news: the Gunnison sage grouse isn't just another northern sage grouse, but a new one of this classification",
+  "category": "SCIENCE"
 }
 ```
 

--- a/docs/weaviate/tutorials/rbac.mdx
+++ b/docs/weaviate/tutorials/rbac.mdx
@@ -15,7 +15,7 @@ import RolePyCode from '!!raw-loader!/_includes/code/python/howto.configure.rbac
 import UserPyCode from '!!raw-loader!/_includes/code/python/howto.configure.rbac.users.py';
 import RoleTSCode from '!!raw-loader!/_includes/code/typescript/howto.configure.rbac.roles.ts';
 
-**Role-Based Access Control (RBAC)** is a powerful security mechanism that allows you to manage who can access and modify your Weaviate instance. In this tutorial, you'll learn how to set up RBAC in Weaviate by defining roles with tailored permissions and assigning them to users. This enables granular control over operations—from reading and writing data to managing collections and tenants—ensuring that only authorized users can perform specific actions.
+**Role-Based Access Control (RBAC)** is a powerful security mechanism that allows you to manage who can access and modify your Weaviate instance. In this tutorial, you'll learn how to set up RBAC in Weaviate by defining roles with tailored permissions and assigning them to users. This enables granular control over operations, from reading and writing data to managing collections and tenants, ensuring that only authorized users can perform specific actions.
 
 In the steps that follow, we’ll cover:
 

--- a/docs/weaviate/tutorials/tls-ssl.mdx
+++ b/docs/weaviate/tutorials/tls-ssl.mdx
@@ -12,7 +12,7 @@ When your Weaviate database is exposed to the internet, unencrypted connections 
 - **Authentication credentials** if transmitted without encryption
 - **API keys and tokens** that could grant unauthorized access to your systems
 
-That's exactly why it's important to secure your database using **SSL/TLS (Secure Sockets Layer/Transport Layer Security)** — encryption protocols that create a secure, encrypted connection between your clients and your database. SSL/TLS ensures that even if network traffic is intercepted, the data remains unreadable to unauthorized parties.
+That's exactly why it's important to secure your database using **SSL/TLS (Secure Sockets Layer/Transport Layer Security)**, encryption protocols that create a secure, encrypted connection between your clients and your database. SSL/TLS ensures that even if network traffic is intercepted, the data remains unreadable to unauthorized parties.
 
 :::info Managed Weaviate deployments
 
@@ -20,7 +20,7 @@ If you're using **Weaviate Cloud** or other managed Weaviate services, SSL/TLS i
 
 :::
 
-This guide will take you through three different options for securing your self-hosted database. Whether you're a small startup or an enterprise giant - there's a solution for you!
+This guide will take you through three different options for securing your self-hosted database. Whether you're a small startup or an enterprise giant, there's a solution for you!
 
 ### When is SSL/TLS required?
 

--- a/docs/weaviate/tutorials/tokenization.md
+++ b/docs/weaviate/tutorials/tokenization.md
@@ -348,14 +348,14 @@ We create three properties: one without folding (`text_default`), one with full 
 **Key observations:**
 - Without folding, only exact accented forms match
 - With `asciiFold: true`, both accented and unaccented queries match
-- `asciiFoldIgnore` lets you preserve specific characters — `"cafe"` no longer matches `"Café"` when `é` is ignored
+- `asciiFoldIgnore` lets you preserve specific characters: `"cafe"` no longer matches `"Café"` when `é` is ignored
 - `asciiFoldIgnore` is immutable after property creation
 
 ## Example 5: Custom and per-property stopword presets
 
 <TokenizerPreview/>
 
-The default stopword presets are `en` and `none`. For a French property, neither is appropriate — `la`, `le`, and `et` should be filtered, but they are not in the English list. Define a custom preset on the collection and assign it to specific properties.
+The default stopword presets are `en` and `none`. For a French property, neither is appropriate: `la`, `le`, and `et` should be filtered, but they are not in the English list. Define a custom preset on the collection and assign it to specific properties.
 
 ### Create a collection with custom stopwords
 
@@ -483,7 +483,7 @@ The default stopword presets are `en` and `none`. For a French property, neither
 **Key observations:**
 - The `fr` preset filters out `la`, `le`, and `et` from BM25 scoring on the French property
 - The same words are not filtered on the English property (they are not English stopwords)
-- Stopwords are still indexed — only filtered at query time — so changing presets does not require reindexing
+- Stopwords are still indexed (they are only filtered at query time), so changing presets does not require reindexing
 - A preset name that matches a built-in (`en`, `none`) replaces the built-in for this collection. To tweak a built-in with `additions`/`removals`, use the collection-level `invertedIndexConfig.stopwords` field instead
 
 ## Example 6: Inspecting tokenization with the tokenize endpoint


### PR DESCRIPTION
Low tier, 4 of 7. 5 findings, 5 files.

An "Example full response" block was wrapped as `{ {...}, {...} }`, which is not valid JSON. The sample code prints each object separately, so an array would have shown output the code never produces. The block keeps the two objects and the label now matches, following the form the sibling quickstarts already use.

Also: a card reused the icon of the card directly above it (the replacement was checked against the bundled Font Awesome stylesheet, since these render as CSS classes), another carried a literal tab in its icon string, two typos on the landing page, and six em dashes.

Verified: every JSON block on the page parsed; build exit 0.