### PR TITLE
docs(modules,connections): fix Go tab rendering, a stale image tag, and unreachable pages

### DIFF
--- a/_includes/code/java-v6/src/test/java/ConnectionTest.java
+++ b/_includes/code/java-v6/src/test/java/ConnectionTest.java
@@ -151,7 +151,7 @@ class ConnectionTest {
     System.out.println(client.isReady()); // Should print: `True`
 
     client.close(); // Free up resources
-    // // END ConnectWithApiKeyExample
+    // END ConnectWithApiKeyExample
   }
 
   @Test

--- a/docs/weaviate/connections/connect-cloud.mdx
+++ b/docs/weaviate/connections/connect-cloud.mdx
@@ -83,7 +83,7 @@ import HostnameWarning from "/_includes/wcs/hostname-warning.mdx";
       text={GoCode}
       startMarker="// START APIKeyWCD"
       endMarker="// END APIKeyWCD"
-      language="py"
+      language="goraw"
     />
     <HostnameWarning />
   </TabItem>
@@ -139,7 +139,7 @@ If you use API-based models for vectorization or RAG, you must provide an API ke
       text={GoCode}
       startMarker="// START ThirdPartyAPIKeys"
       endMarker="// END ThirdPartyAPIKeys"
-      language="py"
+      language="goraw"
     />
   </TabItem>
   <TabItem value="java" label="Java">

--- a/docs/weaviate/modules/index.md
+++ b/docs/weaviate/modules/index.md
@@ -9,7 +9,7 @@ image: og/docs/modules/_title.jpg
 This section describes Weaviate's individual modules, including their capabilities and how to use them.
 
 :::tip Looking for vectorizer, generative AI, or reranker integration docs?
-They have moved to our [model provider integrations](../model-providers/index.md) section, for a more focussed, user-centric look at these integrations.
+They have moved to our [model provider integrations](../model-providers/index.md) section, for a more focused, user-centric look at these integrations.
 :::
 
 ## General
@@ -25,7 +25,7 @@ Weaviate modules can be divided into the following categories:
 - [Generative AI](#vectorizer-reranker-and-generative-ai-integrations): Integrate generative AI models for retrieval augmented generation (RAG).
 - [Backup](#backup-modules): Facilitate backup and restore operations in Weaviate.
 - [Offloading](#offloading-modules): Facilitate offloading of tenant data to external storage.
-- [Others]: Modules that provide additional functionalities.
+- [Others](#other-modules): Modules that provide additional functionalities.
 
 #### Vectorizer, reranker, and generative AI integrations
 
@@ -116,6 +116,15 @@ In addition to the above, there are other modules such as:
 - [text-spellcheck](./spellcheck.md): Spell checking capability for GraphQL queries.
 - [sum-transformers](./sum-transformers.md): Summarize text using transformer models.
 - [usage-modules](./usage-modules.md): Collect and upload usage analytics to GCS or S3 for the purposes of billing.
+- [custom-modules](./custom-modules.md): Attach your own machine learning model to Weaviate as a module.
+
+### Other vectorizer modules
+
+The following vectorizer modules are not covered by the [model provider integration](../model-providers/index.md) pages:
+
+- [text2vec-contextionary](./text2vec-contextionary.md) (deprecated): Vectorize text locally with the lightweight Contextionary model.
+- [img2vec-neural](./img2vec-neural.md): Vectorize images locally with a `resnet50` model.
+- [ref2vec-centroid](./ref2vec-centroid.md): Calculate an object's vector from the centroid of its referenced objects' vectors.
 
 ## Related pages
 

--- a/docs/weaviate/modules/ner-transformers.md
+++ b/docs/weaviate/modules/ner-transformers.md
@@ -57,7 +57,7 @@ services:
       EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
       NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
       ENABLE_COMPOUND_SPLITTING: 'false'
-    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.0.2
+    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.2.1
     ports:
     - 9999:9999
   ner-transformers:

--- a/docs/weaviate/modules/spellcheck.md
+++ b/docs/weaviate/modules/spellcheck.md
@@ -55,7 +55,7 @@ services:
       EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
       NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
       ENABLE_COMPOUND_SPLITTING: 'false'
-    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.0.2
+    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.2.1
     ports:
     - 9999:9999
   text-spellcheck:

--- a/docs/weaviate/modules/sum-transformers.md
+++ b/docs/weaviate/modules/sum-transformers.md
@@ -76,7 +76,7 @@ services:
       EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
       NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
       ENABLE_COMPOUND_SPLITTING: 'false'
-    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.0.2
+    image: cr.weaviate.io/semitechnologies/contextionary:en0.16.0-v1.2.1
     ports:
     - 9999:9999
   sum-transformers:


### PR DESCRIPTION
Low tier, 5 of 7. 4 findings, 6 files.

Two **Go tabs were tagged as Python**, so Go rendered with Python highlighting. They are now `goraw` rather than `go`. That is deliberate and differs from the sibling page: the `go` formatter strips two tabs from two-tab lines and one from one-tab lines, collapsing a full `package main` program to column 0, so copying the sibling would have traded a highlighting bug for an indentation bug. `goraw` preserves nesting and still highlights as Go.

Three module pages pinned a **contextionary image tag that appears in no live source** (`en0.16.0-v1.0.2`, found only in a 2023 blog post and stale build artifacts). The canonical tag, used by weaviate core's compose files and by docs CI, is `en0.16.0-v1.2.1`.

Four module pages existed in the sidebar but were **unreachable from the index body**, and one bullet pointed at an anchor that was never defined.

Verified: build exit 0; all 13 marker regions in the touched Java fixture render byte-identically.