### PR TITLE
docs: fix five review findings that were never dispatched

### DIFF
--- a/_includes/code/java-v6/src/test/java/QuickstartTest.java
+++ b/_includes/code/java-v6/src/test/java/QuickstartTest.java
@@ -5,6 +5,7 @@ import io.weaviate.client6.v1.api.collections.Property;
 import io.weaviate.client6.v1.api.collections.VectorConfig;
 import io.weaviate.client6.v1.api.collections.WeaviateObject;
 import io.weaviate.client6.v1.api.collections.batch.BatchContext;
+import io.weaviate.client6.v1.api.collections.generate.GenerativeProvider;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -170,31 +171,67 @@ class QuickstartTest {
     // END NearText
   }
 
-  // @Test
-  // void testRagQuery() {
-  // // Best practice: store your credentials in environment variables
-  // String weaviateUrl = System.getenv("WEAVIATE_URL");
-  // String weaviateApiKey = System.getenv("WEAVIATE_API_KEY");
+  @Test
+  void testRagQuery() throws Exception {
+    // Setup, not shown in the docs: build the `Question` collection this example
+    // queries, so the test does not depend on the order the other tests run in.
+    // The collection is deliberately left in place: `testCreateCollection` and
+    // `testImportDataWorkflow` both delete it before they recreate it.
+    WeaviateClient setupClient = WeaviateClient.connectToWeaviateCloud(
+        System.getenv("WEAVIATE_URL"),
+        System.getenv("WEAVIATE_API_KEY"));
+    String setupCollectionName = "Question";
+    if (setupClient.collections.exists(setupCollectionName)) {
+      setupClient.collections.delete(setupCollectionName);
+    }
+    setupClient.collections.create(setupCollectionName, col -> col
+        .properties(
+            Property.text("answer"),
+            Property.text("question"),
+            Property.text("category"))
+        .vectorConfig(VectorConfig.text2vecWeaviate()));
+    setupClient.collections.use(setupCollectionName).data.insertMany(
+        Map.of("answer", "DNA",
+            "question", "In 1953 Watson & Crick built a model of the molecular structure of this, the gene-carrying substance",
+            "category", "SCIENCE"),
+        Map.of("answer", "Liver",
+            "question", "This organ removes excess glucose from the blood & stores it as glycogen",
+            "category", "SCIENCE"));
+    Thread.sleep(3000); // Give the vectorizer time to index the new objects
+    setupClient.close();
 
-  // WeaviateClient client = WeaviateClient.connectToWeaviateCloud(
-  // weaviateUrl, // Replace with your Weaviate Cloud URL
-  // weaviateApiKey // Replace with your Weaviate Cloud key
-  // );
+    // START RAG
+    // Best practice: store your credentials in environment variables
+    String weaviateUrl = System.getenv("WEAVIATE_URL");
+    String weaviateApiKey = System.getenv("WEAVIATE_API_KEY");
+    String openaiApiKey = System.getenv("OPENAI_API_KEY");
 
-  // var questions = client.collections.use("Question");
+    // highlight-start
+    WeaviateClient client = WeaviateClient.connectToWeaviateCloud(
+        weaviateUrl, // Replace with your Weaviate Cloud URL
+        weaviateApiKey, // Replace with your Weaviate Cloud key
+        config -> config.setHeaders(
+            Map.of("X-OpenAI-Api-Key", openaiApiKey)) // Replace with your OpenAI API key
+    );
+    // highlight-end
 
-  // // highlight-start
-  // var response = questions.generate.nearText(
-  // q -> q
-  // .query("biology")
-  // .limit(2),
-  // g -> g.groupedTask("Write a tweet with emojis about these facts."));
-  // // highlight-end
+    CollectionHandle<Map<String, Object>> questions = client.collections.use("Question");
 
-  // System.out.println(response.generative().text()); // Inspect the generated
-  // text
-  // }
-  // START RAG
-  // Coming soon
-  // END RAG
+    // highlight-start
+    var response = questions.generate.nearText(
+        "biology",
+        // Query configuration (nearText and limit)
+        q -> q.limit(2),
+        // Generative configuration (the RAG task)
+        g -> g.groupedTask(
+            "Write a tweet with emojis about these facts.",
+            c -> c.generativeProvider(GenerativeProvider.openai(o -> o))));
+    // highlight-end
+
+    // Use `.generative()` to access the generated text
+    System.out.println(response.generative().text());
+
+    client.close(); // Free up resources
+    // END RAG
+  }
 }

--- a/docs/deploy/installation-guides/k8s-installation.md
+++ b/docs/deploy/installation-guides/k8s-installation.md
@@ -261,7 +261,7 @@ In some systems, the cluster hostname may change over time. This is known to cre
 
 ```yaml
 env:
-  - CLUSTER_HOSTNAME: "node-1"
+  CLUSTER_HOSTNAME: "node-1"
 ```
 
 ## Questions and feedback

--- a/docs/deploy/production/kubernetes/get-to-production.md
+++ b/docs/deploy/production/kubernetes/get-to-production.md
@@ -53,12 +53,12 @@ Check out the Academy course [“Run Weaviate on Kubernetes”](https://docs.wea
   <summary> An example of RBAC enabled on your Helm chart </summary>
 
 ```yaml
-  authorization:
+authorization:
   rbac:
     enabled: true
-     root_users:
-    - admin_user1
-    - admin_user2
+    root_users:
+      - admin_user1
+      - admin_user2
 ```
 
 </details>

--- a/docs/weaviate/starter-guides/generative.md
+++ b/docs/weaviate/starter-guides/generative.md
@@ -359,37 +359,48 @@ Check the specific documentation for your deployment method ([Docker](/deploy/in
 <details>
 <summary>How to configure the language model</summary>
 
-Model properties are exposed through the Weaviate module configuration. Accordingly, you can customize them through the `moduleConfig` parameter in the collection definition.
+Model parameters are exposed through the generative model provider configuration. You can set them when you create the collection, alongside the generative integration itself.
 
-For example, the `generative-cohere` module has the following properties:
+For example, the `generative-cohere` integration can be configured as follows:
 
-```json
-    "moduleConfig": {
-        "generative-cohere": {
-            "model": "command-xlarge-nightly",  // Optional - Defaults to `command-xlarge-nightly`. Can also use`command-xlarge-beta` and `command-xlarge`
-            "temperatureProperty": <temperature>,  // Optional
-            "maxTokensProperty": <maxTokens>,  // Optional
-            "kProperty": <k>, // Optional
-            "stopSequencesProperty": <stopSequences>, // Optional
-            "returnLikelihoodsProperty": <returnLikelihoods>, // Optional
-        }
-    }
+```python
+from weaviate.classes.config import Configure
+
+client.collections.create(
+    "DemoCollection",
+    generative_config=Configure.Generative.cohere(
+        # # These parameters are optional
+        # model="command-a-03-2025",
+        # temperature=0.7,
+        # max_tokens=500,
+        # k=5,
+        # stop_sequences=["\n\n"],
+    )
+    # Additional parameters not shown
+)
 ```
 
-And the `generative-openai` module may be configured as follows:
+And the `generative-openai` integration can be configured as follows:
 
-```json
-    "moduleConfig": {
-        "generative-openai": {
-            "model": "gpt-3.5-turbo",  // Optional - Defaults to `gpt-3.5-turbo`
-            "temperatureProperty": <temperature>,  // Optional, applicable to both OpenAI and Azure OpenAI
-            "maxTokensProperty": <max_tokens>,  // Optional, applicable to both OpenAI and Azure OpenAI
-            "frequencyPenaltyProperty": <frequency_penalty>,  // Optional, applicable to both OpenAI and Azure OpenAI
-            "presencePenaltyProperty": <presence_penalty>,  // Optional, applicable to both OpenAI and Azure OpenAI
-            "topPProperty": <top_p>,  // Optional, applicable to both OpenAI and Azure OpenAI
-        },
-    }
+```python
+from weaviate.classes.config import Configure
+
+client.collections.create(
+    "DemoCollection",
+    generative_config=Configure.Generative.openai(
+        # # These parameters are optional
+        # model="gpt-5-mini",
+        # temperature=0.7,
+        # max_tokens=500,
+        # frequency_penalty=0,
+        # presence_penalty=0,
+        # top_p=0.7,
+    )
+    # Additional parameters not shown
+)
 ```
+
+Each parameter is optional. If you do not set a parameter, Weaviate applies the server-defined default. For the available models, the default model and the full parameter list, see the model provider pages for [Cohere](../model-providers/cohere/generative.md) and [OpenAI](../model-providers/openai/generative.md).
 
 See the [documentation](../model-providers/index.md) for various model provider integrations.
 

--- a/docs/weaviate/starter-guides/managing-collections/index.mdx
+++ b/docs/weaviate/starter-guides/managing-collections/index.mdx
@@ -39,104 +39,162 @@ The returned configuration looks similar to this:
 
 ```json
 {
-  "classes": [
+  "class": "Question",
+  "invertedIndexConfig": {
+    "bm25": {
+      "b": 0.75,
+      "k1": 1.2
+    },
+    "cleanupIntervalSeconds": 60,
+    "stopwords": {
+      "additions": null,
+      "preset": "en",
+      "removals": null
+    },
+    "usingBlockMaxWAND": true
+  },
+  "moduleConfig": {
+    "generative-cohere": {}
+  },
+  "multiTenancyConfig": {
+    "autoTenantActivation": false,
+    "autoTenantCreation": false,
+    "enabled": false
+  },
+  "properties": [
     {
-      "class": "Question",
-      "description": "Information from a Jeopardy! question",
-      "invertedIndexConfig": {
-        "bm25": {
-          "b": 0.75,
-          "k1": 1.2
-        },
-        "cleanupIntervalSeconds": 60,
-        "stopwords": {
-          "additions": null,
-          "preset": "en",
-          "removals": null
-        }
-      },
+      "dataType": [
+        "text"
+      ],
+      "indexFilterable": true,
+      "indexRangeFilters": false,
+      "indexSearchable": true,
       "moduleConfig": {
         "text2vec-openai": {
-          "model": "ada",
-          "modelVersion": "002",
-          "type": "text",
-          "vectorizeClassName": true
+          "skip": false,
+          "vectorizePropertyName": false
         }
       },
-      "properties": [
-        {
-          "dataType": ["text"],
-          "description": "The question",
-          "moduleConfig": {
-            "text2vec-openai": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "question",
-          "tokenization": "word"
-        },
-        {
-          "dataType": ["text"],
-          "description": "The answer",
-          "moduleConfig": {
-            "text2vec-openai": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "answer",
-          "tokenization": "word"
-        },
-        {
-          "dataType": ["text"],
-          "description": "The category",
-          "moduleConfig": {
-            "text2vec-openai": {
-              "skip": false,
-              "vectorizePropertyName": false
-            }
-          },
-          "name": "category",
-          "tokenization": "word"
-        }
+      "name": "question",
+      "tokenization": "word"
+    },
+    {
+      "dataType": [
+        "text"
       ],
-      "replicationConfig": {
-        "factor": 1
+      "indexFilterable": true,
+      "indexRangeFilters": false,
+      "indexSearchable": true,
+      "moduleConfig": {
+        "text2vec-openai": {
+          "skip": false,
+          "vectorizePropertyName": false
+        }
       },
-      "shardingConfig": {
-        "virtualPerPhysical": 128,
-        "desiredCount": 1,
-        "actualCount": 1,
-        "desiredVirtualCount": 128,
-        "actualVirtualCount": 128,
-        "key": "_id",
-        "strategy": "hash",
-        "function": "murmur3"
+      "name": "answer",
+      "tokenization": "word"
+    },
+    {
+      "dataType": [
+        "text"
+      ],
+      "indexFilterable": true,
+      "indexRangeFilters": false,
+      "indexSearchable": true,
+      "moduleConfig": {
+        "text2vec-openai": {
+          "skip": false,
+          "vectorizePropertyName": false
+        }
       },
+      "name": "category",
+      "tokenization": "word"
+    }
+  ],
+  "shardingConfig": {
+    "actualCount": 1,
+    "actualVirtualCount": 128,
+    "desiredCount": 1,
+    "desiredVirtualCount": 128,
+    "function": "murmur3",
+    "key": "_id",
+    "strategy": "hash",
+    "virtualPerPhysical": 128
+  },
+  "vectorConfig": {
+    "default": {
       "vectorIndexConfig": {
-        "skip": false,
+        "bq": {
+          "enabled": false
+        },
         "cleanupIntervalSeconds": 300,
-        "maxConnections": 32,
-        "efConstruction": 128,
-        "ef": -1,
-        "dynamicEfMin": 100,
-        "dynamicEfMax": 500,
+        "distance": "cosine",
         "dynamicEfFactor": 8,
-        "vectorCacheMaxObjects": 1000000000000,
+        "dynamicEfMax": 500,
+        "dynamicEfMin": 100,
+        "ef": -1,
+        "efConstruction": 128,
+        "filterStrategy": "acorn",
         "flatSearchCutoff": 40000,
-        "distance": "cosine"
+        "maxConnections": 32,
+        "multivector": {
+          "aggregation": "maxSim",
+          "enabled": false,
+          "muvera": {
+            "dprojections": 16,
+            "enabled": false,
+            "ksim": 4,
+            "repetitions": 10
+          }
+        },
+        "pq": {
+          "bitCompression": false,
+          "centroids": 256,
+          "enabled": false,
+          "encoder": {
+            "distribution": "log-normal",
+            "type": "kmeans"
+          },
+          "segments": 0,
+          "trainingLimit": 100000
+        },
+        "rq": {
+          "bits": 8,
+          "enabled": false,
+          "rescoreLimit": 20
+        },
+        "skip": false,
+        "skipDefaultQuantization": false,
+        "sq": {
+          "enabled": false,
+          "rescoreLimit": 20,
+          "trainingLimit": 100000
+        },
+        "trackDefaultQuantization": false,
+        "vectorCacheMaxObjects": 1000000000000
       },
       "vectorIndexType": "hnsw",
-      "vectorizer": "text2vec-openai"
+      "vectorizer": {
+        "text2vec-openai": {
+          "baseURL": "https://api.openai.com",
+          "isAzure": false,
+          "model": "text-embedding-3-small",
+          "vectorizeClassName": true
+        }
+      }
     }
-  ]
+  },
+  "replicationConfig": {
+    "deletionStrategy": "TimeBasedResolution",
+    "factor": 1,
+    "asyncEnabled": false
+  }
 }
 ```
 
 </details>
 
-Although we only specified the collection name and properties, the returned definition includes much more information.
+Although we only specified the collection name, its properties, the vectorizer and the generative module, the returned definition includes much more information.
 
 This is because Weaviate infers the definition based on the data schema and default settings. Each of these options can be specified manually at collection creation time.
 


### PR DESCRIPTION
A verification pass over all 205 findings of the docs deep review found 23 still present in main. Most are tracked and waiting on a decision or another team. These five were not tracked at all: each was parked behind a blocker that has since cleared, then quietly fell out of scope.

**Two Helm examples that fail on paste.** The RBAC values block did not parse — PyYAML rejects it with `mapping values are not allowed here`, because `rbac:` sat as a sibling of `authorization:` and `root_users:` carried a stray indent. The `CLUSTER_HOSTNAME` example used list syntax where the chart ranges over a map (`{{- range $key, $value := $.Values.env }}`), so it parsed as a one-element list containing a map. Both corrected against the chart itself and verified with a parser before and after:

- `{'env': [{'CLUSTER_HOSTNAME': 'node-1'}]}` (list) → `{'env': {'CLUSTER_HOSTNAME': 'node-1'}}` (map)
- `ScannerError` → `{'authorization': {'rbac': {'enabled': True, 'root_users': [...]}}}`

**Two wrong defaults and six JSON keys that do not exist.** The generative starter guide claimed `command-xlarge-nightly` and `gpt-3.5-turbo` defaults; core has `command-a-03-2025` and `gpt-5-mini`. Its `temperatureProperty` / `maxTokensProperty` / etc. are Go *variable identifiers*, not wire keys, and `returnLikelihoods` has been removed from the module entirely. Rather than correct numbers that rot again, the legacy raw-JSON `moduleConfig` examples are replaced with the current `Configure.Generative` pattern, with defaults pointing at the model provider pages.

**A returned collection definition that no code produces.** The managing-collections guide showed the pre-v1.24 flat shape (top-level `vectorizer` / `vectorIndexConfig` / `vectorIndexType`, no `vectorConfig`), omitted the generative module the snippet configures, and carried invented `description` fields. It is now a real response captured from a running instance, with only the collection name changed. The descriptions are gone because the snippet never sets one and both `Class.Description` and `Property.Description` are `json:",omitempty"`.

**A "Coming soon" stub on a live page.** The Java tab of the quickstart RAG example rendered `// Coming soon` while Python, TypeScript, Go and C# rendered working code. It now has a real test, modelled on the CI-executed `LlmsTxtTest` and compiling against the client version CI builds.

Verified: `yarn build-dev` passes; broken links and anchors are byte-identical to a baseline build of `main`.

One residual: the new Java test compiles but was not executed against a cluster locally, so CI is the first real run of that path.