### PR TITLE
docs(model-providers): document how OpenAI request URLs are built

### DIFF
--- a/docs/weaviate/model-providers/openai/embeddings.md
+++ b/docs/weaviate/model-providers/openai/embeddings.md
@@ -217,6 +217,9 @@ import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 - `modelVersion`: The version string for the model.
 - `type`: The model type, either `text` or `code`.
 - `baseURL`: The URL to use (e.g. a proxy) instead of the default OpenAI URL.
+- `endpoint`: The API path that Weaviate appends to the base URL. Defaults to `/v1/embeddings`. Set it if an OpenAI-compatible service uses a different path.
+
+For how Weaviate combines `baseURL` and `endpoint` into a request URL, see [Header parameters](#header-parameters).
 
 #### (`model` & `dimensions`) or (`model` & `modelVersion`)
 
@@ -272,9 +275,13 @@ Any additional headers provided at runtime will override the existing Weaviate c
 
 Provide the headers as shown in the [API credentials examples](#api-credentials) above.
 
-:::note
+:::note How Weaviate builds the request URL
 
-By passing the `X-OpenAI-Baseurl`, you can use an endpoint compatible with the OpenAI API. Weaviate appends `/v1/embeddings` to this base URL. If this doesn't match your endpoint, you can rewrite the path with a proxy (e.g., `your.domain.com/v1/embeddings` -> `api.deepinfra.com/v1/openai/embeddings`).
+Use the `X-OpenAI-Baseurl` header, or the `baseURL` parameter, to target an OpenAI-compatible service. Weaviate builds the request URL by appending the `endpoint` path (`/v1/embeddings` by default) to the base URL.
+
+If your provider uses a different path, set [`endpoint`](#vectorizer-parameters) to that path, or rewrite the path with a proxy.
+
+The [Azure OpenAI integration](../openai-azure/embeddings.md) builds a deployment-specific path and ignores `endpoint`.
 
 :::
 

--- a/docs/weaviate/model-providers/openai/generative.md
+++ b/docs/weaviate/model-providers/openai/generative.md
@@ -207,6 +207,16 @@ Any additional headers provided at runtime will override the existing Weaviate c
 
 Provide the headers as shown in the [API credentials examples](#api-credentials) above.
 
+:::note How Weaviate builds the request URL
+
+Use the `X-OpenAI-Baseurl` header, or the `baseURL` parameter, to target an OpenAI-compatible service. Weaviate builds the request URL by appending `/v1/chat/completions` to the base URL, or `/v1/completions` for the legacy `text-davinci-002` and `text-davinci-003` models.
+
+The generative integration has no `endpoint` parameter to override this path, unlike the [OpenAI embeddings integration](./embeddings.md#header-parameters). If your provider expects a different path, point the base URL at a proxy that rewrites `/v1/chat/completions` to your provider's path.
+
+The [Azure OpenAI integration](../openai-azure/generative.md) builds a deployment-specific path and ignores the paths above.
+
+:::
+
 ## Retrieval augmented generation
 
 After configuring the generative AI integration, perform RAG operations, either with the [single prompt](#single-prompt) or [grouped task](#grouped-task) method.


### PR DESCRIPTION
The OpenAI embeddings page documented `baseURL` but not the `endpoint` parameter that sets the path Weaviate appends to it. The generative page listed the `X-OpenAI-Baseurl` header with no explanation of the path at all — and it appends a different one.

- **embeddings**: document the `endpoint` parameter (default `/v1/embeddings`) and how the request URL is composed; cross-link the parameter list and Header parameters
- **generative**: add the equivalent note, covering `/v1/chat/completions`, the legacy `/v1/completions` path, and the fact that this integration has no `endpoint` override
- **both**: note that the Azure integration builds a deployment-specific path
- drop the third-party gateway named in the old proxy example

Prose only — no snippets or includes touched. Paths verified against core (`modules/text2vec-openai`, `modules/generative-openai`).