### PR TITLE
chore+docs: uv.lock for 4.23.0, and_cross sweep, and the v1-39 OpenAPI pin

### DIFF
--- a/docs/weaviate/concepts/search/hybrid-search.md
+++ b/docs/weaviate/concepts/search/hybrid-search.md
@@ -191,7 +191,7 @@ This is because BM25 scores are not normalized or bounded like vector distances,
 
 ## Keyword (BM25) search parameters
 
-Hybrid search in Weaviate supports all the parameters available for keyword (BM25) search. This includes, for example, the ability to set the tokenization method, stopwords, BM25 parameters (k1, b), search operators (`and` or `or`), specific properties to search and/or to boost particular properties.
+Hybrid search in Weaviate supports all the parameters available for keyword (BM25) search. This includes, for example, the ability to set the tokenization method, stopwords, BM25 parameters (k1, b), [search operators](./keyword-search.md#keyword-search-operators) (`and`, `or`, or `and_cross`), specific properties to search and/or to boost particular properties.
 
 For more information on these parameters, see the [keyword search page](./keyword-search.md).
 

--- a/docs/weaviate/concepts/search/keyword-search.md
+++ b/docs/weaviate/concepts/search/keyword-search.md
@@ -136,13 +136,14 @@ import SearchOperators from '/_includes/feature-notes/search-operators.mdx';
 
 <SearchOperators/>
 
-Search operators define the minimum number of query [tokens](../../search/bm25.md#set-tokenization) that must be present within a single searched property for an object to be returned.
+Search operators define how many of the query [tokens](../../search/bm25.md#set-tokenization) must match, and whether they must all match within a single searched property.
 
 Conceptually, it works as though a filter is applied to the results of the BM25 score calculation. The available operators are:
 - `and`: All tokens must be present within a single searched property
 - `or`: At least one token must be present within a single searched property, with the minimum number of tokens being configurable (`minimumOrTokensMatch`)
+- `and_cross`: Every token must be matched by at least one of the searched properties, so the tokens can be spread across different properties. All searched properties must share the same tokenization and analyzer settings, otherwise the query fails with an error. (available from `v1.38.8`)
 
-As an example, a BM25 query of `computer networking guide` with the `and` operator would only return objects where all of the tokens `computer`, `networking`, and `guide` appear together within a single searched property. If the tokens are spread across different properties (for example, `computer` in `title` and `networking` in `description`), the object does not match under `and`. In contrast, the same query with the `or` operator would return objects where at least one of those tokens appears in a searched property. If the `or` operator is used with a `minimumOrTokensMatch` of `2`, then at least two of the tokens must be present within a single searched property.
+As an example, a BM25 query of `computer networking guide` with the `and` operator would only return objects where all of the tokens `computer`, `networking`, and `guide` appear together within a single searched property. If the tokens are spread across different properties (for example, `computer` in `title` and `networking guide` in `description`), the object does not match under `and`. That restriction is specific to `and`; the same object does match under `and_cross`, which requires each token to appear in at least one of the searched properties rather than all of them in the same one. In contrast, the same query with the `or` operator would return objects where at least one of those tokens appears in a searched property. If the `or` operator is used with a `minimumOrTokensMatch` of `2`, then at least two of the tokens must be present within a single searched property.
 
 If not specified, the default operator is `or`, with a `minimumOrTokensMatch` of `1`. This means that at least one token must be present in a searched property for the object to be returned.
 

--- a/docs/weaviate/search/hybrid.md
+++ b/docs/weaviate/search/hybrid.md
@@ -387,7 +387,7 @@ import SearchOperators from '/_includes/feature-notes/search-operators.mdx';
 
 <SearchOperators/>
 
-Keyword (BM25) search operators define how many of the query [tokens](#tokenization) must match, and whether they must all match within a single searched property. The options are `or` (default), `and`, and `and_cross`.
+Keyword (BM25) search operators define how many of the query [tokens](#tokenization) must match, and whether they must all match within a single searched property. The options are `or` (default), `and`, and `and_cross` (available from `v1.38.8`).
 
 The keyword leg of a hybrid query accepts the same operators as a standalone keyword search. For `and_cross`, which matches every token across the searched properties combined, see [BM25 search: `and_cross`](./bm25.md#and_cross).
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,7 +64,7 @@ const config = {
         cdn: "https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.49.0",
         configuration: {
           spec: {
-            url: "https://raw.githubusercontent.com/weaviate/weaviate/v1-38/openapi-for-docs/openapi-specs/schema.json",
+            url: "https://raw.githubusercontent.com/weaviate/weaviate/v1-39/openapi-for-docs/openapi-specs/schema.json",
           },
           hideModels: true,
           showSidebar: true,

--- a/uv.lock
+++ b/uv.lock
@@ -1840,7 +1840,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-client"
-version = "4.22.0"
+version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1851,9 +1851,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "validators" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/2a/73cf7d6c7c6aa638738dfcb0d318e0404aab3c0673f82a1a4d89455b21a5/weaviate_client-4.22.0.tar.gz", hash = "sha256:0c50fbef546a522262a87d1138cde0509c7a8a48e702e967be33472e9f7fbae3", size = 860126, upload-time = "2026-06-18T06:08:30.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/9f/8bfe42e3c0693afa321fb712c0a1f1ff2b886059db33543120f6953dde8e/weaviate_client-4.23.0.tar.gz", hash = "sha256:19cc336b4c9e58f06cf01cb9aff8f6d8c0fe747f2e80192a9871c63823e8b18d", size = 873028, upload-time = "2026-08-13T14:23:08.112Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/a3/27353ea3fbf9e7d4f03375176a838c632d009f5167d801adcbb5f6d3bd07/weaviate_client-4.22.0-py3-none-any.whl", hash = "sha256:ff2dbc8d1fc25739942402c22d1aba2350a16ba4a6b6ed0ba140689c70adf1d9", size = 652691, upload-time = "2026-06-18T06:08:28.622Z" },
+    { url = "https://files.pythonhosted.org/packages/15/aa/8cafeb1c09901e8d220b00b771ffea35e5ea51db7d384dc85eff6cf667dc/weaviate_client-4.23.0-py3-none-any.whl", hash = "sha256:f17c645d22e1787e8fa4640e20fcfccdee39c81327af410c544a24c21d419e59", size = 656174, upload-time = "2026-08-13T14:23:06.583Z" },
 ]
 
 [[package]]
@@ -1908,7 +1908,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "weaviate-agents", specifier = ">=1.7.0" },
-    { name = "weaviate-client", specifier = "==4.22.0" },
+    { name = "weaviate-client", specifier = "==4.23.0" },
     { name = "weaviate-demo-datasets", specifier = ">=0.8.1" },
     { name = "weaviate-engram", specifier = ">=0.3.0" },
 ]


### PR DESCRIPTION
Four commits from the final 1.39 sweep. All small, all independent.

**`uv.lock` for weaviate-client 4.23.0.** `pyproject.toml` was bumped while 4.23.0 was tagged but unpublished, so the lockfile kept resolving 4.22.0 and every workflow running a bare `uv sync` died at dependency install. 4.23.0 is on PyPI now.

**`and_cross` added to the BM25 concepts pages.** `concepts/search/keyword-search.md` still listed two operators and asserted, as a worked example, that tokens spread across properties cannot match. That is specific to `and`, not to BM25. `concepts/search/hybrid-search.md` carried the same two-operator claim. Both corrected, and `search/hybrid.md` gained the `v1.38.8` qualifier it was missing. A three-pass sweep confirms the claim now survives in five places, all correct.

**REST API reference repointed to the v1-39 spec.** `docusaurus.config.js` was pinned at `v1-38/openapi-for-docs`. I created `weaviate/weaviate` branch `v1-39/openapi-for-docs` by merging `v1.39.0` into the curated 1.38 spec branch and verified the raw URL serves Swagger 2.0 at `info.version: 1.39.0`, 77 paths.

## Worth knowing

**The 1.39 REST spec is not purely additive.** `PUT /schema/{className}/indexes/{propertyName}` is removed, replaced by `PUT /schema/{className}/properties/{propertyName}/index/{indexName}` with new `/rebuild` and `/cancel` sub-resources. I checked every `api/rest#` deep link in the docs: none targets the removed endpoint, so nothing dangles. But the endpoint disappears from the reference with no doc trail.

**This pin is the only Weaviate version reference in the repo that no automation touches.** `update-config-versions.js` auto-corrects `versions-config.json` and nothing else, and no release checklist mentions creating the `v1-XX/openapi-for-docs` branch or repointing this config. That is the mechanical reason it was missed for 1.39.

## Not fixed here

The `bm25_operators` diagram on the keyword-search page still shows two operators. It is a raster asset and needs a design pass.