### PR TITLE
docs(model-providers): replace hand-maintained Cohere model lists and fix related drift

### DIFF
--- a/docs/weaviate/model-providers/_includes/provider.generative.py
+++ b/docs/weaviate/model-providers/_includes/provider.generative.py
@@ -383,7 +383,6 @@ client.collections.create(
         # max_tokens=500,
         # k=5,
         # stop_sequences=["\n\n"],
-        # return_likelihoods="GENERATION"
     )
     # highlight-end
     # Additional parameters not shown
@@ -411,7 +410,6 @@ response = collection.generate.near_text(
         # max_tokens=500,
         # k=5,
         # stop_sequences=["\n\n"],
-        # return_likelihoods="GENERATION"
     ),
     # Additional parameters not shown
     # highlight-end

--- a/docs/weaviate/model-providers/_includes/provider.generative.ts
+++ b/docs/weaviate/model-providers/_includes/provider.generative.ts
@@ -343,12 +343,11 @@ await client.collections.create({
   // highlight-start
   generative: weaviate.configure.generative.cohere({
     // These parameters are optional
-    model: 'command-r',
+    // model: 'command-r',
     // temperature: 0.7,
     // maxTokens: 500,
     // k: 5,
     // stopSequences: ['\n\n'],
-    // returnLikelihoods: 'GENERATION'
   }),
   // highlight-end
   // Additional parameters not shown
@@ -366,8 +365,6 @@ response = await myCollection.generate.nearText("A holiday film", {
     // maxTokens: 500,
     // k: 5,
     // stopSequences: ['\n\n'],
-    // returnLikelihoods: 'GENERATION' // coming soon
-
   }),
   // highlight-end
 }, {

--- a/docs/weaviate/model-providers/_includes/provider.vectorizer.py
+++ b/docs/weaviate/model-providers/_includes/provider.vectorizer.py
@@ -136,7 +136,7 @@ client.collections.create(
             source_properties=["title"],
             # Further options
             # model="embed-v4.0",
-            # dimensions=512,
+            # dimensions=1024,
             # truncate="END",  # "NONE", "START" or "END"
             # base_url="<custom_cohere_url>"
         )
@@ -193,7 +193,6 @@ client.collections.create(
         Configure.Vectors.multi2vec_cohere(
             name="title_vector",
             model="embed-v4.0",
-            dimensions=1024,
             # Define the fields to be used for the vectorization - using image_fields, text_fields
             image_fields=[
                 Multi2VecField(name="poster", weight=0.9)
@@ -1042,7 +1041,7 @@ client.collections.create(
             # model="text-embedding-3-large",
             # model_version="002",  # Parameter only applicable for `ada` model family and older
             # dimensions=1024,      # Parameter only applicable for `v3` model family and newer
-            # type="text",
+            # type_="text",
             # base_url="<custom_openai_url>",
         )
     ],

--- a/docs/weaviate/model-providers/_includes/provider.vectorizer.ts
+++ b/docs/weaviate/model-providers/_includes/provider.vectorizer.ts
@@ -229,7 +229,7 @@ await client.collections.create({
   vectorizers: [
     weaviate.configure.vectors.multi2VecCohere({
       name: "title_vector",
-      model: "embed-multilingual-v3.0",
+      model: "embed-v4.0",
       // Define the fields to be used for the vectorization - using imageFields, textFields
       imageFields: [{
         name: "poster",
@@ -275,7 +275,7 @@ await client.collections.create({
         weight: 0.1
       }],
       // Further options
-      // model: "embed-multilingual-v3.0",
+      // model: "embed-v4.0",
       // dimensions: 1024,
       // truncate: "END",  // "NONE", "START" or "END"
       // baseURL: "<custom_cohere_url>"

--- a/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
+++ b/docs/weaviate/model-providers/cohere/embeddings-multimodal.md
@@ -103,7 +103,7 @@ Provide the API key to Weaviate using one of the following methods:
 
 ### Select a model
 
-You can specify one of the [available models](#available-models) for the vectorizer to use, as shown in the following configuration example.
+You can specify which [model](#available-models) the vectorizer uses, as shown in the following configuration example.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -126,7 +126,7 @@ You can specify one of the [available models](#available-models) for the vectori
 
 </Tabs>
 
-You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+You can [specify](#vectorizer-parameters) which [model](#available-models) Weaviate uses. If you do not specify a model, Weaviate uses the server default.
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
@@ -294,11 +294,11 @@ The query below returns the `n` most similar objects to the input image from the
 
 ### Available models
 
-- `embed-v4.0`
-- `embed-multilingual-v3.0` (server default)
-- `embed-multilingual-light-v3.0`
-- `embed-english-v3.0`
-- `embed-english-light-v3.0`
+Weaviate does not validate the model name, so you can set any model that your Cohere account can reach. Name validation was removed in `v1.33.0`, and backported to `v1.31.17` and `v1.32.10`.
+
+The server default is `embed-multilingual-v3.0`.
+
+A multimodal collection requires a model that can embed images as well as text. See the [Cohere model documentation](https://docs.cohere.com/docs/models) for the list of available models.
 
 ## Further resources
 

--- a/docs/weaviate/model-providers/cohere/embeddings.md
+++ b/docs/weaviate/model-providers/cohere/embeddings.md
@@ -134,7 +134,7 @@ Provide the API key to Weaviate using one of the following methods:
 
 ### Select a model
 
-You can specify one of the [available models](#available-models) for the vectorizer to use, as shown in the following configuration example.
+You can specify which [model](#available-models) the vectorizer uses, as shown in the following configuration example.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -167,7 +167,7 @@ You can specify one of the [available models](#available-models) for the vectori
 
 </Tabs>
 
-You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+You can [specify](#vectorizer-parameters) which [model](#available-models) Weaviate uses. If you do not specify a model, Weaviate uses the server default.
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
@@ -355,33 +355,19 @@ The query below returns the `n` best scoring objects from the database, set by `
 
 ### Available models
 
-- `embed-v4.0`
-- `embed-multilingual-v3.0` (server default)
-- `embed-multilingual-light-v3.0`
-- `embed-multilingual-v2.0` (previously `embed-multilingual-22-12`)
-- `embed-english-v3.0`
-- `embed-english-light-v3.0`
-- `embed-english-v2.0`
-- `embed-english-light-v2.0`
+Weaviate does not validate the model name, so you can set any model that your Cohere account can reach. Name validation was removed in `v1.33.0`, and backported to `v1.31.17` and `v1.32.10`.
 
-<details>
-  <summary>Deprecated models</summary>
+The server default is `embed-multilingual-v3.0`.
 
-The following models are available, but deprecated:
-- `multilingual-22-12`
-- `large`
-- `medium`
-- `small`
-
-</details>
+See the [Cohere model documentation](https://docs.cohere.com/docs/models) for the list of available models.
 
 ## Further resources
 
 ### Other integrations
 
-- [Cohere multimodal embedding models + Weaviate](./embeddings-multimodal.md)
-- [Cohere generative models + Weaviate](./generative.md)
-- [Cohere reranker models + Weaviate](./reranker.md)
+- [Cohere multimodal embedding models + Weaviate](./embeddings-multimodal.md).
+- [Cohere generative models + Weaviate](./generative.md).
+- [Cohere reranker models + Weaviate](./reranker.md).
 
 ### Code examples
 

--- a/docs/weaviate/model-providers/cohere/generative.md
+++ b/docs/weaviate/model-providers/cohere/generative.md
@@ -108,7 +108,7 @@ import MutableGenerativeConfig from '/_includes/mutable-generative-config.md';
 
 ### Select a model
 
-You can specify one of the [available models](#available-models) for Weaviate to use, as shown in the following configuration example:
+You can specify which [model](#available-models) Weaviate uses, as shown in the following configuration example:
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -131,7 +131,7 @@ You can specify one of the [available models](#available-models) for Weaviate to
 
 </Tabs>
 
-You can [specify](#generative-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+You can [specify](#generative-parameters) which [model](#available-models) Weaviate uses. If you do not specify a model, Weaviate uses the server default.
 
 ### Generative parameters
 
@@ -268,20 +268,7 @@ Weaviate does not validate the model name, so you can set any model that your Co
 
 The server default is `command-a-03-2025`. It changed in `v1.33.0`, and was backported to `v1.31.17` and `v1.32.10`. Earlier releases on each of those lines default to `command-r`.
 
-The following models are commonly used:
-
-- `command-a-03-2025` (server default)
-- `command-r-plus`
-- `command-r` (previous server default)
-- `command-xlarge`
-- `command-xlarge-beta`
-- `command-xlarge-nightly`
-- `command-medium`
-- `command-medium-nightly`
-- `command`
-- `command-nightly`
-- `command-light`
-- `command-light-nightly`
+See the [Cohere model documentation](https://docs.cohere.com/docs/models) for the list of available models.
 
 ## Further resources
 

--- a/docs/weaviate/model-providers/cohere/reranker.md
+++ b/docs/weaviate/model-providers/cohere/reranker.md
@@ -108,7 +108,7 @@ Configure a Weaviate collection to use a Cohere reranker model as follows:
 
 ### Select a model
 
-You can specify one of the [available models](#available-models) for Weaviate to use, as shown in the following configuration example:
+You can specify which [model](#available-models) Weaviate uses, as shown in the following configuration example:
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
@@ -180,17 +180,13 @@ Any search in Weaviate can be combined with a reranker to perform reranking oper
 
 ### Available models
 
-- `rerank-v3.5` (server default)
-- `rerank-english-v3.0`
-- `rerank-multilingual-v3.0`
-- `rerank-english-v2.0`
-- `rerank-multilingual-v2.0`
+Weaviate does not validate the model name, so you can set any model that your Cohere account can reach. Name validation was removed in `v1.33.0`, and backported to `v1.31.17` and `v1.32.10`.
 
-You can also select a fine-tuned reranker model_id, such as:
+The server default is `rerank-v3.5`.
 
-- `500df123-afr3-...`
+See the [Cohere model documentation](https://docs.cohere.com/docs/models) for the list of available models.
 
-See [this blog post](https://weaviate.io/blog/fine-tuning-coheres-reranker) for more information.
+You can also specify a fine-tuned reranker by its model ID, for example `500df123-afr3-...`. For details, see [Fine-Tuning Cohere's Reranker](https://weaviate.io/blog/fine-tuning-coheres-reranker).
 
 For further details on model parameters, see the [Cohere API documentation](https://docs.cohere.com/reference/rerank).
 

--- a/docs/weaviate/model-providers/openai/embeddings.md
+++ b/docs/weaviate/model-providers/openai/embeddings.md
@@ -129,7 +129,7 @@ Provide the API key to Weaviate using one of the following methods:
 
 ### Select a model
 
-You can specify one of the [available models](#available-models) for the vectorizer to use, as shown in the following configuration examples.
+You can specify one of the [available models](#available-models) for the vectorizer to use, as shown in the following configuration examples. If you do not set a model, Weaviate uses the server default, `text-embedding-3-small`.
 
 #### For `text-embedding-3` model family
 
@@ -199,7 +199,7 @@ For older models such as `text-embedding-ada-002`, provide the model name (`ada`
 
 </Tabs>
 
-You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for Weaviate to use. The [default model](#available-models) is used if no model is specified.
+You can [specify](#vectorizer-parameters) one of the [available models](#available-models) for Weaviate to use. If no model is specified, Weaviate uses `text-embedding-3-small`.
 
 import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
@@ -212,7 +212,7 @@ import VectorizationBehavior from '/_includes/vectorization.behavior.mdx';
 
 ### Vectorizer parameters
 
-- `model`: The OpenAI model name or family.
+- `model`: The OpenAI model name or family. Defaults to `text-embedding-3-small`.
 - `dimensions`: The number of dimensions for the model.
 - `modelVersion`: The version string for the model.
 - `type`: The model type, either `text` or `code`.
@@ -412,10 +412,12 @@ The query below returns the `n` best scoring objects from the database, set by `
 
 ### Available models
 
-You can use any OpenAI embedding model with `text2vec-openai`. For document embeddings, choose from the following [embedding model families](https://platform.openai.com/docs/models/embeddings):
+The server default is `text-embedding-3-small`.
+
+For document embeddings, choose from the following [embedding model families](https://platform.openai.com/docs/models/embeddings):
 
 * `text-embedding-3`
-    * Available dimensions:
+    * Available `dimensions` values:
         * `text-embedding-3-large`: `256`, `1024`, `3072` (default)
         * `text-embedding-3-small`: `512`, `1536` (default)
 * `ada`

--- a/docs/weaviate/model-providers/openai/generative.md
+++ b/docs/weaviate/model-providers/openai/generative.md
@@ -285,7 +285,7 @@ In other words, when you have `n` search results, the generative model generates
 
 ### RAG with images
 
-You can also supply images as a part of the input when performing retrieval augmented generation in both single prompts and grouped tasks. 
+You can also supply images as a part of the input when performing retrieval augmented generation in both single prompts and grouped tasks.
 
 <Tabs className="code" groupId="languages">
 
@@ -315,7 +315,12 @@ Weaviate does not validate the model name, so you can set any model that your Op
 
 The server default is `gpt-5-mini`. It changed in `v1.32.3`, and was backported to `v1.30.16` and `v1.31.10`. Earlier releases on each of those lines default to `gpt-3.5-turbo`.
 
-The following models are recognized by Weaviate's token limit table:
+See the [OpenAI model documentation](https://platform.openai.com/docs/models) for the list of available models.
+
+Weaviate stores a token limit for the models below. The limit caps the `maxTokens` value you can set for those models; it does not restrict which models you can use.
+
+<details>
+  <summary>Models with a stored token limit</summary>
 
 * [gpt-5](https://platform.openai.com/docs/models/gpt-5)
 * [gpt-5-mini](https://platform.openai.com/docs/models/gpt-5-mini) (server default)
@@ -329,10 +334,7 @@ The following models are recognized by Weaviate's token limit table:
 * [gpt-4o](https://platform.openai.com/docs/models#gpt-4o)
 * [gpt-4o-mini](https://platform.openai.com/docs/models#gpt-4o-mini)
 
-<details>
-  <summary>Older models</summary>
-
-The following models are available, but not recommended:
+These older models also have a stored limit, but are not recommended:
 
 * [davinci 002](https://platform.openai.com/docs/models/overview)
 * [davinci 003](https://platform.openai.com/docs/models/overview)


### PR DESCRIPTION
### What's being changed:

Core stopped validating model names for the Cohere modules in `v1.33.0` (backported to `v1.31.17` and `v1.32.10`), so the hand-maintained lists on those pages are guaranteed to rot. Each is replaced with the no-validation statement, the server default, and a link to Cohere's own model documentation.

Four corrections found alongside:

- **`openai/embeddings.md` said you can use any OpenAI embedding model.** That is false — `text2vec-openai` still validates against an allowlist (`ent/class_settings.go:185-192`). The page also never stated its server default (`text-embedding-3-small`), and its `(default)` markers refer to dimensions, not model choice.
- **`openai/generative.md`'s list is the token-limit table, not an availability list.** Kept and demoted into a `<details>`, with a lead-in saying what it does: it caps `maxTokens` for those models.
- **`return_likelihoods` removed from four snippets.** The Python client accepts and silently discards it, and core has no reader on any path — so the snippets showed a live-looking option that does nothing.
- **Six Python/TypeScript snippet pairs disagreed** on the same example (`dimensions`, the multimodal model, and one model left active in TypeScript while commented in Python).

### Type of change:

- [x] **Documentation content** updates (non-breaking change to fix/update documentation )

### How has this been tested?

Not built locally. Marker names in the four `_includes` files are byte-identical to `main` (so no page lost a snippet), `<details>`/`<Tabs>`/`<TabItem>` pairing was re-checked on all six pages, both `_includes` Python files compile, and every `#available-models` / `#vectorizer-parameters` / `#generative-parameters` anchor still resolves. Relying on the deploy preview for the site build.