### PR TITLE
fix: repair the Academy course registry, and correct tenant backup coverage

### DIFF
--- a/docs/deploy/configuration/backups.md
+++ b/docs/deploy/configuration/backups.md
@@ -29,7 +29,7 @@ Weaviate's Backup feature is designed to work natively with cloud technology. Mo
 :::caution Important backup considerations
 
 - **Version Requirements**: If you are running Weaviate `v1.23.12` or older, you must [update](/deploy/migration/index.md) to `v1.23.13` or higher before restoring a backup to prevent data corruption.
-- **[Multi-tenancy](/weaviate/concepts/data.md#multi-tenancy) limitations**: Starting in `v1.37`, backups include both `active` (HOT) and `inactive` (COLD) tenants. Inactive tenants are backed up directly from disk without activation. `Offloaded` (FROZEN) tenants are still skipped since they have no local data. In versions prior to `v1.37`, only active tenants are included, so be sure to [activate](/weaviate/manage-collections/multi-tenancy.mdx#manage-tenant-states) any required tenants before creating a backup.
+- **[Multi-tenancy](/weaviate/concepts/data.md#multi-tenancy) limitations**: Backups include both `active` (HOT) and `inactive` (COLD) tenants. Inactive tenants are backed up directly from disk without activation. `Offloaded` (FROZEN) tenants are still skipped since they have no local data. Inactive tenant support was added in `v1.37.0`, and backported to `v1.35.17` and `v1.36.10`. In earlier releases only active tenants are included, so be sure to [activate](/weaviate/manage-collections/multi-tenancy.mdx#manage-tenant-states) any required tenants before creating a backup.
 :::
 
 ## Backup Quickstart

--- a/docs/weaviate/client-libraries/python/async.md
+++ b/docs/weaviate/client-libraries/python/async.md
@@ -22,7 +22,9 @@ For asynchronous operations, use the `WeaviateAsyncClient` async client, availab
 
 The `WeaviateAsyncClient` async client largely supports the same functions and methods as the `WeaviateClient` [synchronous client](./index.mdx), with the key difference that the async client is designed to be used in an `async` function running in an [`asyncio` event loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio-event-loop).
 
-<!-- TODO[g-despot] Uncomment when available 
+<!-- TODO[g-despot] Uncomment when available. Also re-add the "async-python-client-usage"
+entry to src/components/AcademyAdmonition/courses.json. It was removed because
+https://academy.weaviate.io/courses/wa280-py does not exist yet (404).
 import AcademyAdmonition from '@site/src/components/AcademyAdmonition';
 
 <AcademyAdmonition 

--- a/docs/weaviate/concepts/data.md
+++ b/docs/weaviate/concepts/data.md
@@ -459,8 +459,12 @@ When a tenant is offloaded, the entire tenant shard is moved to cloud storage. T
 
 ### Backups
 
-:::caution Backups do not include inactive or offloaded tenants
-Backups of multi-tenant collections will only include `active` tenants, and not `inactive` or `offloaded` tenants. [Activate tenants](../manage-collections/multi-tenancy.mdx#manage-tenant-states) before creating a backup to ensure all data is included.
+:::caution Backups do not include offloaded tenants
+Backups of multi-tenant collections include both `active` and `inactive` tenants. Inactive tenants are read directly from disk, so you do not need to activate them before creating a backup.
+
+`Offloaded` tenants are not included, because their data is not held on local disk. The tenant status is preserved, but the tenant's data is not part of the backup. [Activate offloaded tenants](../manage-collections/multi-tenancy.mdx#manage-tenant-states) before creating a backup to include their data.
+
+Support for backing up `inactive` tenants was added in `v1.37.0`, and backported to `v1.35.17` and `v1.36.10`. In earlier releases, backups include only `active` tenants.
 :::
 
 ### Tenancy and IDs

--- a/docs/weaviate/manage-collections/multi-tenancy.mdx
+++ b/docs/weaviate/manage-collections/multi-tenancy.mdx
@@ -618,8 +618,12 @@ Multi-tenancy collections require the tenant name (e.g. `tenantA`) when creating
 
 ## Backups
 
-:::caution Backups do not include inactive or offloaded tenants
-Backups of [multi-tenant collections](../concepts/data.md#multi-tenancy) will only include `active` tenants, and not `inactive` or `offloaded` tenants. [Activate tenants](#manage-tenant-states) before creating a backup to ensure all data is included.
+:::caution Backups do not include offloaded tenants
+Backups of [multi-tenant collections](../concepts/data.md#multi-tenancy) include both `active` and `inactive` tenants. Inactive tenants are read directly from disk, so you do not need to activate them before creating a backup.
+
+`Offloaded` tenants are not included, because their data is not held on local disk. The tenant status is preserved, but the tenant's data is not part of the backup. [Activate offloaded tenants](#manage-tenant-states) before creating a backup to include their data.
+
+Support for backing up `inactive` tenants was added in `v1.37.0`, and backported to `v1.35.17` and `v1.36.10`. In earlier releases, backups include only `active` tenants.
 :::
 
 ## Related pages

--- a/netlify.toml
+++ b/netlify.toml
@@ -897,6 +897,19 @@ from = "/academy/py/standalone/which_search"
 to   = "/weaviate/search"
 status = 301
 
+# Specific course routes must stay ABOVE the /academy/py/* catch-all: Netlify
+# applies the first matching rule, so anything placed below it is unreachable.
+
+[[redirects]]
+from = "/academy/py/standalone/chunking/*"
+to   = "https://academy.weaviate.io/courses/wa921-py"
+status = 301
+
+[[redirects]]
+from = "/academy/py/starter_multimodal_data/*"
+to   = "https://academy.weaviate.io/courses/wa910-py"
+status = 301
+
 [[redirects]]
 from = "/academy/py/*"
 to   = "https://academy.weaviate.io/courses/wa101t-py"

--- a/src/components/AcademyAdmonition/courses.json
+++ b/src/components/AcademyAdmonition/courses.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "quick-tour-of-weaviate",
-    "title": "A Quick Tour of Weaviate",
+    "title": "Key Concepts & Architecture",
     "description": "Become familiar with Weaviate's architecture, core concepts, and key capabilities. Understand how its features and integrations map to AI builders' needs.",
     "url": "https://academy.weaviate.io/courses/wa050-py"
   },
@@ -30,15 +30,33 @@
     "url": "https://academy.weaviate.io/courses/wa210-py"
   },
   {
+    "id": "search-strategies-in-depth",
+    "title": "Search Strategies: In Depth",
+    "description": "Gain deep, practical knowledge of search strategies in Weaviate. Dive deeper into different search types, tokenization and its impact, and search optimization techniques.",
+    "url": "https://academy.weaviate.io/courses/wa220-py"
+  },
+  {
+    "id": "data-ingestion-in-depth",
+    "title": "Data Ingestion: In Depth",
+    "description": "How you prepare and ingest data has big impact on the quality of your search and downstream applications. Learn about the key options and decisions to make, and some best practices.",
+    "url": "https://academy.weaviate.io/courses/wa230-py"
+  },
+  {
     "id": "embedding-model-evaluation",
     "title": "Embedding Model Evaluation & Selection",
     "description": "Embedding models are the heart of vector search. Learn how to evaluate and select appropriate embedding models for your use case.",
-    "url": "https://academy.weaviate.io/courses/wa150-py"
+    "url": "https://academy.weaviate.io/courses/wa260-py"
   },
   {
-    "id": "async-python-client-usage",
-    "title": "Async Python Client Usage",
-    "description": "Learn how to use Weaviate's async capabilities to handle concurrent operations and large-scale data processing efficiently.",
-    "url": "https://academy.weaviate.io/courses/wa280-py"
+    "id": "multimodal-data-in-focus",
+    "title": "Multimodal Data: In Focus",
+    "description": "A lot of our world is multimodal. Learn how to work with multimodal data, combining the right embedding and generative models with Weaviate.",
+    "url": "https://academy.weaviate.io/courses/wa910-py"
+  },
+  {
+    "id": "document-chunking-strategies",
+    "title": "Document Chunking Strategies",
+    "description": "Learn effective chunking strategies for different types of documents and use cases.",
+    "url": "https://academy.weaviate.io/courses/wa921-py"
   }
 ]

--- a/src/components/AcademyAdmonition/index.jsx
+++ b/src/components/AcademyAdmonition/index.jsx
@@ -118,13 +118,13 @@ import AcademyAdmonition from '@site/src/components/AcademyAdmonition';
 <AcademyAdmonition courseId="quick-tour-of-weaviate" />
 
 // With custom button text
-<AcademyAdmonition 
-  courseId="movie-recommendation-api" 
+<AcademyAdmonition
+  courseId="fast-api-weaviate-rag"
   buttonText="Start Learning"
 />
 
 // Override with custom content (for courses not in JSON)
-<AcademyAdmonition 
+<AcademyAdmonition
   customTitle="Custom Course Title"
   customDescription="This is a custom course description."
   customUrl="https://academy.weaviate.io/courses/custom"


### PR DESCRIPTION
Two unrelated defect classes, one commit each — review them separately.

## 1. The Academy course registry had drifted

`AcademyAdmonition/courses.json` is the map from docs pages to Academy courses, and it had gone stale in four ways: one entry pointed at the wrong course (`embedding-model-evaluation` → wa150-py instead of wa260-py), one carried a since-renamed title, one advertised `wa280-py` which 404s, and four live courses had no entry at all. The component's own usage example also named a courseId that does not exist.

Every id written here was checked three ways: an entry in the Academy `courses.json`, a matching directory on disk, and a live 200. `vdb101m-ts` and `wa101t-js` are deliberately excluded — both are declared in the Academy catalog but neither is actually served.

`netlify.toml`: two legacy paths had no successor rule and fell through to the `/academy/py/*` catch-all, so readers following old chunking and multimodal links landed on the Python starter course. Netlify takes the first matching rule, so ordering is the fix — the two new rules sit above the catch-all. Verified by replaying rule resolution against both the old and new file; six probes change, every regression probe is byte-identical, and the same rules placed *below* the catch-all resolve back to the wrong course.

Note this registry is not a surface: adding an entry does not put a course in front of a reader until a page uses `<AcademyAdmonition courseId="…"/>`. Several pre-existing entries are likewise unreferenced.

## 2. Two pages said backups exclude inactive tenants

They haven't since `89c457f9a9`. Backups include ACTIVE and INACTIVE tenants — inactive shards are read straight off disk with no activation — and only FROZEN/OFFLOADED are skipped, because they hold no local data. `concepts/data.md` and `manage-collections/multi-tenancy.mdx` both carried the old claim; `deploy/configuration/backups.md` already had the substance right.

The direction of this error matters. It tells operators their inactive tenants are unprotected, so they either activate every tenant before each backup — pointless work on a live multi-tenant cluster, and self-defeating — or build a workaround for a problem that no longer exists.

**The floor is not simply `v1.37`.** The change was backported: present in `v1.35.17`, `v1.36.10` and `v1.37.0`, absent from `v1.35.16` and `v1.36.9`. A bare "starting in v1.37" would tell a reader on the supported 1.36 line that they lack the feature, so all three pages now name the backported versions. `backups.md` needed only that correction.

Restore behaviour for offloaded tenants is deliberately not claimed. Core shows their status survives and their shard is omitted from the descriptor; whether a restored offloaded tenant can be onloaded was not verified.

I grepped `docs/`, `_includes/` and `blog/` for other statements of the claim, then inspected every file containing both "backup" and "inactive|offload". These three were the only sites.

## Verification

`npm run build-dev` exits 0. The broken-link and broken-anchor lists are byte-identical to a pre-change baseline build — 4 pre-existing broken links and 1 pre-existing broken anchor, none related to this change. Both new `#manage-tenant-states` anchors validate. Rendered HTML checked on all three tenant pages and on four pages carrying an AcademyAdmonition.

## Related

The matching Academy-side content fixes are weaviate/weaviate-academy#71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KDHXjWpoPozpZh6RpdgRW
