### PR TITLE
Document EXPERIMENTAL_REST_SEARCH_ENABLED

### DIFF
--- a/docs/deploy/configuration/env-vars/index.md
+++ b/docs/deploy/configuration/env-vars/index.md
@@ -49,6 +49,7 @@ import APITable from '@site/src/components/APITable';
 | `ENABLE_TOKENIZER_GSE` | Enable the [`GSE` tokenizer](/weaviate/config-refs/collections.mdx) for use | `boolean` | `true` |
 | `ENABLE_TOKENIZER_KAGOME_JA` | Enable the [`Kagome` tokenizer for Japanese](/weaviate/config-refs/collections.mdx) for use | `boolean` | `true` |
 | `ENABLE_TOKENIZER_KAGOME_KR` | Enable the [`Kagome` tokenizer for Korean](/weaviate/config-refs/collections.mdx) for use | `boolean` | `true` |
+| `EXPERIMENTAL_REST_SEARCH_ENABLED` | (EXPERIMENTAL) Enable the [REST Search API](/weaviate/api/rest): the `POST /v1/search/{collection}/near-text`, `/bm25`, `/hybrid` and `/near-object` endpoints, and the sibling `POST /v1/aggregate/{collection}` endpoint. While disabled, these endpoints reject requests with a `422` status. Default: `false` | `boolean` | `true` |
 | `EXPORT_DEFAULT_BUCKET` | Storage bucket name for [collection exports](/docs/deploy/configuration/export.md). Required for S3, GCS, and Azure backends.<br/>Added in `v1.37` | `string` | `my-export-bucket` |
 | `EXPORT_DEFAULT_PATH` | Optional base path prefix for exported files within the bucket for [collection exports](/docs/deploy/configuration/export.md). Defaults to `""` (no prefix). _Changed in `v1.37.1`: previously required to be explicitly set._<br/>Added in `v1.37` | `string` | `exports/my-cluster` |
 | `EXPORT_ENABLED` | Enable the [collection export](/docs/deploy/configuration/export.md) API. Default: `false`<br/>Added in `v1.37` | `boolean` | `true` |

--- a/docs/weaviate/api/index.mdx
+++ b/docs/weaviate/api/index.mdx
@@ -11,6 +11,7 @@ Weaviate provides multiple Application Programming Interfaces (APIs) to interact
 
   - Includes operations for managing collections (creating, reading, updating, deleting collections and their definitions), performing basic CRUD (Create, Read, Update, Delete) operations on individual data objects, checking node status, backups, and managing cluster health.
   - The machine-readable specification behind this reference is published at <SkipValidationLink href="/openapi.json">`https://docs.weaviate.io/openapi.json`</SkipValidationLink>. See [Machine-readable API specification](#machine-readable-api-specification) below.
+  - The reference also lists an experimental REST Search API (the `/v1/search/{collection}/...` and `/v1/aggregate/{collection}` endpoints), which is disabled by default and rejects requests with a `422` status until [`EXPERIMENTAL_REST_SEARCH_ENABLED`](/deploy/configuration/env-vars/index.md#EXPERIMENTAL_REST_SEARCH_ENABLED) is set to `true`.
 
 - **[Search API - GraphQL](./graphql/index.md)**: Designed specifically for data querying and exploration.
 


### PR DESCRIPTION
The env var gating the experimental REST Search API was undocumented — its only appearance in this repo was inside five 422 error strings in the committed OpenAPI spec.

- `env-vars/index.md`: add the variable to the General table. It gates five endpoints — `POST /v1/search/{collection}/{near-text,bm25,hybrid,near-object}` and the sibling `POST /v1/aggregate/{collection}` — which reject with 422 while it is off.
- `api/index.mdx`: note the API is experimental and off by default. `/weaviate/api/rest` renders those endpoints today with no hint of a gate.

No `Added in vX.Y` marker: the spec says `info.version: 1.39.0` and carries all five paths, but the v1.39.0 CodeBrief records only near-text at that tag. Happy to add one if you know the release that ships all five.

The matching spec change is weaviate/weaviate branch `docs/rest-search-experimental-notice`, off `v1-39/openapi-for-docs`. Once that merges, the weekly spec-refresh job will bring the notice into `static/specs/weaviate-openapi.json` here.