### PR TITLE
docs: correct MMR expansion and stale client-support claims

### DIFF
--- a/docs/weaviate/concepts/search/vector-search.md
+++ b/docs/weaviate/concepts/search/vector-search.md
@@ -256,7 +256,7 @@ import V137Preview from '/_includes/feature-notes/v137-preview.mdx';
 
 Standard vector search returns the closest matches to a query, which often means a cluster of near-duplicate results. For example, searching for "Italian food" in a product catalog might return five images of pizza instead of a diverse spread of Italian dishes.
 
-**Maximum Marginal Relevance (MMR)** solves this by reranking results to balance two objectives:
+**Maximal Marginal Relevance (MMR)** solves this by reranking results to balance two objectives:
 
 - **Relevance**: how well does the item match the query?
 - **Diversity**: how different is the item from the results already selected?

--- a/docs/weaviate/search/boost.md
+++ b/docs/weaviate/search/boost.md
@@ -18,8 +18,6 @@ import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, near-image, and near-media queries.
 
-The examples on this page are Python only. `boost` is available in the Python (`v4.22.0`), TypeScript (`v3.14.0`), Java (`v6.3.0`), and C# (`v1.2.0`) clients, but not yet in the Go client.
-
 ## How it works
 
 A boost is a **post-retrieval rescorer**:

--- a/docs/weaviate/search/boost.md
+++ b/docs/weaviate/search/boost.md
@@ -18,7 +18,7 @@ import BoostNote from '/_includes/feature-notes/boost.mdx';
 
 Apply boost to vector, hybrid, BM25, near-text, near-vector, near-object, near-image, and near-media queries.
 
-The examples on this page are Python only, because `boost` is currently available in the Python client and not yet in the TypeScript, Go, Java, or C# clients.
+The examples on this page are Python only. `boost` is available in the Python (`v4.22.0`), TypeScript (`v3.14.0`), Java (`v6.3.0`), and C# (`v1.2.0`) clients, but not yet in the Go client.
 
 ## How it works
 

--- a/docs/weaviate/search/hybrid.md
+++ b/docs/weaviate/search/hybrid.md
@@ -1059,11 +1059,11 @@ See [Boost](./boost.md) for the supported condition types (filter, property valu
 :::info Added in `v1.38.6`
 :::
 
-Hybrid search fuses a keyword result set and a vector result set, which often means the top of the fused list is a cluster of near-duplicates. **Maximum Marginal Relevance (MMR)** reranks that list to balance relevance with diversity, so that each selected object adds something new to the result set.
+Hybrid search fuses a keyword result set and a vector result set, which often means the top of the fused list is a cluster of near-duplicates. **Maximal Marginal Relevance (MMR)** reranks that list to balance relevance with diversity, so that each selected object adds something new to the result set.
 
 Diversity selection runs after fusion. Both search legs run first, their results are fused with the configured `alpha` and fusion method, and the diversity pass then picks a diverse subset of the fused candidates.
 
-The examples in this section are Python only, because diversity selection is currently available in the Python client and not yet in the TypeScript, Go, Java, or C# clients. There is no GraphQL equivalent.
+The examples in this section are Python only. Diversity selection on hybrid search is available in the Python (`v4.23.0`), Java (`v6.3.1`), and C# (`v1.2.0`) clients, but not yet in the TypeScript or Go clients. There is no GraphQL equivalent.
 
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">

--- a/docs/weaviate/search/hybrid.md
+++ b/docs/weaviate/search/hybrid.md
@@ -1063,8 +1063,6 @@ Hybrid search fuses a keyword result set and a vector result set, which often me
 
 Diversity selection runs after fusion. Both search legs run first, their results are fused with the configured `alpha` and fusion method, and the diversity pass then picks a diverse subset of the fused candidates.
 
-The examples in this section are Python only. Diversity selection on hybrid search is available in the Python (`v4.23.0`), Java (`v6.3.1`), and C# (`v1.2.0`) clients, but not yet in the TypeScript or Go clients. There is no GraphQL equivalent.
-
 <Tabs className="code" groupId="languages">
   <TabItem value="py" label="Python">
     <FilteredTextBlock

--- a/docs/weaviate/search/similarity.md
+++ b/docs/weaviate/search/similarity.md
@@ -673,7 +673,7 @@ import V137Preview from '/\_includes/feature-notes/v137-preview.mdx';
 
 <V137Preview/>
 
-Standard vector search returns the closest matches to the query, which often means a cluster of near-duplicate results. **Maximum Marginal Relevance (MMR)** reranks results to balance relevance with diversity: each selected result must add something new to the result set.
+Standard vector search returns the closest matches to the query, which often means a cluster of near-duplicate results. **Maximal Marginal Relevance (MMR)** reranks results to balance relevance with diversity: each selected result must add something new to the result set.
 
 Add the `diversity_selection` parameter to any vector search query:
 


### PR DESCRIPTION
Two defects found while reviewing the 1.39 release blog post.

**MMR expansion.** Three Database pages said "Maximum Marginal Relevance" while the Query Agent pages said "Maximal". Standardized on Maximal.

**Client support.** `boost.md` and `hybrid.md` both said the feature was Python-only and not yet in TypeScript, Go, Java or C#. Checked against released tags: boost ships in Python `v4.22.0`, TypeScript `v3.14.0`, Java `6.3.0` and C# `1.2.0`; diversity selection on hybrid ships in Python `v4.23.0`, Java `6.3.1` and C# `1.2.0`. Go has neither, and hybrid MMR in TypeScript is genuinely unreleased. Both pages now name real versions.

Follow-ups not in this PR: the Python-only examples on those pages now under-serve the clients that do support these features, and TypeScript exports a `Boost` factory class that is unreachable from the package entry point.