### PR TITLE
fix: show Query Agent recipes, and repoint rotted TypeDoc links

### DIFF
--- a/docs/weaviate/model-providers/cohere/embeddings.md
+++ b/docs/weaviate/model-providers/cohere/embeddings.md
@@ -79,8 +79,8 @@ Provide the API key to Weaviate using one of the following methods:
       endMarker="// END CohereInstantiation"
       language="ts"
       docRefs={[
-        "functions/connectToWeaviateCloud",
-        "classes/ApiKey",
+        "functions/core_src.helpers.connectToWeaviateCloud",
+        "classes/core_src.ApiKey",
       ]}
     />
   </TabItem>

--- a/docs/weaviate/model-providers/nvidia/embeddings.md
+++ b/docs/weaviate/model-providers/nvidia/embeddings.md
@@ -78,8 +78,8 @@ Provide the API key to Weaviate using one of the following methods:
       endMarker="// END NVIDIAInstantiation"
       language="ts"
       docRefs={[
-        "functions/connectToWeaviateCloud",
-        "classes/ApiKey",
+        "functions/core_src.helpers.connectToWeaviateCloud",
+        "classes/core_src.ApiKey",
       ]}
     />
   </TabItem>

--- a/src/components/Documentation/FilteredTextBlock.js
+++ b/src/components/Documentation/FilteredTextBlock.js
@@ -17,7 +17,8 @@ export const DOC_SYSTEMS = {
     },
     ts: {
         baseUrl: 'https://weaviate.github.io/typescript-client',
-        constructUrl: (baseUrl, ref) => `${baseUrl}/${ref}`,
+        // TypeDoc serves each symbol as a `.html` page, so refs stay extensionless.
+        constructUrl: (baseUrl, ref) => `${baseUrl}/${ref}.html`,
         icon: '/img/site/logo-ts.svg',
     },
     go: {

--- a/src/components/RecipesCards/index.jsx
+++ b/src/components/RecipesCards/index.jsx
@@ -102,13 +102,15 @@ export default function RecipesCards({ path }) {
         const filteredRecipes = recipes.filter((recipe) => {
           if (!recipe.notebook) return false;
           let recipeCategory;
-          if (recipe.agent === true) recipeCategory = "agents";
+          // Each value must name a real top-level docs section: it is compared
+          // against the first segment of the page URL.
+          if (recipe.agent === true) recipeCategory = "query-agent";
           else if (recipe.integration === true) recipeCategory = "integrations";
           else recipeCategory = "weaviate"; // Default or base category
 
           const normalizedPathCategory = pathCategory.replace(/\/$/, "");
 
-          // Match recipe category with current path category (allow for plurals like 'agent' vs 'agents')
+          // Match recipe category with current path category (tolerate singular/plural, e.g. 'integration' vs 'integrations')
           return (
             normalizedPathCategory === recipeCategory ||
             normalizedPathCategory === recipeCategory.replace(/s$/, "") || // Handle singular vs plural
@@ -119,6 +121,12 @@ export default function RecipesCards({ path }) {
         console.log(
           `Filtered to ${filteredRecipes.length} recipes for category ${pathCategory}`
         );
+
+        if (filteredRecipes.length === 0) {
+          console.error(
+            `RecipesCards: no entries in /static/config/index.toml match category "${pathCategory}".`
+          );
+        }
 
         const uniqueTags = new Set();
         const cards = filteredRecipes.map((recipe) => {
@@ -211,10 +219,10 @@ export default function RecipesCards({ path }) {
     // Check !loading to avoid brief flash
     return (
       <div>
-        <p>No recipes found for category: "{pathCategory}"</p>
         <p>
-          Check if <code>/static/config/index.toml</code> contains recipe entries
-          matching this category.
+          No recipes are available here yet. Browse the{" "}
+          <a href="https://github.com/weaviate/recipes">Weaviate Recipes</a>{" "}
+          repository for the full set of code examples.
         </p>
       </div>
     );


### PR DESCRIPTION
Two independent fixes.

**Query Agent recipes page was empty.** `RecipesCards` matches a recipe's category against the first segment of the page URL. Recipes flagged `agent = true` in `static/config/index.toml` were bucketed as `"agents"` — a segment no docs section uses — so nothing matched and https://docs.weaviate.io/query-agent/recipes rendered an empty state instead of its five cards. The other two buckets, `"integrations"` and `"weaviate"`, do name real sections. Bucketing these as `"query-agent"` fixes it. Also replaces the empty state's `index.toml` debugging note, which was shown to readers, with a pointer to the recipes repo.

**TypeDoc links 404.** The TypeScript client's TypeDoc site was regenerated with module-qualified, `.html`-suffixed paths, breaking the `connectToWeaviateCloud` and `ApiKey` badges on the Cohere and NVIDIA embeddings pages. This was failing link validation on every PR, not just this one. The extension belongs to the URL scheme rather than to each reference, so it moves into the `ts` `constructUrl` next to the equivalent suffixes for `go` and `java`.

Verified against a local dev server: the recipes page renders all five cards with links matching the sidebar, `/weaviate/recipes` is unchanged at six, and both embeddings pages now emit URLs that return 200 with the badge labels restored to `.connectToWeaviateCloud` and `.ApiKey`.