### PR TITLE
Drop the redundant body from the "Added in" admonitions

### DIFF
--- a/docs/weaviate/model-providers/deepseek/generative.md
+++ b/docs/weaviate/model-providers/deepseek/generative.md
@@ -31,7 +31,6 @@ Examples for the other client languages will follow.
 Your Weaviate instance must be configured with the DeepSeek generative AI integration (`generative-deepseek`) module.
 
 :::info Added in `v1.36.19`, `v1.37.10`, and `v1.38.2`
-The `generative-deepseek` module is available from `v1.36.19` on the `v1.36` line, `v1.37.10` on the `v1.37` line, and `v1.38.2` on the `v1.38` line. Earlier patch releases on these lines do not include it.
 :::
 
 <details>

--- a/docs/weaviate/model-providers/digitalocean/generative.md
+++ b/docs/weaviate/model-providers/digitalocean/generative.md
@@ -31,7 +31,6 @@ Examples for the other client languages will follow.
 Your Weaviate instance must be configured with the DigitalOcean generative AI integration (`generative-digitalocean`) module.
 
 :::info Added in `v1.37.15`, `v1.38.13`, and `v1.39.2`
-The `generative-digitalocean` module is available from `v1.37.15` on the `v1.37` line, `v1.38.13` on the `v1.38` line, and `v1.39.2` on the `v1.39` line. Earlier patch releases on these lines do not include it.
 :::
 
 <details>


### PR DESCRIPTION
On the DeepSeek and DigitalOcean generative pages, the `:::info Added in ...` admonition restated the versions already in its own title, so the reader got the same enumeration twice in a row. This keeps the title and drops the body.

Title-only is the established form — 8 of the 14 `:::info Added in ...` admonitions in the repo already have an empty body, and Docusaurus renders them heading-only.

Leaves `backups.md:884` alone: its body adds a backport to `v1.33.14`, `v1.34.11` and `v1.35.4` rather than restating its title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRPhcXaFRMNZWA5GAT4c3t