### PR TITLE
Correct the memory-mappings log table and widen the fix guidance

### DIFF
--- a/docs/errors/cluster-resources.mdx
+++ b/docs/errors/cluster-resources.mdx
@@ -41,19 +41,20 @@ In the response your client gets when the failure happened inside a request you 
 {"error":[{"message":"updating db: TYPE_UPDATE_TENANT: memory pressure: cannot init shard: not enough memory mappings (see https://docs.weaviate.io/e/core-mem001)"}]}
 ```
 
-Which log entry carries it depends on the operation that hit the limit:
+Which log entry carries it depends on the operation that hit the limit. `<tenant>` and `<error>` stand for the tenant name and the appended error text:
 
-| Log message | `action` field | Level | Where the phrase is |
-| --- | --- | --- | --- |
-| `failed to load shard: memory pressure: cannot load shard: not enough memory mappings` | `load_shard` | error | In the message |
-| `loading shard "MyTenant" failed` | `tenant_activation_lazy_load_shard` | error | Appended to the message, or in a separate `error` field before v1.40 |
-| `failed to reload local index` | (none) | error | In a separate `error` field |
-| `failure while loading shard: memory pressure: cannot init shard: not enough memory mappings` | `replication_engine` | error | In the message, while a replica is moved or copied |
-| `drop-vector: load lazy shard: memory pressure: cannot load shard: not enough memory mappings` | (none) | warning | In the message, while a vector index is dropped |
+| Log message | `action` field | Level |
+| --- | --- | --- |
+| `failed to load shard, loading the rest anyway: <error>` | `load_shard` | error |
+| `loading shard "<tenant>" failed: <error>` | `tenant_activation_lazy_load_shard` | error |
+| `failed to reload local index` | (none) | error |
+| `error updating tenants` | `update_tenants` | error |
+| `error updating tenants: <error>` | `update_tenants_process` | error |
+| `apply command` | (none) | error |
+| `failure while loading shard: <error>` (while a replica is moved or copied) | `replication_engine` | error |
+| `drop-vector: load lazy shard: <error>` (while a vector index is dropped) | (none) | warning |
 
-:::tip Search for the phrase, not the line
-`not enough memory mappings` is the one part that appears somewhere in the entry on every version, sometimes in a sibling `error` field rather than the message. On versions that carry it, every one of these entries also has a `docs_url` field pointing here.
-:::
+The exact line varies by operation and version, so search the logs for `not enough memory mappings`: it appears in the message or in a sibling `error` field, depending on the entry. On versions that include this feature, every entry carrying the phrase also carries a `docs_url` field pointing at this page.
 
 The failure often shows up next to replication errors such as `broadcast: cannot reach enough replicas`, because the shard those requests needed is the one that did not load.
 
@@ -91,12 +92,41 @@ The limit belongs to the host kernel, so where you set it depends on how you run
 4. Restart the affected node so Weaviate reads the new limit.
 
 </TabItem>
+<TabItem value="docker" label="Docker">
+
+On Linux, containers share the host kernel, so the limit is the host's to raise: follow the Linux host steps on the machine that runs Docker, then restart the container. Setting it per container does not work — `docker run --sysctl vm.max_map_count=...` is refused, because Docker permits only namespaced sysctls and this one belongs to the whole host.
+
+Docker Desktop on Mac and Windows runs containers inside a Linux VM, so the Linux steps on your own machine change the wrong kernel. Set the limit inside the VM instead.
+
+On Windows, with the WSL 2 backend:
+
+```bash
+wsl -d docker-desktop -u root sysctl -w vm.max_map_count=4194304
+```
+
+To make it survive a restart, add this to `%USERPROFILE%\.wslconfig`:
+
+```ini
+[wsl2]
+kernelCommandLine = "sysctl.vm.max_map_count=4194304"
+```
+
+On macOS, apply it from a privileged container. The setting lasts until Docker Desktop restarts:
+
+```bash
+docker run --rm --privileged --pid=host alpine nsenter -t 1 -m -u -n -i sysctl -w vm.max_map_count=4194304
+```
+
+Then restart the Weaviate container so Weaviate reads the new limit.
+
+</TabItem>
 <TabItem value="kubernetes" label="Kubernetes">
 
 The setting belongs to the host kernel, not to the container, so setting it inside an unprivileged pod has no effect. Apply it on every node that can schedule a Weaviate pod, through one of:
 
+- the official Helm chart, which already ships a privileged init container, enabled by default, that runs `sysctl -w vm.max_map_count` on the pod's node before Weaviate starts. Its default of `524288` (`initContainers.sysctlVmMaxMapCount`) is well below the value this page recommends, so set `initContainers.sysctlVmMaxMapCount: 4194304` in your values rather than adding infrastructure
 - your node configuration or image, with `vm.max_map_count=4194304` in `/etc/sysctl.conf`
-- a `DaemonSet` that runs `sysctl -w vm.max_map_count=4194304` on each node
+- a `DaemonSet` whose privileged container runs `sysctl -w vm.max_map_count=4194304` on each node
 - a privileged init container on the Weaviate pod that sets it before Weaviate starts
 
 Then restart the affected pod so Weaviate reads the new limit.

--- a/docs/weaviate/release-notes/known-issues.mdx
+++ b/docs/weaviate/release-notes/known-issues.mdx
@@ -439,13 +439,15 @@ Upgrade to fixed version:
 ```
 
 - Tenant activation failures
-- From `v1.40`, these entries carry `docs_url=https://docs.weaviate.io/e/core-mem001`, and the error returned to the client ends in the same link. Both lead to [not enough memory mappings](/errors/cluster-resources#not-enough-memory-mappings), which has the fix.
+- On versions that carry it, these entries have a `docs_url=https://docs.weaviate.io/e/core-mem001` field, and the error returned to the client ends in the same link. Both lead to [not enough memory mappings](/errors/cluster-resources#not-enough-memory-mappings), which has the fix.
 
 #### Root cause
 
 The system has reached the operating system limit for memory-mapped files (`vm.max_map_count`). Each shard requires multiple memory mappings, and the default OS limit may be insufficient for large multi-tenant deployments.
 
 #### Resolution
+
+Platform-specific steps (Linux, Docker, Kubernetes, Weaviate Cloud) are in [not enough memory mappings](/errors/cluster-resources#not-enough-memory-mappings). In short:
 
 **Increase the system memory mapping limit:**
 
@@ -454,15 +456,15 @@ The system has reached the operating system limit for memory-mapped files (`vm.m
 sysctl vm.max_map_count
 
 # Increase to 3-4x current value
-# Example: 2097152 → 8388608
-sysctl -w vm.max_map_count=8388608
+# Example: 1048576 → 4194304
+sysctl -w vm.max_map_count=4194304
 ```
 
 **Make the change persistent:**
 
 ```bash
 # Add to /etc/sysctl.conf
-echo "vm.max_map_count=8388608" >> /etc/sysctl.conf
+echo "vm.max_map_count=4194304" >> /etc/sysctl.conf
 ```
 
 **Restart affected pods to apply the new configuration.**


### PR DESCRIPTION
Follow-up to #521 for the not-enough-memory-mappings entry, verified against weaviate/weaviate#12738 (including its review-fix pass) and the Helm chart.

- The log table now lists the eight wired log sites with their exact current messages; the "Where the phrase is" column and the version-pinned claims are replaced by a search-for-the-phrase invariant.
- The Kubernetes tab leads with the Helm chart's built-in `sysctlInitContainer` (its `524288` default sits below the recommended value), and a new Docker tab covers Linux hosts, the `--sysctl` refusal, and Docker Desktop's VM on Windows and macOS.
- known-issues now recommends the same `4194304` as this page and defers platform steps here.

Review note: the three field-style table rows (`apply command`, `failed to reload local index`, `error updating tenants`) match weaviate/weaviate#12738 after its review-fix commit — if that PR's log shapes change again, re-check those rows.