### PR TITLE
Refresh the OpenAPI spec to 1.39.3

### DIFF
--- a/static/specs/weaviate-openapi.json
+++ b/static/specs/weaviate-openapi.json
@@ -147,6 +147,135 @@
         "apikey"
       ]
     },
+    "DBUserCredential": {
+      "type": "object",
+      "description": "A single database user's exportable API-key credential. Carries the argon2id key hash for strong-key users; for users whose key cannot be migrated (imported/weak, revoked, or missing a hash) secureHash is null and status names the reason.",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The name (ID) of the user, without any namespace prefix."
+        },
+        "userIdentifier": {
+          "type": "string",
+          "description": "The random identifier embedded in the user's API key, used to resolve the key hash. Exactly 16 characters for an importable record; empty when the export reports a user whose key is not carried."
+        },
+        "secureHash": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The argon2id PHC hash of the user's API key. Null when the key cannot be migrated (see status)."
+        },
+        "apiKeyFirstLetters": {
+          "type": "string",
+          "maxLength": 3,
+          "description": "First 3 letters of the associated API key."
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the user is active. A deactivated (not revoked) user is carried with active=false and reproduced on import."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Date and time in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "The namespace the user was bound to on the source. Informational on export; import binds the user to the request's target namespace."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "exported",
+            "imported_key",
+            "revoked"
+          ],
+          "description": "Export classification. Only 'exported' carries a usable secureHash; the others report why the user was not carried."
+        }
+      },
+      "required": [
+        "userId"
+      ]
+    },
+    "UserExportResponse": {
+      "type": "object",
+      "description": "The full set of database-user credential records on the source, one per user.",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DBUserCredential"
+          }
+        }
+      },
+      "required": [
+        "users"
+      ]
+    },
+    "UserImportRequest": {
+      "type": "object",
+      "description": "A batch of database-user credentials to recreate on the target, bound to a single target namespace.",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "The target namespace every user in this request is created under. Required on namespace-enabled clusters."
+        },
+        "users": {
+          "type": "array",
+          "description": "The credential records to import. Only records with a strong (argon2id) secureHash are importable.",
+          "items": {
+            "$ref": "#/definitions/DBUserCredential"
+          }
+        }
+      },
+      "required": [
+        "users"
+      ]
+    },
+    "UserImportResponse": {
+      "type": "object",
+      "description": "The per-user outcome of an import batch.",
+      "properties": {
+        "results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserImportResult"
+          }
+        }
+      },
+      "required": [
+        "results"
+      ]
+    },
+    "UserImportResult": {
+      "type": "object",
+      "description": "The outcome of importing a single database-user credential.",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "The name (ID) of the user, without any namespace prefix."
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "created",
+            "reconciled",
+            "skipped_exists",
+            "error"
+          ],
+          "description": "The outcome for this user."
+        },
+        "error": {
+          "type": "string",
+          "description": "The reason, present only when status is 'error'."
+        }
+      },
+      "required": [
+        "userId",
+        "status"
+      ]
+    },
     "Role": {
       "type": "object",
       "properties": {
@@ -683,7 +812,7 @@
         },
         "taskId": {
           "type": "string",
-          "description": "ID of the reindex task driving this index entry. Present on every task-driven entry (`pending`, `indexing`, `failed`, `cancelled`, and the finalize-window override); absent on a plain `ready` entry. A coupled searchable+filterable tokenization migration reports the same `taskId` on both affected entries."
+          "description": "ID of the reindex task driving this index entry. Present on every task-driven entry (`pending`, `indexing`, `failed`, `cancelled`); absent on a plain `ready` entry. A coupled searchable+filterable tokenization migration reports the same `taskId` on both affected entries."
         },
         "tokenization": {
           "type": "string"
@@ -2743,9 +2872,10 @@
           "format": "date-time"
         },
         "finishedAt": {
-          "description": "The time when the task was finished.",
+          "description": "The time when the task reached a terminal status. Absent while the task is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedNodes": {
           "description": "The nodes that finished the task.",
@@ -2800,14 +2930,16 @@
           "x-omitempty": true
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated.",
+          "description": "The time when the unit was last updated, including its transition to a terminal status. Absent for a unit that has not started yet.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedAt": {
-          "description": "The time when the unit finished.",
+          "description": "The time when the unit reached a terminal status. Absent while the unit is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         }
       }
     },
@@ -3954,10 +4086,17 @@
           "x-nullable": true
         },
         "returnProperties": {
-          "description": "The properties to return. A dot-path selects one hop across a reference (e.g. `hasAuthor.name`). Omitted returns all non-reference, non-blob properties; an empty array returns no properties.",
+          "description": "The non-reference properties to return. Omitted returns all non-reference, non-blob properties; an empty array returns no properties. References are selected with `returnReferences`.",
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "returnReferences": {
+          "description": "The cross-references to return under each result's `references` key. Each entry selects one reference property and what to return from the referenced objects. Omitted or empty returns no references.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchReferenceSelector"
           }
         },
         "returnMetadata": {
@@ -4035,6 +4174,49 @@
         "query": {
           "description": "The query to rerank with. Defaults to the search query.",
           "type": "string"
+        }
+      }
+    },
+    "SearchReferenceSelector": {
+      "description": "Selects one cross-reference to return, and what to return from each referenced object.",
+      "type": "object",
+      "required": [
+        "linkOn"
+      ],
+      "properties": {
+        "linkOn": {
+          "description": "The reference property to follow.",
+          "type": "string"
+        },
+        "targetCollection": {
+          "description": "The referenced collection to select. Required when `linkOn` is a multi-target reference.",
+          "type": "string"
+        },
+        "returnProperties": {
+          "description": "The non-reference properties to return from each referenced object. Omitted returns all non-reference, non-blob properties of the referenced collection; an empty array returns no properties.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "returnMetadata": {
+          "description": "The metadata to return under each referenced object's `metadata` key. Omitted or empty returns no `metadata` block.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "id",
+              "creationTime",
+              "lastUpdateTime"
+            ]
+          }
+        },
+        "returnReferences": {
+          "description": "The cross-references to return from each referenced object. Nesting deeper than `QUERY_CROSS_REFERENCE_DEPTH_LIMIT` is rejected.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchReferenceSelector"
+          }
         }
       }
     },
@@ -4230,6 +4412,65 @@
         }
       }
     },
+    "SearchResultReferenceMetadata": {
+      "description": "The metadata of a referenced object, populated according to the selector's `returnMetadata`. Every field is optional and only present when it was requested.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "The referenced object's UUID.",
+          "type": "string",
+          "format": "uuid",
+          "x-nullable": true
+        },
+        "creationTime": {
+          "description": "The referenced object's creation time, as epoch milliseconds.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true
+        },
+        "lastUpdateTime": {
+          "description": "The referenced object's last-update time, as epoch milliseconds.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true
+        }
+      }
+    },
+    "SearchResultReference": {
+      "description": "One referenced object: the selected non-reference properties under `properties`, deeper cross-references under `references`, and the requested metadata under `metadata`.",
+      "type": "object",
+      "required": [
+        "properties"
+      ],
+      "properties": {
+        "collection": {
+          "description": "The collection the referenced object belongs to. Returned for multi-target references.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The selected non-reference properties of the referenced object; nested (object / object[]) properties are pruned to the selected nested fields. Always present — `{}` when the selector selects no properties.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/JsonObject"
+          },
+          "x-omitempty": false
+        },
+        "references": {
+          "description": "The cross-references selected one hop deeper. Omitted when the selector selects none, or when the referenced object has no entry for any of them.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SearchResultReference"
+            }
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/SearchResultReferenceMetadata",
+          "x-nullable": true
+        }
+      }
+    },
     "SearchResultObject": {
       "description": "A single search hit: the object's `id` (always returned), the selected non-reference properties under `properties`, the selected cross-references under `references`, and the requested retrieval metadata under `metadata`.",
       "type": "object",
@@ -4252,12 +4493,12 @@
           "x-omitempty": false
         },
         "references": {
-          "description": "The selected cross-references: reference name to the array of referenced objects, each carrying the selected one-hop properties. Omitted when the request selects no references.",
+          "description": "The selected cross-references: reference property name to the array of referenced objects. Omitted when the request selects no references, or when the hit has no entry for any of the selected references.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/JsonObject"
+              "$ref": "#/definitions/SearchResultReference"
             }
           }
         },
@@ -4279,7 +4520,7 @@
     },
     "description": "# Introduction\n Weaviate is an open source, AI-native vector database that helps developers create intuitive and reliable AI-powered applications. \n ### Base Path \nThe base path for the Weaviate server is structured as `[YOUR-WEAVIATE-HOST]:[PORT]/v1`. As an example, if you wish to access the `schema` endpoint on a local instance, you would navigate to `http://localhost:8080/v1/schema`. Ensure you replace `[YOUR-WEAVIATE-HOST]` and `[PORT]` with your actual server host and port number respectively. \n ### Questions? \nIf you have any comments or questions, please feel free to reach out to us at the community forum [https://forum.weaviate.io/](https://forum.weaviate.io/). \n### Issues? \nIf you find a bug or want to file a feature request, please open an issue on our GitHub repository for [Weaviate](https://github.com/weaviate/weaviate). \n### Need more documentation? \nFor a quickstart, code examples, concepts and more, please visit our [documentation page](https://docs.weaviate.io/weaviate).",
     "title": "Weaviate REST API",
-    "version": "1.39.0"
+    "version": "1.39.3"
   },
   "parameters": {
     "CommonAfterParameterQuery": {
@@ -5195,6 +5436,106 @@
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An error has occurred while trying to fulfill the request. Most likely the ErrorResponse will contain more information about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/experimental/export-db-users": {
+      "post": {
+        "summary": "Export all database-user credentials",
+        "description": "Experimental: this endpoint may change or be removed without notice. Export every database (`db` user type) user's API-key credential for migration to another cluster. Strong-key users carry their argon2id key hash; imported/weak and revoked users are reported with a null hash and a status naming why they cannot be migrated. Root users only.",
+        "operationId": "exportUsers",
+        "x-serviceIds": [
+          "weaviate.experimental.export-db-users"
+        ],
+        "tags": [
+          "experimental"
+        ],
+        "responses": {
+          "200": {
+            "description": "The exported user credentials.",
+            "schema": {
+              "$ref": "#/definitions/UserExportResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "An error has occurred while trying to fulfill the request. Most likely the ErrorResponse will contain more information about the error.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/experimental/import-db-users": {
+      "post": {
+        "summary": "Import database-user credentials",
+        "description": "Experimental: this endpoint may change or be removed without notice. Recreate exported database (`db` user type) user credentials on this cluster under a target namespace. Each user is created with its original key hash so the source key keeps working. Returns a per-user result. Only strong-key records are importable. Root users only.",
+        "operationId": "importUsers",
+        "x-serviceIds": [
+          "weaviate.experimental.import-db-users"
+        ],
+        "tags": [
+          "experimental"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UserImportRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The per-user import results.",
+            "schema": {
+              "$ref": "#/definitions/UserImportResponse"
+            }
+          },
+          "400": {
+            "description": "Malformed request.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized or invalid credentials."
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -9022,7 +9363,7 @@
           "schema"
         ],
         "summary": "Get index status for all properties of a collection",
-        "description": "Returns per-property index state including active reindex progress. This powers the UI to show live migration status.",
+        "description": "Returns per-property index state including active reindex progress. This powers the UI to show live migration status. The response reflects the state of the node that answered, which may briefly omit the entry for a just-submitted migration or still report its pre-migration state.",
         "parameters": [
           {
             "name": "className",
@@ -11712,7 +12053,7 @@
     },
     "/mcp": {
       "post": {
-        "description": "MCP Streamable HTTP endpoint. Handles JSON-RPC requests for tool discovery and invocation.",
+        "description": "MCP Streamable HTTP endpoint. Handles JSON-RPC requests for tool discovery and invocation. Every request is authenticated on its own; no Mcp-Session-Id is issued or required.",
         "tags": [
           "mcp"
         ],
@@ -11727,33 +12068,40 @@
         "responses": {
           "200": {
             "description": "JSON-RPC response or SSE stream"
-          }
-        }
-      },
-      "get": {
-        "description": "Opens an SSE stream for receiving MCP server-sent events.",
-        "tags": [
-          "mcp"
-        ],
-        "operationId": "mcp.get",
-        "produces": [
-          "text/event-stream"
-        ],
-        "responses": {
-          "200": {
-            "description": "SSE event stream"
+          },
+          "503": {
+            "description": "MCP server is disabled",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },
       "delete": {
-        "description": "Terminates an MCP session.",
+        "description": "Accepted so clients that end their session explicitly keep working. The server keeps no session state, so there is nothing to terminate.",
         "tags": [
           "mcp"
         ],
         "operationId": "mcp.delete",
         "responses": {
           "200": {
-            "description": "Session terminated"
+            "description": "Accepted; there is no session state to terminate"
+          },
+          "503": {
+            "description": "MCP server is disabled",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -11761,7 +12109,7 @@
     "/aggregate/{collection}": {
       "post": {
         "summary": "Aggregate over a collection",
-        "description": "Aggregates over the objects of a collection. Phase 1 supports counts: the number of matching objects, either in total (flat `count` response) or per group of a `groupBy` property (`groups` response). A `where` filter limits the objects that are aggregated; an empty body returns the collection's total object count.",
+        "description": "Aggregates over the objects of a collection. Phase 1 supports counts: the number of matching objects, either in total (flat `count` response) or per group of a `groupBy` property (`groups` response). A `where` filter limits the objects that are aggregated; an empty body returns the collection's total object count. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints.",
         "tags": [
           "aggregate"
         ],
@@ -11842,7 +12190,7 @@
     "/search/{collection}/bm25": {
       "post": {
         "summary": "Search a collection with bm25",
-        "description": "Performs a keyword (BM25F) search over the objects of a collection. Objects are scored against the query with the BM25F ranking function over the searchable text properties (all of them, or the `queryProperties` subset) and the best-scoring objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`.",
+        "description": "Performs a keyword (BM25F) search over the objects of a collection. Objects are scored against the query with the BM25F ranking function over the searchable text properties (all of them, or the `queryProperties` subset) and the best-scoring objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints.",
         "tags": [
           "search"
         ],
@@ -11929,7 +12277,7 @@
     "/search/{collection}/hybrid": {
       "post": {
         "summary": "Search a collection with hybrid",
-        "description": "Performs a hybrid search over the objects of a collection: the query is scored with the BM25F ranking function over the searchable text properties (all of them, or the `queryProperties` subset) and, in parallel, vectorized server-side and searched against the vector index; the two rankings are fused (per `fusionType`, weighted by `alpha`) and the best objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`.",
+        "description": "Performs a hybrid search over the objects of a collection: the query is scored with the BM25F ranking function over the searchable text properties (all of them, or the `queryProperties` subset) and, in parallel, vectorized server-side and searched against the vector index; the two rankings are fused (per `fusionType`, weighted by `alpha`) and the best objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints.",
         "tags": [
           "search"
         ],
@@ -11999,13 +12347,7 @@
             }
           },
           "500": {
-            "description": "An error has occurred while trying to fulfill the request. Most likely the ErrorResponse will contain more information about the error.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "502": {
-            "description": "The embedding provider failed to vectorize the query for the vector part of the search; the search cannot run.",
+            "description": "An error has occurred while trying to fulfill the request, including a failure of the embedding provider to vectorize the query for the vector part of the search. Most likely the ErrorResponse will contain more information about the error.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -12022,7 +12364,7 @@
     "/search/{collection}/near-object": {
       "post": {
         "summary": "Search a collection with near-object",
-        "description": "Performs a similarity search over the objects of a collection, anchored at an existing object: the stored vector of the source object (referenced by `id`) is searched against the vector index and the closest objects are returned — the source object itself included — each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. No query is vectorized, so collections without a vectorizer module are fully searchable.",
+        "description": "Performs a similarity search over the objects of a collection, anchored at an existing object: the stored vector of the source object (referenced by `id`) is searched against the vector index and the closest objects are returned — the source object itself included — each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. No query is vectorized, so collections without a vectorizer module are fully searchable. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints.",
         "tags": [
           "search"
         ],
@@ -12109,7 +12451,7 @@
     "/search/{collection}/near-text": {
       "post": {
         "summary": "Search a collection with near-text",
-        "description": "Performs a semantic (near-text) search over the objects of a collection. The query text is vectorized server-side by the collection's vectorizer module and the closest objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`.",
+        "description": "Performs a semantic (near-text) search over the objects of a collection. The query text is vectorized server-side by the collection's vectorizer module and the closest objects are returned, each as an envelope of its `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints.",
         "tags": [
           "search"
         ],
@@ -12179,13 +12521,7 @@
             }
           },
           "500": {
-            "description": "An error has occurred while trying to fulfill the request. Most likely the ErrorResponse will contain more information about the error.",
-            "schema": {
-              "$ref": "#/definitions/ErrorResponse"
-            }
-          },
-          "502": {
-            "description": "The embedding provider failed to vectorize the query; the search cannot run.",
+            "description": "An error has occurred while trying to fulfill the request, including a failure of the embedding provider to vectorize the query. Most likely the ErrorResponse will contain more information about the error.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -12240,11 +12576,11 @@
     },
     {
       "name": "search",
-      "description": "Operations for querying collections over REST. The near-text endpoint performs semantic vector search with server-side embedding of the query text; the bm25 endpoint performs keyword (BM25F) search over the searchable text properties. Each result carries the object's `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`."
+      "description": "Operations for querying collections over REST. The near-text endpoint performs semantic vector search with server-side embedding of the query text; the bm25 endpoint performs keyword (BM25F) search over the searchable text properties. Each result carries the object's `id`, the selected `properties`, the selected `references` and, when requested, its retrieval `metadata`. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints."
     },
     {
       "name": "aggregate",
-      "description": "Operations for aggregating over collections. The aggregate endpoint counts the objects that match an optional `where` filter, in total or grouped by a property's distinct values."
+      "description": "Operations for aggregating over collections. The aggregate endpoint counts the objects that match an optional `where` filter, in total or grouped by a property's distinct values. \n\n**Note**: This API is experimental and disabled by default; set `EXPERIMENTAL_REST_SEARCH_ENABLED=true` to enable the REST search and aggregate endpoints."
     },
     {
       "name": "backups",


### PR DESCRIPTION
Refreshed `static/specs/weaviate-openapi.json` from `v1-39/openapi-for-docs` after merging `stable/v1.39` into that branch (pushed as 82292b6a9e, so the weekly refresh job sees the same spec and will not open a revert PR).

1.39.0 → 1.39.3: 81 → 83 paths, 130 → 138 definitions. New in the published reference are the two experimental db-user migration endpoints, which carry their own "may change or be removed without notice" warning, and the `SearchReference*` definitions, so the REST search endpoints now document cross-reference selection and results.

Worth a reviewer's attention: the previous copy predated core 22474d2d7e and carried the "experimental, disabled by default" notice on only 5 of the 7 places it belongs. All five REST search/aggregate endpoints and both tags now carry it.